### PR TITLE
Remove empty divs. Fixes layout error on AB#137644

### DIFF
--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkPanel.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkPanel.cshtml
@@ -8,8 +8,12 @@
     {
         headingLevel = 1;
     }
+    var body = GovUkTypography.Apply(Model.Content.Value<string>("panelText"), new TypographyOptions { RemoveWrappingParagraph = true, BackgroundType = BackgroundType.Dark });
 }
 <govuk-panel heading-level="@headingLevel">
     <govuk-panel-title>@(Model.Content.Value<string>("panelHeading"))</govuk-panel-title>
-    <govuk-panel-body>@Html.Raw(GovUkTypography.Apply(Model.Content.Value<string>("panelText"), new TypographyOptions{ RemoveWrappingParagraph = true, BackgroundType = BackgroundType.Dark }))</govuk-panel-body>
+    @if (!string.IsNullOrEmpty(body)) 
+    {
+        <govuk-panel-body>@Html.Raw(body)</govuk-panel-body>
+    }
 </govuk-panel>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkRadios.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkRadios.cshtml
@@ -49,17 +49,19 @@
             else
             {
                 var value = block.Content.Value<string>("value") ?? string.Empty;
+                var radioHint = GovUkTypography.Apply(block.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
+                var conditional = block.Content.Value<OverridableBlockListModel>("conditionalBlocks")!;
 
                 <govuk-radios-item value="@value" class="@(block.Settings.Value<string>("cssClasses"))" checked="@(value.ToUpperInvariant() == attemptedValue)">@(block.Content.Value<string>("label"))
-                    <govuk-radios-item-hint>@Html.Raw(GovUkTypography.Apply(block.Content.Value<string>("hint"), new TypographyOptions{ RemoveWrappingParagraph = true }))</govuk-radios-item-hint>
-                    @{
-                        var conditional = block.Content.Value<OverridableBlockListModel>("conditionalBlocks")!;
-                        if (conditional.Any()){
+                        @if (!string.IsNullOrEmpty(radioHint))
+                        {
+                            <govuk-radios-item-hint>@Html.Raw(radioHint)</govuk-radios-item-hint>
+                        }
+                        @if (conditional.Any()){
                             <govuk-radios-item-conditional>
                                 @await Html.PartialAsync("GOVUK/BlockList", conditional)
                             </govuk-radios-item-conditional>
                         }
-                    }
                 </govuk-radios-item>                
             }
         }


### PR DESCRIPTION
This is just a couple of if statements to avoid rendering divs if they have no content.