### PR TITLE
Fixed issue where custom validation wasn't created

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
@@ -262,11 +262,11 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
                         AddOrUpdateHtmlAttribute(targetElement, "type", "number");
                     }
 
-                    if (!validateElement) // Not already handled
+                    // Get anything else that inherits from ValidationAttribute
+                    var baseValidationAttributes = modelProperty.GetCustomAttributes<ValidationAttribute>();
+                    if (baseValidationAttributes != null && baseValidationAttributes.Count() > 0)
                     {
-                        // Get anything else that inherits from ValidationAttribute
-                        var baseValidationAttribute = modelProperty.GetCustomAttribute<ValidationAttribute>();
-                        if (baseValidationAttribute != null)
+                        foreach (var baseValidationAttribute in baseValidationAttributes)
                         {
                             // Recast to see if we should be adding client-side attributes
                             var customValidation = baseValidationAttribute as IClientModelValidator;

--- a/GovUk.Frontend.ExampleApp/Models/CustomValidationViewModel.cs
+++ b/GovUk.Frontend.ExampleApp/Models/CustomValidationViewModel.cs
@@ -16,6 +16,7 @@ namespace GovUk.Frontend.ExampleApp.Models
         [Range(1, 10, ErrorMessage = "Must be between 1 and 10")]
         public int Field2 { get; set; }
 
+        [Required(ErrorMessage = "This field is required")]
         [CustomValidator("Field1", "Field2", ErrorMessage = "This field must be the sum of box 1 and box 2")]
         public string Field3 { get; set; }
     }


### PR DESCRIPTION
If fields had more than one validation attribute, any 'custom' validation attribute was ignored.