### PR TITLE
Create Duplicate of file TagHelperContextExtensions.cs

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelperContextExtensions.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelperContextExtensions.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.Extensions
+{
+    /// <summary>
+    /// Copied from GovUk.Frontend.AspNetCore
+    /// </summary>
+    internal static class TagHelperContextExtensions
+    {
+        public static TItem GetContextItem<TItem>(this TagHelperContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!context.Items.TryGetValue(typeof(TItem), out var item))
+            {
+                throw new InvalidOperationException($"No context item found for type: '{typeof(TItem).FullName}'.");
+            }
+
+            return (TItem)item;
+        }
+
+        public static IDisposable SetScopedContextItem<TItem>(this TagHelperContext context, TItem item)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            return SetScopedContextItem(context, typeof(TItem), item);
+        }
+
+        public static IDisposable SetScopedContextItem(
+            this TagHelperContext context,
+            object key,
+            object value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            context.Items.TryGetValue(key, out var previousValue);
+            context.Items[key] = value;
+
+            return new RestoreItemsOnDispose(context, key, previousValue);
+        }
+
+        internal class RestoreItemsOnDispose : IDisposable
+        {
+            private readonly TagHelperContext _context;
+            private readonly object _key;
+            private readonly object? _previousValue;
+
+            public RestoreItemsOnDispose(
+                TagHelperContext context,
+                object key,
+                object? previousValue)
+            {
+                _context = context ?? throw new ArgumentNullException(nameof(context));
+                _key = key ?? throw new ArgumentNullException(nameof(key));
+                _previousValue = previousValue;
+            }
+
+            public void Dispose()
+            {
+                if (_previousValue != null)
+                {
+                    _context.Items[_key] = _previousValue;
+                }
+                else
+                {
+                    _context.Items.Remove(_key);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Because
- It is declared internal in GovUk.FrontEnd.AspNetCore

We need the class to be `public` so that we can use it in our own assemblies.
This commit will add the class from GovUk.FrontEnd.AspNetCore and make it
`public`. We need this for the NotifiableEvents.Websites.Umbraco

This file should be removed once the the class is made public in  GovUk.FrontEnd.AspNetCore