### PR TITLE
Fix missing 'Formats' menu in the Umbraco rich text editor

### DIFF
--- a/GovUk.Frontend.Umbraco/Directory.Build.targets
+++ b/GovUk.Frontend.Umbraco/Directory.Build.targets
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- This file is run automatically when the project is built. https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019 
+	     Run a custom command using Dart SASS installed by the AspNetCore.SassCompiler NuGet package. The default package configuration cannot be used
+		 because in Release configuration it removes the comments that are needed to configure the Umbraco rich text editor.
+		 -->
+	<Target Name="BuildSass" BeforeTargets="BeforeBuild">
+		<Message Text="Run SassCompiler $(MSBuildProjectFullPath)" Importance="high"/>
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='AspNetCore.SassCompiler']/@Version">
+			<Output TaskParameter="Result" ItemName="SassCompilerVersion" />
+		</XmlPeek>
+		<PropertyGroup>
+			<SassCompilerVersion>@(SassCompilerVersion)</SassCompilerVersion>
+			<SassPath>$(UserProfile)\.nuget\packages\aspnetcore.sasscompiler\$(SassCompilerVersion)\runtimes\win-x64\src\</SassPath>
+			<SourceFolder>$(MsBuildThisFileDirectory)Styles\</SourceFolder>
+			<TargetFolder>$(MsBuildThisFileDirectory)wwwroot\</TargetFolder>
+		</PropertyGroup>
+		<Exec Command="powershell -NonInteractive -NoProfile Get-Content &quot;$(SourceFolder)govuk-umbraco-rich-text-editor.scss&quot; | &quot;$(SassPath)dart.exe&quot; &quot;$(SassPath)sass.snapshot&quot; --stdin --load-path=$(SourceFolder) $(TargetFolder)css\govuk-umbraco-rich-text-editor.css"/>
+		<Message Text="SassCompiler complete for $(MSBuildProjectFullPath)" Importance="high"/>
+	</Target>
+
+</Project>

--- a/GovUk.Frontend.Umbraco/sasscompiler.json
+++ b/GovUk.Frontend.Umbraco/sasscompiler.json
@@ -1,0 +1,6 @@
+/* Point to any folder that doesn't contain SASS files. 
+   This is just to render the default MSBuild action for AspNetCore.SassCompiler inert. 
+   A custom action is run using Directory.Build.targets. */
+{
+  "SourceFolder": "Views"
+}


### PR DESCRIPTION
When building in Release configuration, the default SASS compiler removes comments. We need the comments to configure the Umbraco rich text editor, so disable the default compiler and use a custom command. AB#146111