### PR TITLE
GOV.UK table styles omit padding-right on the last cell 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-table.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-table.scss
@@ -5,12 +5,12 @@
 .govuk-table__caption {
     @include govuk-responsive-margin(1,"bottom");
 }
-.govuk-table__header {
+.govuk-table__header, .govuk-table__header:last-child {
     @include govuk-responsive-padding(4);
     background-color: $tpr-colour-whisper;
     border: solid govuk-px-to-rem(2) $tpr-colour-very-light-grey;
 }
-.govuk-table__cell {
+.govuk-table__cell, .govuk-table__cell:last-child {
     @include govuk-responsive-padding(4);
     border: solid govuk-px-to-rem(2) $tpr-colour-very-light-grey;
 }


### PR DESCRIPTION
GOV.UK table styles omit padding-right on the last cell because they have no vertical border. Restore that padding for TPR styles. AB#146662