### PR TITLE
Numeric fields with a decimal point would always be announced as 'invalid entry'

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
@@ -3,15 +3,12 @@ using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using RangeAttribute = System.ComponentModel.DataAnnotations.RangeAttribute;
@@ -39,7 +36,12 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
 
         private class ExampleClass
         {
-            public double NumberField { get; set; }
+            public int IntegerField { get; set; }
+
+            public double DoubleField { get; set; }
+
+            [RegularExpression("[0-9.,]+", ErrorMessage = errorMessageRegex)]
+            public double NumberFieldWithRegex { get; set; }
 
             public string UnvalidatedField { get; set; }
 
@@ -261,7 +263,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             var viewContext = new ViewContext() { ClientValidationEnabled = true };
             var property = typeof(ExampleClass).GetProperty(nameof(ExampleClass.CustomField));
             var options = Options.Create(new MvcDataAnnotationsLocalizationOptions());
-            
+
             var propertyResolver = new Mock<IModelPropertyResolver>();
             propertyResolver.Setup(x => x.ResolveModelType(viewContext)).Returns(typeof(ExampleClass));
             propertyResolver.Setup(x => x.ResolveModelProperty(typeof(ExampleClass), nameof(ExampleClass.CustomField))).Returns(typeof(ExampleClass).GetProperty(nameof(ExampleClass.CustomField)));
@@ -278,7 +280,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
                 new CustomTestValidatorAttributeAdapter(baseValidationAttribute, null));
 
             var htmlUpdater = new ClientSideValidationHtmlEnhancer(propertyResolver.Object, mockMetaDataProvider.Object, options,
-                validationAttributeAdapterProvider.Object) ;
+                validationAttributeAdapterProvider.Object);
 
             // Check support for multiple inputs with the same name, because the required attribute
             // has to support a group of radio buttons or checkboxes
@@ -630,18 +632,19 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='number']") == null); // different to the numeric version of this test
         }
 
-        [Test]
-        public void Numeric_fields_without_range_have_text_input_type_numeric_input_mode()
+        [TestCase(nameof(ExampleClass.IntegerField), "[0-9]*")]
+        [TestCase(nameof(ExampleClass.DoubleField), "[0-9.]*")]
+        public void Numeric_fields_without_range_have_text_input_type_numeric_input_mode(string propertyName, string expectedRegex)
         {
             var viewContext = new ViewContext() { ClientValidationEnabled = true };
             var options = Options.Create(new MvcDataAnnotationsLocalizationOptions());
             var propertyResolver = new Mock<IModelPropertyResolver>();
-            var property = typeof(ExampleClass).GetProperty(nameof(ExampleClass.NumberField));
+            var property = typeof(ExampleClass).GetProperty(propertyName);
             propertyResolver.Setup(x => x.ResolveModelType(viewContext)).Returns(typeof(ExampleClass));
-            propertyResolver.Setup(x => x.ResolveModelProperty(typeof(ExampleClass), nameof(ExampleClass.NumberField))).Returns(property);
+            propertyResolver.Setup(x => x.ResolveModelProperty(typeof(ExampleClass), propertyName)).Returns(property);
             var htmlUpdater = new ClientSideValidationHtmlEnhancer(propertyResolver.Object, Mock.Of<IModelMetadataProvider>(), options, Mock.Of<IValidationAttributeAdapterProvider>());
 
-            var result = htmlUpdater.EnhanceHtml($"<input name=\"{nameof(ExampleClass.NumberField)}\">",
+            var result = htmlUpdater.EnhanceHtml($"<input name=\"{propertyName}\">",
                 viewContext,
                 errorMessageRequired,
                 errorMessageRegex,
@@ -658,7 +661,37 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
 
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='text']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@inputmode='numeric']") != null);
-            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@pattern='[0-9]*']") != null);
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@pattern='{expectedRegex}']") != null);
+        }
+
+
+        [Test]
+        public void Regex_validator_has_higher_priority_than_regex_for_numeric_fields()
+        {
+            var viewContext = new ViewContext() { ClientValidationEnabled = true };
+            var options = Options.Create(new MvcDataAnnotationsLocalizationOptions());
+            var propertyResolver = new Mock<IModelPropertyResolver>();
+            var property = typeof(ExampleClass).GetProperty(nameof(ExampleClass.NumberFieldWithRegex));
+            propertyResolver.Setup(x => x.ResolveModelType(viewContext)).Returns(typeof(ExampleClass));
+            propertyResolver.Setup(x => x.ResolveModelProperty(typeof(ExampleClass), nameof(ExampleClass.NumberFieldWithRegex))).Returns(property);
+            var htmlUpdater = new ClientSideValidationHtmlEnhancer(propertyResolver.Object, Mock.Of<IModelMetadataProvider>(), options, Mock.Of<IValidationAttributeAdapterProvider>());
+
+            var result = htmlUpdater.EnhanceHtml($"<input name=\"{nameof(ExampleClass.NumberFieldWithRegex)}\">",
+                viewContext,
+                errorMessageRequired,
+                errorMessageRegex,
+                errorMessageEmail,
+                errorMessagePhone,
+                errorMessageLength,
+                errorMessageMinLength,
+                errorMessageMaxLength,
+                errorMessageRange,
+                errorMessageCompare);
+
+            var document = new HtmlDocument();
+            document.LoadHtml(result);
+
+            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@pattern='[0-9.,]+']") != null);
         }
 
         [Test]
