### PR TITLE
The focus style of the back to top link should not include padding

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.BackToTopLink.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.BackToTopLink.cs
@@ -22,15 +22,19 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
             var outer = new TagBuilder("div");
             outer.MergeCssClass("tpr-back-to-top");
 
+            var middle = new TagBuilder("div");
+            middle.MergeCssClass("govuk-width-container");
+
             var inner = new TagBuilder("div");
-            inner.MergeCssClass("govuk-width-container");
+            inner.MergeCssClass("tpr-back-to-top__inner");
 
             var link = new TagBuilder(BackToTopLinkElement);
             if (attributes != null) link.MergeAttributes(attributes);
             link.MergeCssClass("govuk-link");
             link.Attributes.Add("href", href);
 
-            outer.InnerHtml.AppendHtml(inner);
+            outer.InnerHtml.AppendHtml(middle);
+            middle.InnerHtml.AppendHtml(inner);
             inner.InnerHtml.AppendHtml(link);
             link.InnerHtml.AppendHtml(content);
 

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-back-to-top.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-back-to-top.scss
@@ -7,10 +7,9 @@
     padding-top: govuk-px-to-rem(11); // to achieve WCAG minimum click target height of 44px
 }
 
-@include govuk-media-query($from: desktop) {
-    .tpr-back-to-top {
-        text-align: right;
-    }
+.tpr-back-to-top__inner {
+    display: inline-block;
+    padding: 0 16px 0 0; // space equal to that for the arrow, so that the link is centered on the text only
 }
 
 // Customisations to the default style applied by .govuk-link
@@ -18,7 +17,18 @@
     @include govuk-link-style-no-visited-state;
     display: inline-block;
     position: relative;
-    padding: 0 16px govuk-px-to-rem(11) 16px; // space for the arrow, but center on the text only
+    padding: 0 0 0 16px; // space for the arrow
+    margin-bottom: govuk-px-to-rem(11);
+}
+
+@include govuk-media-query($from: desktop) {
+    .tpr-back-to-top {
+        text-align: right;
+    }
+
+    .tpr-back-to-top__inner {
+        padding: 0;
+    }
 }
 
 // Arrow pointing upward, made of CSS borders
@@ -26,7 +36,7 @@
     content: "";
     display: block;
     position: absolute;
-    top: -4px;
+    top: 6px;
     bottom: 0;
     left: 0;
     width: 7px;

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/TPR/Head.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/TPR/Head.cshtml
@@ -1,1 +1,2 @@
 ﻿<link rel="stylesheet" href="/_content/GovUk.Frontend.AspNetCore.Extensions/tpr/tpr.css" />
+<script src="/_content/GovUk.Frontend.AspNetCore.Extensions/tpr/tpr-back-to-top.js"></script>

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/tpr/tpr-back-to-top.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/tpr/tpr-back-to-top.js
@@ -1,12 +1,14 @@
 ﻿// Back to top should only appear when the page is longer than 4vh
 document.addEventListener('scroll', function () {
+    const backToTop = document.querySelector('.tpr-back-to-top');
+    if (!backToTop) { return; }
     const backToTopScrollPosition = 4 * window.innerHeight;
     const y = document.getElementsByTagName("html")[0].scrollTop;
     if (y > backToTopScrollPosition) {
 
-        document.querySelector('.tpr-back-to-top').style.display= 'block';
+        backToTop.style.display = 'block';
 
     } else {
-        document.querySelector('.tpr-back-to-top').style.display = 'none';
+        backToTop.style.display = 'none';
     }
 });

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/tpr/tpr-back-to-top.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/tpr/tpr-back-to-top.js
@@ -1,0 +1,12 @@
+﻿// Back to top should only appear when the page is longer than 4vh
+document.addEventListener('scroll', function () {
+    const backToTopScrollPosition = 4 * window.innerHeight;
+    const y = document.getElementsByTagName("html")[0].scrollTop;
+    if (y > backToTopScrollPosition) {
+
+        document.querySelector('.tpr-back-to-top').style.display= 'block';
+
+    } else {
+        document.querySelector('.tpr-back-to-top').style.display = 'none';
+    }
+});


### PR DESCRIPTION
Fixes AB#143787 The focus style of the back to top link should not include padding.

Before:

![image](https://user-images.githubusercontent.com/1260550/201380188-8d7469a3-e231-4252-ba8d-3ce4a0b33573.png)

After: 

![image](https://user-images.githubusercontent.com/1260550/201380256-2045ed08-ebe1-4f74-ab6f-f4b78435a407.png)

Also fixes AB#143794 'Back to top' should appear only when the content is scrolled to 4x the viewport height.