### PR TITLE
Column layout work for AB#133306

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
@@ -105,3 +105,30 @@
     @extend .govuk-grid-row--tpr-divider;
     width: 100%;
 }
+
+
+/*
+    Columns with alternating white and grey backgrounds.
+    Columns should have a *-from-desktop grid width applied, eg govuk-grid-column-one-third-from-desktop for a three column layout.
+    Switch to flexbox for desktop layouts so that, when columns are active, column backgrounds extend the full height of the column.
+*/
+
+.govuk-grid-row--tpr-columns > .govuk-grid-column > .govuk-grid-row > .govuk-grid-column {
+    @include govuk-responsive-padding(4, "top"); // space above and below text in the column is required on a non-white background
+    @include govuk-responsive-padding(4, "bottom");
+    @include govuk-responsive-margin(2, "bottom"); // vertical space between columns when stacked
+}
+
+@include govuk-media-query($from: desktop) {
+    .govuk-grid-row--tpr-columns > .govuk-grid-column > .govuk-grid-row {
+        display: flex;
+    }
+
+    .govuk-grid-row--tpr-columns > .govuk-grid-column > .govuk-grid-row > .govuk-grid-column {
+        @include govuk-responsive-margin(0, "bottom"); // vertical space no longer needed when not stacked
+    }
+}
+
+.govuk-grid-row--tpr-columns > .govuk-grid-column > .govuk-grid-row > .govuk-grid-column:nth-child(even) {
+    background: $tpr-colour-white-smoke;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
@@ -132,3 +132,10 @@
 .govuk-grid-row--tpr-columns > .govuk-grid-column > .govuk-grid-row > .govuk-grid-column:nth-child(even) {
     background: $tpr-colour-white-smoke;
 }
+
+/* 
+    Keep the set of columns away from the browser edge - particularly relevant in error state where you want to see the error border.
+*/
+.govuk-grid-row--tpr-columns > .govuk-grid-column {
+    margin-left:0;
+}

--- a/GovUk.Frontend.Umbraco/Models/OverridablePublishedElement.cs
+++ b/GovUk.Frontend.Umbraco/Models/OverridablePublishedElement.cs
@@ -54,13 +54,14 @@ namespace GovUk.Frontend.Umbraco.Models
         /// <param name="value"></param>
         public void OverrideValue(string alias, object value)
         {
-            if (_propertyValues.ContainsKey(alias))
+            var key = alias.ToUpperInvariant();
+            if (_propertyValues.ContainsKey(key))
             {
-                _propertyValues[alias] = value;
+                _propertyValues[key] = value;
             }
             else
             {
-                _propertyValues.Add(alias, value);
+                _propertyValues.Add(key, value);
             }
         }
 
@@ -83,9 +84,10 @@ namespace GovUk.Frontend.Umbraco.Models
         /// </remarks>
         public T? Value<T>(string alias, string? culture = null, string? segment = null, Fallback fallback = default, T? defaultValue = default)
         {
-            if (_propertyValues.ContainsKey(alias))
+            var key = alias.ToUpperInvariant();
+            if (_propertyValues.ContainsKey(key))
             {
-                return (T)_propertyValues[alias];
+                return (T)_propertyValues[key];
             }
 
             return _publishedElement != null ? _publishedElement.Value(alias, culture, segment, fallback, defaultValue) : default;

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridColumn.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridColumn.cshtml
@@ -6,7 +6,7 @@
 @using Umbraco.Extensions
 @{
     var blocks = Model.Content.Value<OverridableBlockListModel>("blocks");
-    blocks.RenderGrid = false;
+    blocks!.RenderGrid = Model.Settings?.Value<bool>("renderRowsAndColumnsForChildBlocks") ?? false;
     var columnClass = GovUkGridClassBuilder.BuildGridColumnClass(
                         Model.Settings?.Value<string>("columnSize"), 
                         Model.Settings?.Value<string>("columnSizeFromDesktop"), 

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridRow.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkGridRow.cshtml
@@ -5,7 +5,7 @@
 @using GovUk.Frontend.Umbraco.Services
 @using Umbraco.Extensions
 @{
-    var blocks = Model.Content.Value<OverridableBlockListModel>("blocks")?.ToList();
+    var blocks = Model.Content.Value<OverridableBlockListModel>("blocks")?.FilteredBlocks().ToList();
     var rowClass = Model.Settings?.Value<string>("cssClassesForRow");
     var columnClass = GovUkGridClassBuilder.BuildGridColumnClass(
                         Model.Settings?.Value<string>("columnSize"), 

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridcolumnsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridcolumnsettings.config
@@ -22,6 +22,31 @@
     <AllowedTemplates />
   </Info>
   <Structure />
-  <GenericProperties />
-  <Tabs />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>8a59f6f7-0d35-4c2c-8cb6-35a7a1d1e5e5</Key>
+      <Name>Render rows and columns for child blocks</Name>
+      <Alias>renderRowsAndColumnsForChildBlocks</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>10</SortOrder>
+      <Tab Alias="grid">Grid</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>342fca03-c00d-4fa7-b74e-260a38f5955d</Key>
+      <Caption>Grid</Caption>
+      <Alias>grid</Alias>
+      <Type>Group</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+  </Tabs>
 </ContentType>


### PR DESCRIPTION
- Column blocks were not respecting the filter
- Umbraco property aliases should not be case-sensitive when overriding values as you end up with multiple values per property
- Add styles for TPR columns with alternating background colours
- Add the ability to turn grid rendering on for a column to generate extra markup