### PR TITLE
The previous change to legend styling incorrectly affected legends as page headings

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-date-input.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-date-input.scss
@@ -1,15 +1,7 @@
 ﻿@import '_variables.scss';
 @import 'govuk/base';
 
-/* Change GOV.UK date input styles where the TPR brand diverges from the GOV.UK Design System. 
-
-   _govuk-fieldset.scss makes legends bigger by default, so reset them for date fields to be the same 
-   as the TPR version of .govuk-label.
-*/
-.govuk-date-input__fieldset > legend {
-    @extend .govuk-fieldset__legend--s;
-}
-
+/* Change GOV.UK date input styles where the TPR brand diverges from the GOV.UK Design System. */
 .govuk-label.govuk-date-input__label {
     font-weight: $tpr-font-weight-semi-bold;
 }

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-fieldset.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-fieldset.scss
@@ -4,7 +4,14 @@
 /* Change GOV.UK fieldset styles where the TPR brand diverges from the GOV.UK Design System. 
    
    Legends should look like h2. They need to be bolder than GOV.UK because we make .govuk-label bold.
+   However we need to be careful not to affect legends used as the page heading or a label for a 
+   single question (radios, checkboxes and date inputs). Use custom classes that are inert without a
+   TPR stylesheet to achieve this.
 */
