### PR TITLE
Change default TPR styling for legends to be bigger

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -207,5 +207,9 @@
 	<ItemGroup>
 	  <Folder Include="Content\" />
 	</ItemGroup>
+	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_govuk-fieldset.scss" />
+	</ItemGroup>
 
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-date-input.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-date-input.scss
@@ -1,7 +1,15 @@
 ﻿@import '_variables.scss';
 @import 'govuk/base';
 
-/* Change GOV.UK date input styles where the TPR brand diverges from the GOV.UK Design System. */
+/* Change GOV.UK date input styles where the TPR brand diverges from the GOV.UK Design System. 
+
+   _govuk-fieldset.scss makes legends bigger by default, so reset them for date fields to be the same 
+   as the TPR version of .govuk-label.
+*/
+.govuk-date-input__fieldset > legend {
+    @extend .govuk-fieldset__legend--s;
+}
+
 .govuk-label.govuk-date-input__label {
     font-weight: $tpr-font-weight-semi-bold;
 }

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-fieldset.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-fieldset.scss
@@ -1,0 +1,10 @@
+﻿@import '_variables.scss';
+@import 'govuk/base';
+
+/* Change GOV.UK fieldset styles where the TPR brand diverges from the GOV.UK Design System. 
+   
+   Legends should look like h2. They need to be bolder than GOV.UK because we make .govuk-label bold.
+*/
+legend.govuk-fieldset__legend {
+    @extend .govuk-fieldset__legend--m;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
@@ -35,6 +35,7 @@
 @import '_govuk-button.scss';
 @import '_govuk-caption.scss';
 @import '_govuk-date-input.scss';
+@import '_govuk-fieldset.scss';
 @import '_govuk-input.scss';
 @import '_govuk-inset-text.scss';
 @import '_govuk-label.scss';

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDateInput.cshtml
@@ -27,7 +27,7 @@
 <govuk-client-side-validation
     error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-date-input name-prefix="@modelPropertyName" id="@modelPropertyName" value="@dateValue" class="@cssClass">
-        <govuk-date-input-fieldset>
+        <govuk-date-input-fieldset class="govuk-date-input__fieldset">
             <govuk-date-input-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-date-input-fieldset-legend>
             @if (!string.IsNullOrWhiteSpace(hint))
             {


### PR DESCRIPTION
TPR styles change field labels to be bold, so legends need to be bigger and bolder too - like h2.

Do that in the TPR override SCSS so that it's the default for all TPR sites, but the base component remains true to the GOV.UK Design System. Handle date fields as an exception.

The following underlined lines of text are both legends, without anything applied beyond the TPR default:

<img width="524" alt="image" src="https://user-images.githubusercontent.com/1260550/185912920-6c51ec52-931d-42ce-93c8-91f798c72f1e.png">


AB#108343