### PR TITLE
Change the + icon to an SVG file rather than data URI 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-add-link.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-add-link.scss
@@ -1,18 +1,12 @@
 ﻿@import '_variables.scss';
 
-@function url-friendly-colour($colour) {
-    @return '%23' + str-slice('#{$colour}', 2, -1)
-}
-
+// The add image is from Material UI https: //fonts.google.com/icons?selected=Material+Icons+Outlined:add
+// Using a background image means no extra HTML is required and no extra characters are exposed to assistive technology.
 p.tpr-add-link {
     a {
         padding-left: 20px;
         background-repeat: no-repeat;
         background-position: 0 2px;
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='#{url-friendly-colour($govuk-link-colour)}' width='18px' height='18px'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z'/%3E%3C/svg%3E");
-    }
-
-    a:visited {
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='#{url-friendly-colour($govuk-link-visited-colour)}' width='18px' height='18px'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z'/%3E%3C/svg%3E");
+        background-image: url(/_content/GovUK.Frontend.AspNetCore.Extensions/tpr/add_royal_blue_24dp.svg);
     }
 }

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/tpr/add_royal_blue_24dp.svg
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/tpr/add_royal_blue_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#006ebc" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>


### PR DESCRIPTION
Content Security Policy was blocking the + icon from displaying because we do not allow data URIs. This is good practice since a data URI could be malicious, so instead convert the icon to a format we do allow.

AB#143747