-legend.govuk-fieldset__legend {
+.govuk-fieldset__legend--for-fieldset {
     @extend .govuk-fieldset__legend--m;
+}
+
+.govuk-fieldset__legend--for-field {
+    font-weight: $tpr-font-weight-bold;
 }

--- a/GovUk.Frontend.ExampleApp/Views/Checkboxes/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Checkboxes/Index.cshtml
@@ -13,7 +13,7 @@
         <govuk-checkboxes name="Field1">
             <govuk-checkboxes-fieldset>
                 <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">Checkboxes</govuk-checkboxes-fieldset-legend>
-                <govuk-checkboxes-hint>This is the hint</govuk-checkboxes-hint>
+                <govuk-checkboxes-hint>This is the hint. If you don't set the legend as the page heading, you must apply <code>.govuk-fieldset__legend--for-field</code> if you want TPR styling.</govuk-checkboxes-hint>
                 <govuk-checkboxes-item value="1">Item one (reveals related question)
                     <govuk-checkboxes-item-conditional>
                         <govuk-input asp-for="Field2"><govuk-input-label>Answer this related question</govuk-input-label></govuk-input>

--- a/GovUk.Frontend.ExampleApp/Views/DateInput/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/DateInput/Index.cshtml
@@ -18,7 +18,8 @@
 
           <govuk-date-input asp-for="Field2">
             <govuk-date-input-fieldset>
-                <govuk-date-input-fieldset-legend>This is the legend for field 2. The hint is optional.</govuk-date-input-fieldset-legend>
+                <govuk-date-input-fieldset-legend class="govuk-fieldset__legend--for-field">This is the legend for field 2. The hint is optional.</govuk-date-input-fieldset-legend>
+                <govuk-date-input-hint>You must apply <code>.govuk-fieldset__legend--for-field</code> if you want TPR styling.</govuk-date-input-hint>
             </govuk-date-input-fieldset>
         </govuk-date-input>
     </govuk-client-side-validation>

--- a/GovUk.Frontend.ExampleApp/Views/Radios/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Radios/Index.cshtml
@@ -12,8 +12,8 @@
     <govuk-client-side-validation>
         <govuk-radios asp-for="Field1">
             <govuk-radios-fieldset>
-                <govuk-radios-fieldset-legend>This is the legend</govuk-radios-fieldset-legend>
-                <govuk-radios-hint>This is the hint</govuk-radios-hint>
+                <govuk-radios-fieldset-legend class="govuk-fieldset__legend--for-field">This is the legend</govuk-radios-fieldset-legend>
+                <govuk-radios-hint>This is the hint. You must apply <code>.govuk-fieldset__legend--for-field</code> if you want TPR styling.</govuk-radios-hint>
                 <govuk-radios-item value="1">
                     Item one (reveals related question)
                     <govuk-radios-item-conditional>

--- a/GovUk.Frontend.ExampleApp/Views/TextInput/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/TextInput/Index.cshtml
@@ -12,11 +12,12 @@
 <h1 class="govuk-heading-l">@ViewData["Title"]</h1>
 
 <p class="govuk-body">To demonstrate localisation, use the language switcher to change the language of error messages.</p>
+<p class="govuk-body">You must apply <code>.govuk-fieldset__legend--for-fieldset</code> if you want TPR styling.</p>
 
 <form asp-controller="TextInput" asp-action="Post" method="post" novalidate>
     <govuk-client-side-validation>
         <govuk-fieldset>
-            <govuk-fieldset-legend>The first two fields are in a fieldset</govuk-fieldset-legend>
+            <govuk-fieldset-legend class="govuk-fieldset__legend--for-fieldset">The first two fields are in a fieldset</govuk-fieldset-legend>
                 <govuk-input asp-for="Field1">
                     <govuk-input-label>Field label</govuk-input-label>
                     <govuk-input-hint>This field must be numeric, and between 5 and 20 characters</govuk-input-hint>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCheckboxes.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkCheckboxes.cshtml
@@ -29,7 +29,7 @@
 <govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-checkboxes name="@modelPropertyName" class="@cssClass" checkboxes-class="@cssClassesForCheckboxes">
          <govuk-checkboxes-fieldset>
-            <govuk-checkboxes-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-checkboxes-fieldset-legend>
+            <govuk-checkboxes-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : "govuk-fieldset__legend--for-field")">@legend</govuk-checkboxes-fieldset-legend>
             @{
                 if (!string.IsNullOrWhiteSpace(fieldsetHint))
                 {

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkDateInput.cshtml
@@ -28,7 +28,7 @@
     error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-date-input name-prefix="@modelPropertyName" id="@modelPropertyName" value="@dateValue" class="@cssClass">
         <govuk-date-input-fieldset class="govuk-date-input__fieldset">
-            <govuk-date-input-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-date-input-fieldset-legend>
+            <govuk-date-input-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : "govuk-fieldset__legend--for-field")">@legend</govuk-date-input-fieldset-legend>
             @if (!string.IsNullOrWhiteSpace(hint))
             {
                 <govuk-date-input-hint>@Html.Raw(hint)</govuk-date-input-hint>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkFieldset.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkFieldset.cshtml
@@ -10,6 +10,6 @@
     var legend = Model.Content.Value<string>("legend")?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
 }
 <govuk-fieldset class="@cssClass">
-    <govuk-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-fieldset-legend>
+    <govuk-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : "govuk-fieldset__legend--for-fieldset")">@legend</govuk-fieldset-legend>
     @await Html.PartialAsync("GOVUK/BlockList", blocks)
 </govuk-fieldset>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkRadios.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkRadios.cshtml
@@ -31,7 +31,7 @@
 <govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-radios name="@modelPropertyName" class="@cssClass" radios-class="@cssClassesForRadios">
          <govuk-radios-fieldset>
-            <govuk-radios-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : null)">@legend</govuk-radios-fieldset-legend>
+            <govuk-radios-fieldset-legend is-page-heading="@legendIsPageHeading" class="@(legendIsPageHeading ? "govuk-fieldset__legend--l" : "govuk-fieldset__legend--for-field")">@legend</govuk-radios-fieldset-legend>
         @if (!string.IsNullOrWhiteSpace(fieldsetHint))
         {
             <govuk-radios-hint class="@cssClassesForHint">@Html.Raw(fieldsetHint)</govuk-radios-hint>


### PR DESCRIPTION
This approach is tested with:
- ordinary fieldsets
- radios as an ordinary question or a page heading
- checkboxes as an ordinary question or a page heading
- date input as an ordinary question or a page heading
- plain .NET and Umbraco implementations

AB#108343