### PR TITLE
AB#108354 make legend optional

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuklegend.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuklegend.config
@@ -27,7 +27,7 @@
       <Alias>legend</Alias>
       <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
       <Type>Umbraco.TextBox</Type>
-      <Mandatory>true</Mandatory>
+      <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[Use {{name}} to include the page name.]]></Description>
       <SortOrder>0</SortOrder>


### PR DESCRIPTION
Bonds Category breakdown page requires a fieldset to display the error for the total of the text inputs. However the prototype doesn't include a legend for the fieldset.