@@ -749,10 +782,10 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             });
 
             var htmlUpdater = new ClientSideValidationHtmlEnhancer(
-                propertyResolver.Object, 
-                Mock.Of<IModelMetadataProvider>(), 
-                options, 
-                Mock.Of<IValidationAttributeAdapterProvider>(), 
+                propertyResolver.Object,
+                Mock.Of<IModelMetadataProvider>(),
+                options,
+                Mock.Of<IValidationAttributeAdapterProvider>(),
                 localiserFactory.Object);
 
             var result = htmlUpdater.EnhanceHtml($"<input name=\"{nameof(ExampleClass.RequiredField)}\">",
@@ -844,12 +877,12 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             propertyResolver.Setup(x => x.ResolveModelType(viewContext)).Returns(typeof(ExampleClass));
             propertyResolver.Setup(x => x.ResolveModelProperty(typeof(ExampleClass), nameof(ExampleClass.CustomField))).Returns(typeof(ExampleClass).GetProperty(nameof(ExampleClass.CustomField)));
 
-            
+
             var localiser = new Mock<IStringLocalizer>(MockBehavior.Loose);
 
             localiser.Setup(x => x[errorMessageRequiredCustom, It.IsAny<object[]>()]).Returns(new LocalizedString(errorMessageRequiredCustom, "Error from localiser"));
             var localiserFactory = new Mock<IStringLocalizerFactory>();
-            localiserFactory.Setup(x => x.Create(property.DeclaringType)).Returns(localiser.Object);           
+            localiserFactory.Setup(x => x.Create(property.DeclaringType)).Returns(localiser.Object);
 
             var metadataProvider = new EmptyModelMetadataProvider();
             var metadata = metadataProvider.GetMetadataForProperty(containerType: typeof(ExampleClass), propertyName: nameof(ExampleClass.CustomField));
@@ -871,10 +904,10 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
                 new CustomTestValidatorAttributeAdapter(baseValidationAttribute, localiser.Object));
 
             var htmlUpdater = new ClientSideValidationHtmlEnhancer(
-                propertyResolver.Object, 
-                mockMetaDataProvider.Object, 
-                options, 
-                validationAttributeAdapterProvider.Object, 
+                propertyResolver.Object,
+                mockMetaDataProvider.Object,
+                options,
+                validationAttributeAdapterProvider.Object,
                 localiserFactory.Object);
 
             // Check support for multiple inputs with the same name, because the required attribute

--- a/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.Tests/ClientSideValidationHtmlEnhancerTests.cs
@@ -43,9 +43,6 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             [RegularExpression("[0-9.,]+", ErrorMessage = errorMessageRegex)]
             public double NumberFieldWithRegex { get; set; }
 
-            [RegularExpression("[0-9.,]+", ErrorMessage = errorMessageRegex)]
-            public double NumberFieldWithRegex { get; set; }
-
             public string UnvalidatedField { get; set; }
 
             [Required(ErrorMessage = errorMessageRequired)]
@@ -665,36 +662,6 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@type='text']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@inputmode='numeric']") != null);
             Assert.True(document.DocumentNode.SelectSingleNode($"//input[@pattern='{expectedRegex}']") != null);
