### PR TITLE
Make all numeric input fields of type text

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
@@ -616,6 +616,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@data-val-range-min='{min}']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@data-val-range-max='{max}']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='text']") != null);
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@inputmode='numeric']") != null);
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@pattern='[0-9]*']") != null);
         }
 
         [Test]
@@ -681,6 +683,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
 
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='text']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@inputmode='numeric']") != null);
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@pattern='[0-9]*']") != null);
         }
 
         [Test]

--- a/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
@@ -615,7 +615,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@data-val-range='{errorMessageRange}']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@data-val-range-min='{min}']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@data-val-range-max='{max}']") != null);
-            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='number']") != null);
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='text']") != null);
         }
 
         [Test]
@@ -654,7 +654,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
         }
 
         [Test]
-        public void Numeric_fields_without_range_have_type_equals_number_added()
+        public void Numeric_fields_without_range_have_text_input_type_numeric_input_mode()
         {
             var viewContext = new ViewContext() { ClientValidationEnabled = true };
             var options = Options.Create(new MvcDataAnnotationsLocalizationOptions());
@@ -679,7 +679,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             var document = new HtmlDocument();
             document.LoadHtml(result);
 
-            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='number']") != null);
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='text']") != null);
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@inputmode='numeric']") != null);
         }
 
         [Test]

--- a/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
@@ -259,7 +259,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
 
                     if (IsNumericType(modelProperty.PropertyType))
                     {
-                        AddOrUpdateHtmlAttribute(targetElement, "type", "number");
+                        AddOrUpdateHtmlAttribute(targetElement, "type", "text");
                     }
 
                     if (!validateElement) // Not already handled

--- a/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
@@ -260,6 +260,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
                     if (IsNumericType(modelProperty.PropertyType))
                     {
                         AddOrUpdateHtmlAttribute(targetElement, "type", "text");
+                        AddOrUpdateHtmlAttribute(targetElement, "inputmode", "numeric");
+                        AddOrUpdateHtmlAttribute(targetElement, "pattern", "[0-9]*");
                     }
 
                     if (!validateElement) // Not already handled

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
@@ -478,6 +478,12 @@ function createGovUkValidator() {
       }
 
       return true;
+      },
+
+    // Custom range validator to handle numbers with commas in
+    validateRangeWithCommas(value, element, param) {
+      var commaFreeVal = Number(value.replace(',',''));    
+      return this.optional(element) || (commaFreeVal >= param[0] && commaFreeVal <= param[1]);
     },
   };
 
@@ -496,6 +502,8 @@ window.addEventListener("DOMContentLoaded", function () {
     });
 
     validator.addMethod("phone", govuk.validatePhone);
+    validator.addMethod("range", govuk.validateRangeWithCommas);
+      
     validator.unobtrusive.adapters.addBool("phone");
     validator.unobtrusive.parse();
   }


### PR DESCRIPTION
AB#133749 
Changes:
- Add the "text" attribute to input elements when the model is a numeric type
Because:
- We want to add commas to monetry fields which are not valid an input element of type "number". Also, the [GDS Standards](https://design-system.service.gov.uk/components/text-input/#numbers) say that type "text" should be used for entering numbers unless specific user research suggests we should do otherwise. There is a longer read on this on the [GDS blog site](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/).