### PR TITLE
Our sticky footer CSS was causing rich text boxes in Umbraco to grow and grow

### DIFF
--- a/GovUk.Frontend.Umbraco/Styles/govuk-umbraco-rich-text-editor.scss
+++ b/GovUk.Frontend.Umbraco/Styles/govuk-umbraco-rich-text-editor.scss
@@ -1,6 +1,11 @@
 ﻿/* Import the TPR stylesheet (which includes govuk-frontend) so that the rich text editor can look like the GOV.UK Design System with TPR branding.*/
 @use '../../GovUk.Frontend.AspNetCore.Extensions/wwwroot/tpr/tpr.css';
 
+/* The TPR sticky footer applies a 100% height to these, but we do not want that to apply in the rich text editor 
+   as it causes it to grow beyond its configured size.
+*/
+html, body { height: auto; }
+
 /* The following styles appear in the style select dropdown when enabled, using the names defined in the `umb_name` comments.
    position: static is specified only so that the selector is included in the compiled stylesheet along with the comment.
 */


### PR DESCRIPTION
Fixes AB#146271