### PR TITLE
The black background of the context bar did not always cover the violet behind

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprContextBar.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprContextBar.cs
@@ -37,6 +37,14 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
 
             var context23container = new TagBuilder("div");
             context23container.MergeCssClass("tpr-context__container");
+            if (!hasContext2)
+            {
+                context23container.MergeCssClass("tpr-context__container--context-2-empty");
+            }
+            if (!hasContext3)
+            {
+                context23container.MergeCssClass("tpr-context__container--context-3-empty");
+            }
 
             var context2Element = new TagBuilder("div");
             context2Element.MergeCssClass("govuk-body");

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-header.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-header.scss
@@ -155,13 +155,7 @@ $tpr-header-left-width-xl: 200px;
     }
 }
 
-
-
 // For .tpr-context stack everything by default.
-.tpr-context__inner {
-    min-height: govuk-px-to-rem(50);
-}
-
 .tpr-context .govuk-body {
     font-weight: $tpr-font-weight-regular;
     line-height: $tpr-header-line-height;
@@ -187,7 +181,14 @@ $tpr-header-left-width-xl: 200px;
     align-items: center;
     padding: $tpr-header-vertical-space $govuk-gutter-half;
     background-color: $tpr-colour-black;
-    min-height: 1.8em; // Ensures the black background covers the violet when .tpr-context__context-3 is not rendered
+}
+
+// Hide context 2 on small viewports if empty
+.tpr-context__container--context-2-empty .tpr-context__context-2 {
+    padding: 0;
+}
+.tpr-context__container--context-2-empty .tpr-context__context-3-inner {
+    border-top: none;
 }
 
 // Use another div inside .tpr-context__context-3 so that at larger sizes a left border can come in on the inner element,
@@ -266,6 +267,12 @@ $tpr-header-left-width-xl: 200px;
         align-items: center;
     }
 
+    // Ensures the black background of .tpr-context__context-2 expands to cover the violet when .tpr-context__context-2 is empty and .tpr-context__context-3 is not rendered
+    .tpr-context__container--context-2-empty.tpr-context__container--context-3-empty {
+        display: flex;
+        align-self: stretch;
+    }
+
     .tpr-context__context-1 {
         padding: $tpr-header-vertical-space $govuk-gutter $tpr-header-vertical-space 0;
         width: $tpr-header-image-width;
@@ -303,6 +310,14 @@ $tpr-header-left-width-xl: 200px;
     .tpr-context__context-3 {
         display: flex;
         align-items: center;
+        background: $tpr-colour-black; // Ensures the black background covers the violet when the content of .tpr-context__context-2 is short or empty
+    }
+
+    // Ensures the height of .tpr-context__context-2 is consistent whether or not .tpr-context__context-3 is rendered
+    // Vertical space should be equal to the sum of padding & margin on .tpr-context__context-3-inner
+    .tpr-context__context-2::after {
+        content: ' ';
+        padding: $tpr-header-vertical-space*1.5 0;
     }
 
     .tpr-context__context-3 {


### PR DESCRIPTION
Fix for task AB#142964

Previously the context bar could look like this, with the black not fully covering the violet:

![image](https://user-images.githubusercontent.com/1260550/200597840-915a677d-2e62-4eee-bc14-96955e4d34f0.png)

Now the different scenarios look like this:

### Mobile
![image](https://user-images.githubusercontent.com/1260550/200597960-2278fda0-8cfe-433e-9b40-351ab76970e6.png)

### Tablet
![image](https://user-images.githubusercontent.com/1260550/200598016-3cbdf13e-3c68-4010-b2d4-55ae51db2757.png)

### Desktop
![image](https://user-images.githubusercontent.com/1260550/200598083-84920713-dba1-44f3-8356-3e2395536bb4.png)