-        }
-
-
-        [Test]
-        public void Regex_validator_has_higher_priority_than_regex_for_numeric_fields()
-        {
-            var viewContext = new ViewContext() { ClientValidationEnabled = true };
-            var options = Options.Create(new MvcDataAnnotationsLocalizationOptions());
-            var propertyResolver = new Mock<IModelPropertyResolver>();
-            var property = typeof(ExampleClass).GetProperty(nameof(ExampleClass.NumberFieldWithRegex));
-            propertyResolver.Setup(x => x.ResolveModelType(viewContext)).Returns(typeof(ExampleClass));
-            propertyResolver.Setup(x => x.ResolveModelProperty(typeof(ExampleClass), nameof(ExampleClass.NumberFieldWithRegex))).Returns(property);
-            var htmlUpdater = new ClientSideValidationHtmlEnhancer(propertyResolver.Object, Mock.Of<IModelMetadataProvider>(), options, Mock.Of<IValidationAttributeAdapterProvider>());
-
-            var result = htmlUpdater.EnhanceHtml($"<input name=\"{nameof(ExampleClass.NumberFieldWithRegex)}\">",
-                viewContext,
-                errorMessageRequired,
-                errorMessageRegex,
-                errorMessageEmail,
-                errorMessagePhone,
-                errorMessageLength,
-                errorMessageMinLength,
-                errorMessageMaxLength,
-                errorMessageRange,
-                errorMessageCompare);
-
-            var document = new HtmlDocument();
-            document.LoadHtml(result);
-
-            Assert.True(document.DocumentNode.SelectSingleNode($"//input[@pattern='[0-9.,]+']") != null);
         }
 
 

--- a/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -23,14 +22,14 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
         private readonly IValidationAttributeAdapterProvider _validationAttributeAdapterProvider;
 
         public ClientSideValidationHtmlEnhancer(
-            IModelPropertyResolver modelPropertyResolver, 
+            IModelPropertyResolver modelPropertyResolver,
             IModelMetadataProvider metadataProvider,
             IOptions<MvcDataAnnotationsLocalizationOptions> options,
             IValidationAttributeAdapterProvider validationAttributeAdapterProvider,
         IStringLocalizerFactory? factory = null)
         {
             _modelPropertyResolver = modelPropertyResolver ?? throw new ArgumentNullException(nameof(modelPropertyResolver));
-            
+
             _factory = factory;
             _metadataProvider = metadataProvider;
             _validationAttributeAdapterProvider = validationAttributeAdapterProvider;
@@ -72,7 +71,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
                 }
 
                 // Add the data-val-* attributes for ASP.NET / jQuery validation to pick up
