### PR TITLE
Enables changing property values in a block list item 

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/date-input.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/date-input.config
@@ -18,10 +18,12 @@
   "layout": {
     "Umbraco.BlockList": [
       {
-        "contentUdi": "umb://element/71eb78cf02b74557881f868ddceeab05"
+        "contentUdi": "umb://element/71eb78cf02b74557881f868ddceeab05",
+        "settingsUdi": "umb://element/451edfded1c14987bceb19e65b560015"
       },
       {
-        "contentUdi": "umb://element/f7858c6eea17470b96aa5392a7935d6a"
+        "contentUdi": "umb://element/f7858c6eea17470b96aa5392a7935d6a",
+        "settingsUdi": "umb://element/4546d68bee21490396a41578090b5f77"
       },
       {
         "contentUdi": "umb://element/95292d2e67554e919afb3de9a38a7033",
@@ -83,6 +85,14 @@
     {
       "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
       "udi": "umb://element/dcc8183ff9804a28b1219a2289868ff7"
+    },
+    {
+      "contentTypeKey": "ec4a6e3f-a6a8-4c8a-9d4c-d3e90399ac2c",
+      "udi": "umb://element/451edfded1c14987bceb19e65b560015"
+    },
+    {
+      "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
+      "udi": "umb://element/4546d68bee21490396a41578090b5f77"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco/Models/FilteredBlockListItem.cs
+++ b/GovUk.Frontend.Umbraco/Models/FilteredBlockListItem.cs
@@ -4,16 +4,18 @@ using Umbraco.Cms.Core.Models.Blocks;
 
 namespace GovUk.Frontend.Umbraco.Models
 {
-    public class FilteredBlockListItem
+    public class FilteredBlockListItem : BlockListItem
     {
-        public FilteredBlockListItem(BlockListItem item, Func<BlockListModel, IEnumerable<BlockListItem>>? filter)
+        public FilteredBlockListItem(BlockListItem item, Func<IEnumerable<BlockListItem>, IEnumerable<BlockListItem>>? filter) :
+            base(item.ContentUdi, new OverridablePublishedElement(item.Content), item.SettingsUdi, new OverridablePublishedElement(item.Settings))
         {
-            Item = item;
             Filter = filter ?? (x => x);
         }
 
-        public Func<BlockListModel, IEnumerable<BlockListItem>> Filter { get; private set; }
+        public new IOverridablePublishedElement Content { get => (IOverridablePublishedElement)base.Content; }
 
-        public BlockListItem Item { get; set; }
+        public new IOverridablePublishedElement Settings { get => (IOverridablePublishedElement)base.Settings; }
+
+        public Func<IEnumerable<BlockListItem>, IEnumerable<BlockListItem>> Filter { get; private set; }
     }
 }

--- a/GovUk.Frontend.Umbraco/Models/FilteredBlockListModel.cs
+++ b/GovUk.Frontend.Umbraco/Models/FilteredBlockListModel.cs
@@ -1,24 +1,40 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Umbraco.Cms.Core.Models.Blocks;
 
 namespace GovUk.Frontend.Umbraco.Models
 {
-    public class FilteredBlockListModel
+    public class FilteredBlockListModel : IEnumerable<FilteredBlockListItem>
     {
-        private readonly BlockListModel _model;
+        private readonly List<FilteredBlockListItem> _items = new();
 
-        public FilteredBlockListModel(BlockListModel model, Func<BlockListModel, IEnumerable<BlockListItem>>? filter = null)
+        public FilteredBlockListModel(BlockListModel model, Func<IEnumerable<BlockListItem>, IEnumerable<BlockListItem>>? filter = null)
         {
-            _model = model;
             Filter = filter ?? (x => x);
+            foreach (var item in model)
+            {
+                _items.Add(new FilteredBlockListItem(item, Filter));
+            }
         }
 
-        public Func<BlockListModel, IEnumerable<BlockListItem>> Filter { get; private set; }
+        public Func<IEnumerable<BlockListItem>, IEnumerable<BlockListItem>> Filter { get; private set; }
 
-        public IEnumerable<BlockListItem> FilteredBlocks()
+        public IEnumerable<FilteredBlockListItem> FilteredBlocks()
         {
-            return Filter(_model);
+            return (IEnumerable<FilteredBlockListItem>)Filter(_items);
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<FilteredBlockListItem> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)_items).GetEnumerator();
         }
 
         public bool RenderGrid { get; set; } = true;

--- a/GovUk.Frontend.Umbraco/Models/IOverridablePublishedElement.cs
+++ b/GovUk.Frontend.Umbraco/Models/IOverridablePublishedElement.cs
@@ -1,0 +1,13 @@
+﻿using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace GovUk.Frontend.Umbraco.Models
+{
+    /// <summary>
+    /// A wrapper for <see cref="IPublishedElement"/> which allows property values to be overridden.
+    /// </summary>
+    public interface IOverridablePublishedElement : IPublishedElement
+    {
+        void OverrideValue(string alias, object value);
+        T? Value<T>(string alias);
+    }
+}

--- a/GovUk.Frontend.Umbraco/Models/PublishedElement.cs
+++ b/GovUk.Frontend.Umbraco/Models/PublishedElement.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace GovUk.Frontend.Umbraco.Models
+{
+    /// <summary>
+    /// A wrapper for <see cref="IPublishedElement"/> which allows property values to be overriden.
+    /// </summary>
+    public class OverridablePublishedElement : IPublishedElement, IOverridablePublishedElement
+    {
+        private readonly IPublishedElement _publishedElement;
+        private readonly Dictionary<string, object> _propertyValues = new();
+
+        public OverridablePublishedElement(IPublishedElement publishedElement) => _publishedElement = publishedElement;
+
+        /// <summary>
+        /// Gets the content type
+        /// </summary>
+        public IPublishedContentType ContentType => _publishedElement.ContentType;
+
+        /// <summary>
+        /// Gets the unique key of the published element
+        /// </summary>
+        public Guid Key => _publishedElement.Key;
+
+        /// <summary>
+        /// Gets the properties of the element.
+        /// </summary>
+        /// <remarks>
+        /// Contains one <see cref="IPublishedProperty"/> for each property defined by the content type, including inherited properties. Some properties have no value.
+        /// </remarks>
+        public IEnumerable<IPublishedProperty> Properties => _publishedElement.Properties;
+
+        /// <summary>
+        /// Gets a property identified by its alias.
+        /// </summary>
+        /// <param name="alias"></param>
+        /// <returns>The property identified by the alias</returns>
+        /// <remarks>
+        /// If a content type has no property with that alias, including inherited properties, returns <c>null</c>.
+        /// 
+        /// Otherwise return a property -- that may have no value (ie <c>HasValue</c> is <c>false</c>).
+        /// 
+        /// The alias is case insensitive.
+        /// </remarks>
+        public IPublishedProperty? GetProperty(string alias) => _publishedElement.GetProperty(alias);
+
+        /// <summary>
+        /// Sets a value for the property identified by the alias, which will be returned by <see cref="Value"/> in preference to the value saved in the Umbraco back office.
+        /// </summary>
+        /// <param name="alias"></param>
+        /// <param name="value"></param>
+        public void OverrideValue(string alias, object value)
+        {
+            if (_propertyValues.ContainsKey(alias))
+            {
+                _propertyValues[alias] = value;
+            }
+            else
+            {
+                _propertyValues.Add(alias, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets the value of a content's property identified by its alias, converted to a specified type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="alias"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The value comes a value passed to <see cref="OverrideValue"/>, or from the <see cref="IPublishedProperty"/> field <c>Value</c> ie it is suitable for use when rendering content.
+        /// 
+        /// If no property with the specified alias exists, or if the property has no value, or if it could not be converted, returns <c>default(T)</c>.
+        /// 
+        /// The alias is case-insensitive.
+        /// </remarks>
+        public T? Value<T>(string alias)
+        {
+            if (_propertyValues.ContainsKey(alias))
+            {
+                return (T)_propertyValues[alias];
+            }
+
+            return _publishedElement != null ? _publishedElement.Value<T>(alias) : default(T);
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco/README.md
+++ b/GovUk.Frontend.Umbraco/README.md
@@ -218,3 +218,29 @@ viewModel.FilteredBlocks = new FilteredBlockListModel(viewModel.Page.Blocks, mod
 /// View
 <partial name="GOVUK/FilteredBlockList" model="Model.FilteredBlocks" />
 ```
+
+## Overriding values in the block list
+
+When using the block list editor, if you need to conditionally override some values in specific blocks you can do that. (This does not yet work for nested block lists.)
+
+For example, if you wanted to apply an additional CSS class to a grid row:
+
+```csharp
+/// Model
+public class MyDocumentTypeViewModel
+{
+    public MyDocumentType Page { get; set; }
+
+    public FilteredBlockListModel FilteredBlocks { get; set; }
+}
+
+/// Controller
+using GovUk.Frontend.Umbraco.Models
+using System.Linq;
+
+viewModel.FilteredBlocks = new FilteredBlockListModel(viewModel.Page.Blocks);
+viewModel.FilteredBlocks.First(x => x.Content.ContentType.Alias == "govukGridRow").Settings.OverrideValue("cssClassesForRow", "my-custom-class");
+
+/// View
+<partial name="GOVUK/FilteredBlockList" model="Model.FilteredBlocks" />
+```

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/FilteredBlockList.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/FilteredBlockList.cshtml
@@ -19,6 +19,8 @@
 {
     if (blocks[i]?.ContentUdi == null) { continue; }
 
+    var block = blocks[i] is FilteredBlockListItem ? blocks[i] : new FilteredBlockListItem(blocks[i], Model.Filter);
+
     var isGridRowBlock = blocks[i].Content.ContentType.Alias == "govukGridRow";
     string rowClass = GovUkGridClassBuilder.BuildGridRowClass(blocks[i].Settings?.Value<string>("cssClassesForRow"));
     var columnClass = GovUkGridClassBuilder.BuildGridColumnClass(
@@ -40,7 +42,7 @@
         @:<div class="@rowClass"> 
         @:<div class="@columnClass"> 
     }
-    @await Html.PartialAsync("GOVUK/" + blocks[i].Content.ContentType.Alias, new FilteredBlockListItem(blocks[i], Model.Filter))
+    @await Html.PartialAsync("GOVUK/" + blocks[i].Content.ContentType.Alias, block)
     @if (Model.RenderGrid && !isGridRowBlock && !sameAsNext) {
         @:</div> 
         @:</div> 

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkBackToMenu.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkBackToMenu.cshtml
@@ -7,8 +7,8 @@
 @using Umbraco.Cms.Core.Models
 @using Umbraco.Extensions
 @{
-    var text = Model.Item.Content.Value<string>("text");
-    var link = Model.Item.Content.Value<Link>("link");
+    var text = Model.Content.Value<string>("text");
+    var link = Model.Content.Value<Link>("link");
     link.Url = hostUpdater.UpdateHost(link.Url, Context.Request.Host.Host);
 }
-<govuk-back-to-menu href="@link.Url" id="@Model.Item.Content.Key">@text</govuk-back-to-menu>
+<govuk-back-to-menu href="@link.Url" id="@Model.Content.Key">@text</govuk-back-to-menu>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
@@ -4,18 +4,18 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    var text = Model.Item.Content.Value<string>("text");
-    switch (Model.Item.Settings.Value<string>("typeOfButton")) {
+    var text = Model.Content.Value<string>("text");
+    switch (Model.Settings.Value<string>("typeOfButton")) {
         case "Secondary":
-            <govuk-button class="govuk-button--secondary" type="button" id="@Model.Item.Content.Key">@text</govuk-button>
+            <govuk-button class="govuk-button--secondary" type="button" id="@Model.Content.Key">@text</govuk-button>
             break;
 
         case "Warning":
-            <govuk-button class="govuk-button--warning" type="button" id="@Model.Item.Content.Key">@text</govuk-button>
+            <govuk-button class="govuk-button--warning" type="button" id="@Model.Content.Key">@text</govuk-button>
             break;
 
         default:
-            <govuk-button type="submit" id="@Model.Item.Content.Key">@text</govuk-button>
+            <govuk-button type="submit" id="@Model.Content.Key">@text</govuk-button>
             break;
     }
 }

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButtonGroup.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButtonGroup.cshtml
@@ -5,7 +5,7 @@
 @using Umbraco.Extensions
 @using System.Linq
 @{
-    var buttons = new FilteredBlockListModel(Model.Item.Content.Value<BlockListModel>("buttons"), Model.Filter) { RenderGrid = false };
+    var buttons = new FilteredBlockListModel(Model.Content.Value<BlockListModel>("buttons"), Model.Filter) { RenderGrid = false };
 }
 @if (buttons.FilteredBlocks().Any()) {
 <div class="govuk-button-group">

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCaption.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCaption.cshtml
@@ -4,7 +4,7 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    var caption = Model.Item.Content.Value<string>("caption");
+    var caption = Model.Content.Value<string>("caption");
 }
 @if (!string.IsNullOrWhiteSpace(caption)) 
 {

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCheckbox.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCheckbox.cshtml
@@ -7,18 +7,18 @@
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Item.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
     ViewContext.ModelState.TryGetValue(modelPropertyName, out var modelStateEntry);
-    var cssClass = Model.Item.Settings.Value<string>("cssClasses");
-    var value = Model.Item.Content.Value<string>("value");
-    var checkboxHint = GovUkTypography.Apply(Model.Item.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
-    var conditional = Model.Item.Content.Value<BlockListModel>("conditionalBlocks");
+    var cssClass = Model.Settings.Value<string>("cssClasses");
+    var value = Model.Content.Value<string>("value");
+    var checkboxHint = GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
+    var conditional = Model.Content.Value<BlockListModel>("conditionalBlocks");
 }
 
-<govuk-client-side-validation error-message-required="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+<govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-checkboxes name="@modelPropertyName" class="@cssClass">
         <govuk-checkboxes-error-message>@(modelStateEntry != null && modelStateEntry.Errors.Any() ? string.Join(". ", modelStateEntry.Errors.Select(x => x.ErrorMessage)) : null)</govuk-checkboxes-error-message>
-        <govuk-checkboxes-item value="@value" checked="@(modelStateEntry?.AttemptedValue?.ToUpperInvariant() == value.ToUpperInvariant())">@(Model.Item.Content.Value<string>("label"))
+        <govuk-checkboxes-item value="@value" checked="@(modelStateEntry?.AttemptedValue?.ToUpperInvariant() == value.ToUpperInvariant())">@(Model.Content.Value<string>("label"))
             @if (!string.IsNullOrWhiteSpace(checkboxHint)) 
             {
                 <govuk-checkboxes-item-hint>@Html.Raw(checkboxHint)</govuk-checkboxes-item-hint>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCheckboxes.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCheckboxes.cshtml
@@ -7,18 +7,18 @@
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
 @{
-    var checkboxes = Model.Item.Content.Value<BlockListModel>("checkboxes");
-    var modelPropertyName = Model.Item.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var checkboxes = Model.Content.Value<BlockListModel>("checkboxes");
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
     ViewContext.ModelState.TryGetValue(modelPropertyName, out var modelStateEntry);
-    var cssClass = Model.Item.Settings.Value<string>("cssClasses");
-    var fieldsetHint = GovUkTypography.Apply(Model.Item.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
-    var legendIsPageHeading = Model.Item.Settings.Value<bool>("legendIsPageHeading");
-    var legend = Model.Item.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
+    var cssClass = Model.Settings.Value<string>("cssClasses");
+    var fieldsetHint = GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
+    var legendIsPageHeading = Model.Settings.Value<bool>("legendIsPageHeading");
+    var legend = Model.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
     var selectedValues = new List<string>();
     if (!string.IsNullOrEmpty(modelStateEntry?.AttemptedValue)) { selectedValues.AddRange(modelStateEntry.AttemptedValue.ToUpperInvariant().Split(",")); }
 }
 
-<govuk-client-side-validation error-message-required="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+<govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-checkboxes name="@modelPropertyName" class="@cssClass">
          <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-checkboxes-fieldset-legend>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDateInput.cshtml
@@ -7,15 +7,15 @@
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Item.Settings.Value<string>(PropertyAliases.ModelProperty);
-    var cssClass = Model.Item.Settings.Value<string>("cssClasses");
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var cssClass = Model.Settings.Value<string>("cssClasses");
     ViewContext.ModelState.TryGetValue(modelPropertyName, out var modelStateEntry);
-    var legendIsPageHeading = Model.Item.Settings.Value<bool>("legendIsPageHeading");
-    var legend = Model.Item.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
-    var hint = GovUkTypography.Apply(Model.Item.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
+    var legendIsPageHeading = Model.Settings.Value<bool>("legendIsPageHeading");
+    var legend = Model.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
+    var hint = GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-date-input name-prefix="@modelPropertyName" id="@modelPropertyName" class="@cssClass">
         <govuk-date-input-fieldset>
             <govuk-date-input-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-date-input-fieldset-legend>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDetails.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDetails.cshtml
@@ -3,7 +3,7 @@
 @using GovUk.Frontend.Umbraco.Typography
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
-<govuk-details id="@Model.Item.Content.Key">
-    <govuk-details-summary>@(Model.Item.Content.Value<string>("summary"))</govuk-details-summary>
-    <govuk-details-text>@Html.Raw(GovUkTypography.Apply(Model.Item.Content.Value<string>("text"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-details-text>
+<govuk-details id="@Model.Content.Key">
+    <govuk-details-summary>@(Model.Content.Value<string>("summary"))</govuk-details-summary>
+    <govuk-details-text>@Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("text"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-details-text>
 </govuk-details>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkErrorSummary.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkErrorSummary.cshtml
@@ -3,7 +3,7 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    var title = Model.Item.Content.Value<string>("title");
+    var title = Model.Content.Value<string>("title");
     if (string.IsNullOrWhiteSpace(title)) { title = "There is a problem"; }
     var visibleClass = ViewContext.ModelState.ErrorCount > 0 ? "govuk-!-display-block" : "govuk-!-display-none";
 }

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkFieldset.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkFieldset.cshtml
@@ -4,10 +4,10 @@
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
 @{
-    var blocks = Model.Item.Content.Value<BlockListModel>("blocks");
-    var cssClass = Model.Item.Settings.Value<string>("cssClasses");
-    var legendIsPageHeading = Model.Item.Settings.Value<bool>("legendIsPageHeading");
-    var legend = Model.Item.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
+    var blocks = Model.Content.Value<BlockListModel>("blocks");
+    var cssClass = Model.Settings.Value<string>("cssClasses");
+    var legendIsPageHeading = Model.Settings.Value<bool>("legendIsPageHeading");
+    var legend = Model.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
 }
 <govuk-fieldset class="@cssClass">
     <govuk-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-fieldset-legend>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridColumn.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridColumn.cshtml
@@ -5,11 +5,11 @@
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
 @{
-    var blocks = Model.Item.Content.Value<BlockListModel>("blocks");
+    var blocks = Model.Content.Value<BlockListModel>("blocks");
     var columnClass = GovUkGridClassBuilder.BuildGridColumnClass(
-                        Model.Item.Settings?.Value<string>("columnSize"), 
-                        Model.Item.Settings?.Value<string>("columnSizeFromDesktop"), 
-                        Model.Item.Settings?.Value<string>("cssClassesForColumn")).TrimEnd();
+                        Model.Settings?.Value<string>("columnSize"), 
+                        Model.Settings?.Value<string>("columnSizeFromDesktop"), 
+                        Model.Settings?.Value<string>("cssClassesForColumn")).TrimEnd();
 }
     <div class="@columnClass">
         @await Html.PartialAsync("GOVUK/FilteredBlockList", new FilteredBlockListModel(blocks,Model.Filter){ RenderGrid = false })

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridRow.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridRow.cshtml
@@ -5,12 +5,12 @@
 @using GovUk.Frontend.Umbraco.Services
 @using Umbraco.Extensions
 @{
-    var blocks = Model.Item.Content.Value<BlockListModel>("blocks");
-    var rowClass = Model.Item.Settings.Value<string>("cssClassesForRow");
+    var blocks = Model.Content.Value<BlockListModel>("blocks");
+    var rowClass = Model.Settings?.Value<string>("cssClassesForRow");
     var columnClass = GovUkGridClassBuilder.BuildGridColumnClass(
-                        Model.Item.Settings?.Value<string>("columnSize"), 
-                        Model.Item.Settings?.Value<string>("columnSizeFromDesktop"), 
-                        Model.Item.Settings?.Value<string>("cssClassesForColumn")).TrimEnd();
+                        Model.Settings?.Value<string>("columnSize"), 
+                        Model.Settings?.Value<string>("columnSizeFromDesktop"), 
+                        Model.Settings?.Value<string>("cssClassesForColumn")).TrimEnd();
 }
 <div class="govuk-grid-row @rowClass">
     <div class="@columnClass">

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkInsetText.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkInsetText.cshtml
@@ -3,4 +3,4 @@
 @using GovUk.Frontend.Umbraco.Typography
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
-<govuk-inset-text id="@Model.Item.Content.Key">@Html.Raw(GovUkTypography.Apply(Model.Item.Content.Value<string>("text"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-inset-text>
+<govuk-inset-text id="@Model.Content.Key">@Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("text"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-inset-text>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkLink.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkLink.cshtml
@@ -5,7 +5,7 @@
 @using Umbraco.Cms.Core.Models
 @using Umbraco.Extensions
 @{
-    var text = Model.Item.Content.Value<string>("text");
-    var link = Model.Item.Content.Value<Link>("link");
+    var text = Model.Content.Value<string>("text");
+    var link = Model.Content.Value<Link>("link");
 }
-<a href="@link.Url" class="govuk-link" id="@Model.Item.Content.Key">@text</a>
+<a href="@link.Url" class="govuk-link" id="@Model.Content.Key">@text</a>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkLinkAsButton.cshtml
@@ -5,9 +5,9 @@
 @using Umbraco.Cms.Core.Models
 @using Umbraco.Extensions
 @{
-    var text = Model.Item.Content.Value<string>("text");
-    var link = Model.Item.Content.Value<Link>("link");
-    var isStartButton = Model.Item.Settings.Value<bool>("isStartButton");
-    var cssClass = Model.Item.Settings.Value<string>("cssClasses");
+    var text = Model.Content.Value<string>("text");
+    var link = Model.Content.Value<Link>("link");
+    var isStartButton = Model.Settings.Value<bool>("isStartButton");
+    var cssClass = Model.Settings.Value<string>("cssClasses");
 }
-<govuk-button-link is-start-button="@isStartButton" href="@link.Url" id="@Model.Item.Content.Key" class="@cssClass">@text</govuk-button-link>
+<govuk-button-link is-start-button="@isStartButton" href="@link.Url" id="@Model.Content.Key" class="@cssClass">@text</govuk-button-link>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkNotificationBanner.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkNotificationBanner.cshtml
@@ -5,17 +5,17 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    if (!Enum.TryParse(typeof(NotificationBannerType), Model.Item.Settings.Value<string>("type"), out var bannerType))
+    if (!Enum.TryParse(typeof(NotificationBannerType), Model.Settings.Value<string>("type"), out var bannerType))
     {
         bannerType = NotificationBannerType.Default;
     }
-    var heading = GovUkTypography.Apply(Model.Item.Content.Value<string>("heading"), new TypographyOptions{ RemoveWrappingParagraph = true });
-    var text = GovUkTypography.Apply(Model.Item.Content.Value<string>("text"), new TypographyOptions { RemoveWrappingParagraph = true });
+    var heading = GovUkTypography.Apply(Model.Content.Value<string>("heading"), new TypographyOptions{ RemoveWrappingParagraph = true });
+    var text = GovUkTypography.Apply(Model.Content.Value<string>("text"), new TypographyOptions { RemoveWrappingParagraph = true });
 }
 <govuk-notification-banner type="@((NotificationBannerType)bannerType!)">
-    @if (!string.IsNullOrEmpty(Model.Item.Settings.Value<string>("title")))
+    @if (!string.IsNullOrEmpty(Model.Settings.Value<string>("title")))
     {
-        <govuk-notification-banner-title>@(Model.Item.Settings.Value<string>("title"))</govuk-notification-banner-title>
+        <govuk-notification-banner-title>@(Model.Settings.Value<string>("title"))</govuk-notification-banner-title>
     }
     @if (string.IsNullOrEmpty(text))
     {

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkPageHeading.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkPageHeading.cshtml
@@ -2,6 +2,6 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    var cssClass = ("govuk-heading-l " + Model.Item.Settings?.Value<string>("cssClasses")).TrimEnd();
+    var cssClass = ("govuk-heading-l " + Model.Settings?.Value<string>("cssClasses")).TrimEnd();
 }
 <h1 class="@cssClass">@Umbraco.AssignedContentItem.Name</h1>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkPanel.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkPanel.cshtml
@@ -4,12 +4,12 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    if (!Int32.TryParse(Model.Item.Settings.Value<string>("headingLevel")?.Replace("Heading ", string.Empty), out var headingLevel))
+    if (!Int32.TryParse(Model.Settings.Value<string>("headingLevel")?.Replace("Heading ", string.Empty), out var headingLevel))
     {
         headingLevel = 1;
     }
 }
 <govuk-panel heading-level="@headingLevel">
-    <govuk-panel-title>@(Model.Item.Content.Value<string>("panelHeading"))</govuk-panel-title>
-    <govuk-panel-body>@Html.Raw(GovUkTypography.Apply(Model.Item.Content.Value<string>("panelText"), new TypographyOptions{ RemoveWrappingParagraph = true, BackgroundType = BackgroundType.Dark }))</govuk-panel-body>
+    <govuk-panel-title>@(Model.Content.Value<string>("panelHeading"))</govuk-panel-title>
+    <govuk-panel-body>@Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("panelText"), new TypographyOptions{ RemoveWrappingParagraph = true, BackgroundType = BackgroundType.Dark }))</govuk-panel-body>
 </govuk-panel>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkRadios.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkRadios.cshtml
@@ -7,20 +7,20 @@
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
 @{
-    var radioButtons = Model.Item.Content.Value<BlockListModel>("radioButtons");
-    var modelPropertyName = Model.Item.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var radioButtons = Model.Content.Value<BlockListModel>("radioButtons");
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
     ViewContext.ModelState.TryGetValue(modelPropertyName, out var modelStateEntry);
     var attemptedValue = modelStateEntry?.AttemptedValue?.ToUpperInvariant();
-    var cssClass = Model.Item.Settings.Value<string>("cssClasses");
-    if (Model.Item.Settings.Value<string>("layout") == "Horizontal")
+    var cssClass = Model.Settings.Value<string>("cssClasses");
+    if (Model.Settings.Value<string>("layout") == "Horizontal")
     {
         cssClass = (cssClass + " govuk-radios--inline").TrimStart();
     }
-    var hint = GovUkTypography.Apply(Model.Item.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
-    var legendIsPageHeading = Model.Item.Settings.Value<bool>("legendIsPageHeading");
-    var legend = Model.Item.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
+    var hint = GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
+    var legendIsPageHeading = Model.Settings.Value<bool>("legendIsPageHeading");
+    var legend = Model.Content.Value<string>("legend").Replace("{{name}}", Umbraco.AssignedContentItem.Name);
 }
-<govuk-client-side-validation error-message-required="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+<govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-radios name="@modelPropertyName" class="@cssClass">
          <govuk-radios-fieldset>
             <govuk-radios-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-radios-fieldset-legend>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkSelect.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkSelect.cshtml
@@ -6,16 +6,16 @@
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
 @{
-    var options = Model.Item.Content.Value<BlockListModel>("options");
-    var modelPropertyName = Model.Item.Settings.Value<string>(PropertyAliases.ModelProperty);
-    var cssClass = Model.Item.Settings.Value<string>("cssClasses");
+    var options = Model.Content.Value<BlockListModel>("options");
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var cssClass = Model.Settings.Value<string>("cssClasses");
     ViewContext.ModelState.TryGetValue(modelPropertyName, out var modelStateEntry);
     var attemptedValue = modelStateEntry?.AttemptedValue?.ToUpperInvariant();
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-select name="@modelPropertyName" class="@cssClass">
-        <govuk-select-label>@(Model.Item.Content.Value<string>("label"))</govuk-select-label>
+        <govuk-select-label>@(Model.Content.Value<string>("label"))</govuk-select-label>
         <govuk-select-error-message>@(modelStateEntry != null && modelStateEntry.Errors.Any() ? string.Join(". ", modelStateEntry.Errors.Select(x => x.ErrorMessage)) : null)</govuk-select-error-message>
         @foreach (var block in Model.Filter(options))
         {

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextInput.cshtml
@@ -6,23 +6,23 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Item.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
     ViewContext.ModelState.TryGetValue(modelPropertyName, out var modelStateEntry);
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
-    error-message-regex="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRegex))"
-    error-message-email="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageEmail))"
-    error-message-phone="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessagePhone))"
-    error-message-length="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageLength))"
-    error-message-minlength="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageMinLength))"
-    error-message-maxlength="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
-    error-message-range="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRange))"
-    error-message-compare="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageCompare))"
+    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
+    error-message-regex="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRegex))"
+    error-message-email="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageEmail))"
+    error-message-phone="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessagePhone))"
+    error-message-length="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageLength))"
+    error-message-minlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMinLength))"
+    error-message-maxlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
+    error-message-range="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRange))"
+    error-message-compare="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageCompare))"
 >
-    <govuk-input name="@modelPropertyName" value="@modelStateEntry?.AttemptedValue" input-class="@(Model.Item.Settings.Value<string>("cssClasses"))">
-        <govuk-input-label>@(Model.Item.Content.Value<string>("label"))</govuk-input-label>
-        <govuk-input-hint>@Html.Raw(GovUkTypography.Apply(Model.Item.Content.Value<string>("hint"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-input-hint>
+    <govuk-input name="@modelPropertyName" value="@modelStateEntry?.AttemptedValue" input-class="@(Model.Settings.Value<string>("cssClasses"))">
+        <govuk-input-label>@(Model.Content.Value<string>("label"))</govuk-input-label>
+        <govuk-input-hint>@Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-input-hint>
         <govuk-input-error-message>@(modelStateEntry != null && modelStateEntry.Errors.Any() ? string.Join(". ", modelStateEntry.Errors.Select(x => x.ErrorMessage)) : null)</govuk-input-error-message>
     </govuk-input>
 </govuk-client-side-validation>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextarea.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextarea.cshtml
@@ -10,41 +10,41 @@
 @using System.ComponentModel.DataAnnotations
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Item.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
     ViewContext.ModelState.TryGetValue(modelPropertyName, out var modelStateEntry);
-    Int32.TryParse(Model.Item.Settings.Value<string>("rows"), out var rows);
+    Int32.TryParse(Model.Settings.Value<string>("rows"), out var rows);
     if (rows < 2) { rows = 5; }
-    var labelIsPageHeading = Model.Item.Settings.Value<bool>("labelIsPageHeading");
+    var labelIsPageHeading = Model.Settings.Value<bool>("labelIsPageHeading");
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
-    error-message-regex="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRegex))"
-    error-message-email="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageEmail))"
-    error-message-length="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageLength))"
-    error-message-minlength="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageMinLength))"
-    error-message-maxlength="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
-    error-message-range="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageRange))"
-    error-message-compare="@(Model.Item.Settings.Value<string>(PropertyAliases.ErrorMessageCompare))"
+    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
+    error-message-regex="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRegex))"
+    error-message-email="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageEmail))"
+    error-message-length="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageLength))"
+    error-message-minlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMinLength))"
+    error-message-maxlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
+    error-message-range="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRange))"
+    error-message-compare="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageCompare))"
 >
-    @if (Model.Item.Settings.Value<bool>("showCharacterCount"))
+    @if (Model.Settings.Value<bool>("showCharacterCount"))
     {
-        var threshold = Model.Item.Settings.Value<int?>("characterCountThreshold");
+        var threshold = Model.Settings.Value<int?>("characterCountThreshold");
         var modelProperty = propertyResolver.ResolveModelProperty(propertyResolver.ResolveModelType(ViewContext), modelPropertyName);
         var maxLengthAttr = modelProperty.GetCustomAttributes<MaxLengthAttribute>().FirstOrDefault();
         var stringLengthAttr = modelProperty.GetCustomAttributes<StringLengthAttribute>().FirstOrDefault();
         int? maxLength = maxLengthAttr != null ? maxLengthAttr.Length : stringLengthAttr != null ? stringLengthAttr.MaximumLength : null;
-        <govuk-character-count name="@modelPropertyName" form-group-class="@(Model.Item.Settings.Value<string>("cssClasses"))" rows="@rows" max-length="@maxLength" threshold="@threshold">
-            <govuk-character-count-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@(Model.Item.Content.Value<string>("label"))</govuk-character-count-label>
-            <govuk-character-count-hint>@Html.Raw(GovUkTypography.Apply(Model.Item.Content.Value<string>("hint"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-character-count-hint>
+        <govuk-character-count name="@modelPropertyName" form-group-class="@(Model.Settings.Value<string>("cssClasses"))" rows="@rows" max-length="@maxLength" threshold="@threshold">
+            <govuk-character-count-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@(Model.Content.Value<string>("label"))</govuk-character-count-label>
+            <govuk-character-count-hint>@Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-character-count-hint>
             <govuk-character-count-error-message>@(modelStateEntry != null && modelStateEntry.Errors.Any() ? string.Join(". ", modelStateEntry.Errors.Select(x => x.ErrorMessage)) : null)</govuk-character-count-error-message>
             <govuk-character-count-value>@modelStateEntry?.AttemptedValue</govuk-character-count-value>
         </govuk-character-count>
     }
     else
     {
-        <govuk-textarea name="@modelPropertyName" class="@(Model.Item.Settings.Value<string>("cssClasses"))" rows="@rows">
-            <govuk-textarea-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@(Model.Item.Content.Value<string>("label"))</govuk-textarea-label>
-            <govuk-textarea-hint>@Html.Raw(GovUkTypography.Apply(Model.Item.Content.Value<string>("hint"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-textarea-hint>
+        <govuk-textarea name="@modelPropertyName" class="@(Model.Settings.Value<string>("cssClasses"))" rows="@rows">
+            <govuk-textarea-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@(Model.Content.Value<string>("label"))</govuk-textarea-label>
+            <govuk-textarea-hint>@Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-textarea-hint>
             <govuk-textarea-error-message>@(modelStateEntry != null && modelStateEntry.Errors.Any() ? string.Join(". ", modelStateEntry.Errors.Select(x => x.ErrorMessage)) : null)</govuk-textarea-error-message>
             <govuk-textarea-value>@modelStateEntry?.AttemptedValue</govuk-textarea-value>
         </govuk-textarea>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTypography.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTypography.cshtml
@@ -5,7 +5,7 @@
 @using HtmlAgilityPack
 @using Umbraco.Extensions
 @{
-    var html = Model.Item.Content.Value<string>("text");
+    var html = Model.Content.Value<string>("text");
     html = GovUkTypography.Apply(html);
 }
 @if (!string.IsNullOrWhiteSpace(html))

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkWarningText.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkWarningText.cshtml
@@ -4,9 +4,9 @@
 @using GovUk.Frontend.Umbraco.Models
 @using Umbraco.Extensions
 @{
-    var iconFallbackText = Model.Item.Content.Value<string>("iconFallbackText");
+    var iconFallbackText = Model.Content.Value<string>("iconFallbackText");
     if (string.IsNullOrWhiteSpace(iconFallbackText)) { iconFallbackText = "Warning"; }
 }
-<govuk-warning-text icon-fallback-text="@iconFallbackText" id="@Model.Item.Content.Key">
-    @Html.Raw(GovUkTypography.Apply(Model.Item.Content.Value<string>("text"), new TypographyOptions{ RemoveWrappingParagraph = true }))
+<govuk-warning-text icon-fallback-text="@iconFallbackText" id="@Model.Content.Key">
+    @Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("text"), new TypographyOptions{ RemoveWrappingParagraph = true }))
 </govuk-warning-text>


### PR DESCRIPTION
Blocks in a block list are returned as read-only in an Umbraco controller. But sometimes we will need to update properties, eg to set an error class in a "css classes" property if a field is invalid. This update to the `FilteredBlockList` approach allows that to happen very simply, although currently it's only written to support a top-level block list rather than a nested block list.

README.md is updated to show how to use it.

Will be required for story AB#108343.

date-input.config is just a page that got saved during testing. It was originally created before most block types had a settings type configured.