### PR TITLE
The optional link around the TPR logo was required in Umbraco

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuksummarylistaction.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuksummarylistaction.config
@@ -27,7 +27,7 @@
       <Alias>link</Alias>
       <Definition>cf7747bb-a48a-430b-90b3-39e1a264becc</Definition>
       <Type>Umbraco.MultiUrlPicker</Type>
-      <Mandatory>false</Mandatory>
+      <Mandatory>true</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
       <SortOrder>0</SortOrder>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKLinkPicker.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKLinkPicker.config
@@ -6,7 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
   </Info>
   <Config><![CDATA[{
-  "MinNumber": 1,
+  "MinNumber": 0,
   "MaxNumber": 1,
   "OverlaySize": "small",
   "IgnoreUserStartNodes": false,

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -102,6 +102,7 @@
 		<Content Remove="uSync\v9\DataTypes\GOVUKSelectOptions.config" />
 		<Content Remove="uSync\v9\DataTypes\GOVUKSummaryListActions.config" />
 		<Content Remove="uSync\v9\DataTypes\GOVUKSummaryListBlockList.config" />
+		<Content Remove="uSync\v9\DataTypes\TPRRichTextEditorTPRHeader.config" />
 		<Content Remove="wwwroot\css\govuk-umbraco-rich-text-editor.css" />
 		<Content Remove="wwwroot\css\govuk-umbraco-rich-text-editor.css.map" />
 	</ItemGroup>
@@ -425,6 +426,9 @@
 			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</None>
 		<None Include="uSync\v9\DataTypes\GOVUKSummaryListBlockList.config">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</None>
+		<None Include="uSync\v9\DataTypes\TPRRichTextEditorTPRHeader.config">
 			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</None>
 		<None Include="wwwroot\css\govuk-umbraco-rich-text-editor.css">

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuksummarylistaction.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuksummarylistaction.config
@@ -27,7 +27,7 @@
       <Alias>link</Alias>
       <Definition>cf7747bb-a48a-430b-90b3-39e1a264becc</Definition>
       <Type>Umbraco.MultiUrlPicker</Type>
-      <Mandatory>false</Mandatory>
+      <Mandatory>true</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
       <SortOrder>0</SortOrder>

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKLinkPicker.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKLinkPicker.config
@@ -6,7 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
   </Info>
   <Config><![CDATA[{
-  "MinNumber": 1,
+  "MinNumber": 0,
   "MaxNumber": 1,
   "OverlaySize": "small",
   "IgnoreUserStartNodes": false,

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/TPRRichTextEditorTPRHeader.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/TPRRichTextEditorTPRHeader.config
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="48f89b23-2121-4f38-acca-02770993ca35" Alias="TPR Rich text editor (TPR header)" Level="1">
+  <Info>
+    <Name>TPR Rich text editor (TPR header)</Name>
+    <EditorAlias>Umbraco.TinyMCE</EditorAlias>
+    <DatabaseType>Ntext</DatabaseType>
+  </Info>
+  <Config><![CDATA[{
+  "Editor": {
+    "toolbar": [
+      "link",
+      "unlink"
+    ],
+    "stylesheets": [],
+    "maxImageSize": 500,
+    "mode": "classic"
+  },
+  "OverlaySize": "small",
+  "HideLabel": false,
+  "IgnoreUserStartNodes": false,
+  "MediaParentId": null
+}]]></Config>
+</DataType>


### PR DESCRIPTION
The optional link around the TPR logo was required in Umbraco. Reduce the minimum number of links in the property editor, and ensure fields are mandatory where a link actually is required. AB#142696

Also adds a missing datatype required for configuring the TPR header. AB#142694