### PR TITLE
Add duplicate of file TagHelperContentExtensions.cs

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelperContentExtensions.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelperContentExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.Extensions
+{
+    /// <summary>
+    /// Copied from GovUk.Frontend.AspNetCore
+    /// </summary>
+    internal static class TagHelperContentExtensions
+    {
+        public static IHtmlContent Snapshot(this TagHelperContent content)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            return new HtmlString(content.GetContent());
+        }
+    }
+}


### PR DESCRIPTION
Because
- The class is declared internal in GovUk.FrontEnd.AspNetCore and we want to access it in our own assemblies

This commit adds the class to our project so that we can access it

This file should be deleted once the class is declared public in GovUk.FrontEnd.AspNetCore