### PR TITLE
If an invisible error placeholder was present, the title bar incorrectly showed the prefix 'Error:'

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/__tests__/govuk-validation-updateTitle.tests.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/__tests__/govuk-validation-updateTitle.tests.js
@@ -1,9 +1,22 @@
 const govuk = require("../wwwroot/govuk/govuk-validation");
+const errorPlaceholderHtml =
+  '<p class="govuk-error-message" id="some-field-error" data-valmsg-for="some-field" data-valmsg-replace="false"><span class="govuk-visually-hidden">Error:</span></p>';
+const errorHtml =
+  '<p class="govuk-error-message" id="some-field-error" data-valmsg-for="some-field" data-valmsg-replace="false"><span class="govuk-visually-hidden">Error:</span> A real error</p>';
 
 describe("updateTitle", () => {
+  it("should not add Error: when there is an empty error placeholder", () => {
+    document.title = "Example";
+    document.body.innerHTML = errorPlaceholderHtml;
+
+    govuk().updateTitle();
+
+    expect(document.title).toBe("Example");
+  });
+
   it("should add Error: when there is an error", () => {
     document.title = "Example";
-    document.body.innerHTML = '<p class="govuk-error-message"></p>';
+    document.body.innerHTML = errorHtml;
 
     govuk().updateTitle();
 
@@ -12,7 +25,7 @@ describe("updateTitle", () => {
 
   it("should not add Error: multiple times", () => {
     document.title = "Error: Example";
-    document.body.innerHTML = '<p class="govuk-error-message"></p>';
+    document.body.innerHTML = errorHtml;
 
     govuk().updateTitle();
 

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
@@ -34,7 +34,22 @@ function createGovUkValidator() {
      */
     updateTitle: function () {
       const prefix = "Error: ";
-      const hasError = document.querySelector(".govuk-error-message");
+      const hasError = [].slice
+        .call(document.querySelectorAll(".govuk-error-message"))
+        .filter(function (error) {
+          const prefix = error.querySelector(".govuk-visually-hidden");
+          const textNode = 3;
+          for (let i = 0; i < error.childNodes.length; i++) {
+            let x = error.childNodes[i];
+            if (
+              x !== prefix &&
+              (x.nodeType !== textNode || x.textContent.trim())
+            ) {
+              return true;
+            }
+          }
+          return false;
+        }).length;
       const index = document.title.indexOf(prefix);
       if (hasError && index !== 0) {
         document.title = prefix + document.title;


### PR DESCRIPTION
Fix code and update tests. Relevant for story AB#108343