### PR TITLE
If CSS files were missing the project wouldn't build

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Directory.Build.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions/Directory.Build.targets
@@ -4,7 +4,7 @@
 	     Run a custom command using Dart SASS installed by the AspNetCore.SassCompiler NuGet package. The default package configuration cannot be used
 		 because passing the `-load-path` argument needed by the GOV.UK Front End source code only works when using the `-stdin` argument.
 		 -->
-	<Target Name="BuildSass" BeforeTargets="AfterBuild">
+	<Target Name="BuildSass" BeforeTargets="BeforeBuild">
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='AspNetCore.SassCompiler']/@Version">
 		<Output TaskParameter="Result" ItemName="SassCompilerVersion" />
     </XmlPeek>


### PR DESCRIPTION
If CSS files were missing the project wouldn't build. They must be generated before the attempt to build. AB#129954