### PR TITLE
AB#146271 updated logo alt text

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
@@ -10,7 +10,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
     public partial class ComponentGenerator
     {
         internal const string TprFooterBarElement = "footer";
-        public const string FooterLogoDefaultAlt = "Go to The Pensions Regulator website";
+        public const string FooterLogoDefaultAlt = "The Pensions Regulator home page";
         internal const string FooterLogoDefaultHref = "https://www.thepensionsregulator.gov.uk";
         internal static string CopyrightDefaultContent = $"{DateTimeOffset.UtcNow.Year} The Pensions Regulator";
 
@@ -72,7 +72,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
                     var copyrightElement = new TagBuilder("p");
                     copyrightElement.MergeCssClass("govuk-body");
                     copyrightElement.MergeCssClass("tpr-footer__copyright");
-                    copyrightElement.InnerHtml.Append("© " + copyright);
+                    copyrightElement.InnerHtml.Append("ï¿½ " + copyright);
                     contentContainer.InnerHtml.AppendHtml(copyrightElement);
                 }
                 tagBuilder.InnerHtml.AppendHtml(contentContainer);

--- a/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
@@ -72,7 +72,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
                     var copyrightElement = new TagBuilder("p");
                     copyrightElement.MergeCssClass("govuk-body");
                     copyrightElement.MergeCssClass("tpr-footer__copyright");
-                    copyrightElement.InnerHtml.Append("� " + copyright);
+                    copyrightElement.InnerHtml.AppendHtml("&copy; " + copyright);
                     contentContainer.InnerHtml.AppendHtml(copyrightElement);
                 }
                 tagBuilder.InnerHtml.AppendHtml(contentContainer);

--- a/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
@@ -10,7 +10,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
     {
         internal const string TprHeaderBarElement = "div";
         internal const string DefaultHeaderLabel = "Making workplace pensions work";
-        public const string HeaderLogoDefaultAlt = "Go to The Pensions Regulator website";
+        public const string HeaderLogoDefaultAlt = "The Pensions Regulator home page";
         internal const string HeaderLogoDefaultHref = "https://www.thepensionsregulator.gov.uk";
 
         public virtual TagBuilder GenerateTprHeaderBar(


### PR DESCRIPTION
During the Civic assessment of the AE sites, they noted that the logo alt text needs to be "The Pensions Regulator home page". This also brings it in line with the corp site (which was similarly audited).