-                AddClientSideValidationAttributes(viewContext, _modelPropertyResolver, _metadataProvider, _factory, 
+                AddClientSideValidationAttributes(viewContext, _modelPropertyResolver, _metadataProvider, _factory,
                     _validationAttributeAdapterProvider,
                     _options, inputs, errorMessage?.Attributes,
                     errorMessageRequired,
@@ -176,6 +175,13 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
 
                     var validateElement = false;
 
+                    if (IsNumericType(modelProperty.PropertyType))
+                    {
+                        AddOrUpdateHtmlAttribute(targetElement, "type", "text");
+                        AddOrUpdateHtmlAttribute(targetElement, "inputmode", "numeric");
+                        AddOrUpdateHtmlAttribute(targetElement, "pattern", "[0-9]*");
+                    }
+
                     // Compare
                     var compareAttr = modelProperty.GetCustomAttributes<CompareAttribute>().FirstOrDefault();
                     if (compareAttr != null)
@@ -240,7 +246,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
                     {
                         targetElement.Attributes.Add("data-val-regex", SelectBestErrorMessage(errorMessageRegex, regexAttr.ErrorMessage, localizer));
                         targetElement.Attributes.Add("data-val-regex-pattern", regexAttr.Pattern);
-                        targetElement.Attributes.Add("pattern", regexAttr.Pattern);
+                        AddOrUpdateHtmlAttribute(targetElement, "pattern", regexAttr.Pattern);
                         validateElement = true;
                     }
 
@@ -264,60 +270,51 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
                         validateElement = true;
                     }
 
-                    if (IsNumericType(modelProperty.PropertyType))
+                    // Get anything else that inherits from ValidationAttribute
+                    var baseValidationAttributes = modelProperty.GetCustomAttributes<ValidationAttribute>();
+                    if (baseValidationAttributes != null && baseValidationAttributes.Count() > 0)
                     {
-                        AddOrUpdateHtmlAttribute(targetElement, "type", "text");
-                        AddOrUpdateHtmlAttribute(targetElement, "inputmode", "numeric");
-                        AddOrUpdateHtmlAttribute(targetElement, "pattern", "[0-9]*");
-                    }
-
-                    //if (!validateElement)
-                    {
-                        // Get anything else that inherits from ValidationAttribute
-                        var baseValidationAttributes = modelProperty.GetCustomAttributes<ValidationAttribute>();
-                        if (baseValidationAttributes != null && baseValidationAttributes.Count() > 0)
+                        foreach (var baseValidationAttribute in baseValidationAttributes)
                         {
-                            foreach (var baseValidationAttribute in baseValidationAttributes)
+                            var adapter = validationAttributeAdapterProvider.GetAttributeAdapter(baseValidationAttribute, localizer);
+
+                            if (adapter != null)
                             {
-                                var adapter = validationAttributeAdapterProvider.GetAttributeAdapter(baseValidationAttribute, localizer);
+                                var attrDictionary = new Dictionary<string, string>();
 
-                                if (adapter != null)
+                                // Get existing attributes - have to iterate to avoid duplication
+                                foreach (var attribute in targetElement.Attributes)
                                 {
-                                    var attrDictionary = new Dictionary<string, string>();
-                                    
-                                    // Get existing attributes - have to iterate to avoid duplication
-                                    foreach(var attribute in targetElement.Attributes)
+                                    if (!attrDictionary.ContainsKey(attribute.Name))
                                     {
-                                        if (!attrDictionary.ContainsKey(attribute.Name))
-                                        {
-                                            attrDictionary.Add(attribute.Name, attribute.Value);
-                                        }
+                                        attrDictionary.Add(attribute.Name, attribute.Value);
                                     }
-
-                                    // Get metadata
-                                    var metadata = metadataProvider.GetMetadataForType(modelType);
-
-                                    // Now call the Adapter's AddValidation method. This merges existing attributes with anything already present
-                                    adapter!.AddValidation(
-                                        new ClientModelValidationContext(viewContext, metadata, metadataProvider, attrDictionary)
-                                        );
-
-                                    // Remove existing html attributes
-                                    targetElement.Attributes.RemoveAll();
-
-                                    // And add them back in again - this time with everything populated by the AddValidation method.
-                                    foreach (var attr in attrDictionary)
-                                    {
-                                        targetElement.Attributes.Add(attr.Key, attr.Value);
-                                    }
-
-                                    validateElement = true;
                                 }
+
+                                // Get metadata
+                                var metadata = metadataProvider.GetMetadataForType(modelType);
+
+                                // Now call the Adapter's AddValidation method. This merges existing attributes with anything already present
+                                adapter!.AddValidation(
+                                    new ClientModelValidationContext(viewContext, metadata, metadataProvider, attrDictionary)
+                                    );
+
+                                // Remove existing html attributes
+                                targetElement.Attributes.RemoveAll();
+
+                                // And add them back in again - this time with everything populated by the AddValidation method.
+                                foreach (var attr in attrDictionary)
+                                {
+                                    targetElement.Attributes.Add(attr.Key, attr.Value);
+                                }
+
+                                validateElement = true;
                             }
                         }
                     }
 
-                    if (validateElement) {
+                    if (validateElement)
+                    {
                         if (!targetElement.Attributes.Contains("data-val"))
                         {
                             targetElement.Attributes.Add("data-val", "true");

--- a/GovUk.Frontend.ExampleApp/Models/TextInputViewModel.cs
+++ b/GovUk.Frontend.ExampleApp/Models/TextInputViewModel.cs
@@ -21,6 +21,7 @@ namespace GovUk.Frontend.ExampleApp.Models
         public string Field4 { get; set; }
 
         [Range(5, 50, ErrorMessage = "Must be a number between 5 and 50")]
+        [RegularExpression(@"[0-9.]+", ErrorMessage = "Field must be only numbers (Model Resource)")]
         public int Field5 { get; set; }
     }
 }

--- a/GovUk.Frontend.ExampleApp/Models/TextInputViewModel.cs
+++ b/GovUk.Frontend.ExampleApp/Models/TextInputViewModel.cs
@@ -21,7 +21,6 @@ namespace GovUk.Frontend.ExampleApp.Models
         public string Field4 { get; set; }
 
         [Range(5, 50, ErrorMessage = "Must be a number between 5 and 50")]
-        [RegularExpression(@"[0-9.]+", ErrorMessage = "Field must be only numbers (Model Resource)")]
         public int Field5 { get; set; }
     }
 }


### PR DESCRIPTION
Numeric fields with a decimal point would always be announced as 'invalid entry'.

This would usually be the correct behaviour for an integer field, but change the behaviour so a floating point numeric type (float, double, decimal) also allows a `.` character.

Allow a `[RegularExpression]` validator to further override the default numeric regex when required. AB#143785