### PR TITLE
Feature/147581 ne features

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
@@ -41,7 +41,14 @@ $tpr-button-padding: 20px;
     border-color: $tpr-colour-royal-blue;
     box-shadow: none;
 }
-.govuk-button--secondary:hover, .govuk-button--secondary:active {
+
+/* Only for links styled as secondary buttons, we need the extra weight of the a. selector to override GOV.UK color */
+a.govuk-button--secondary:link, a.govuk-button--secondary:visited {
+    color: $tpr-colour-royal-blue;
+}
+
+.govuk-button--secondary:hover, .govuk-button--secondary:active,
+a.govuk-button--secondary:hover {
     color: $tpr-colour-white;
     background-color: $tpr-colour-royal-blue;
 }

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
@@ -85,7 +85,7 @@
         width: govuk-grid-width($width);
     }
 
-    .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > .govuk-form-group > fieldset > .govuk-fieldset__child--#{$width} {
+    .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > .govuk-form-group > fieldset > .govuk-form-group > .govuk-fieldset__child--#{$width} {
         width: govuk-grid-width($width);
     }
 
@@ -97,7 +97,7 @@
             width: govuk-grid-width($width);
         }
 
-        .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > .govuk-form-group > fieldset > .govuk-fieldset__child--#{$width}-from-desktop {
+        .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > .govuk-form-group > fieldset > .govuk-form-group > .govuk-fieldset__child--#{$width}-from-desktop {
             width: govuk-grid-width($width);
         }
     }

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
@@ -1,6 +1,18 @@
 ﻿@import '_variables.scss';
 @import 'govuk/base';
 
+/*
+    govuk-frontend includes width overrides like .govuk-!-width-two-thirds which apply from tablet upwards.
+    Add similar override classes that apply from desktop.
+*/
+@each $width in map-keys($govuk-grid-widths) {
+    .govuk-\!-width-#{$width}-from-desktop {
+        @include govuk-media-query($from: desktop) {
+            width: govuk-grid-width($width) !important;
+        }
+    }
+}
+
 /* 
     Modifier for .govuk-grid-row which adds a decorative divider after the row with padding above and margin below. 
     Use ::after so we can align the divider with content but don't need to mess with the margin & padding of 
@@ -57,52 +69,43 @@
 }
 
 
-/* There is a special case where the legend is the page heading (see https://design-system.service.gov.uk/components/fieldset/).
+/* There is a special case where the label or legend is the page heading (see https://design-system.service.gov.uk/components/fieldset/).
    In this case .govuk-grid-row--tpr-divider will not work because the HTML structure is different. 
-   .govuk-grid-row--tpr-divider-for-fieldset must be applied to the .govuk-grid-row instead.
+   .govuk-grid-row--tpr-divider-for-label-as-heading or .govuk-grid-row--tpr-divider-for-fieldset must be applied to the .govuk-grid-row instead.
 
    1. First this overrides the column width chosen for the .govuk-grid-row. It must be 100% for the divider to span the page.
 
-   2. The column width is applied instead to elements within the fieldset, including the h1 inside the legend. 
+   2. The column width is applied instead to elements that make up the field, or within the fieldset. 
 
-      Very specific selectors are used so that nested fieldsets are not matched. The first two selectors target the fieldset
-      component of the GOV.UK Design System. The second two target radio and checkbox groups. The .govuk-fieldset__child target 
-      child components of radio and checkbox groups, eg the hint and error message for the group. All are repeated in *-from-desktop versions.
+      Very specific selectors are used so that nested fieldsets are not matched. Selectors target text input, textarea, date input, fieldset,
+      and radio and checkbox group components of the GOV.UK Design System. All are repeated in *-from-desktop versions.
 
-      Components placed inside the fieldset should typically have .govuk-grid-column-full applied, since the desired width comes from their container element.
+      Components placed inside a fieldset should typically have .govuk-grid-column-full applied, since the desired width comes from their container element.
 
-   3. Finally, the divider is applied to the legend element, which is set to 100% wide so that the divider spans the page.
+   3. Finally, the divider is applied to the h1 (for labels) or legend (for fieldsets) element, which is set to 100% wide so that the divider spans the page.
 */
+.govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column,
 .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column {
     width: 100%;
 }
 
 @each $width in map-keys($govuk-grid-widths) {
+    .govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column-#{$width} > .govuk-form-group > *,
     .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width} > fieldset > *,
-    .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width} > fieldset > legend > h1,
-    .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width} > .govuk-form-group > fieldset > *,
-    .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width} > .govuk-form-group > fieldset > legend > h1 {
-        width: govuk-grid-width($width);
-    }
-
-    .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > .govuk-form-group > fieldset > .govuk-form-group > .govuk-fieldset__child--#{$width} {
+    .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width} > .govuk-form-group > fieldset > * {
         width: govuk-grid-width($width);
     }
 
     @include govuk-media-query($from: desktop) {
+        .govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column-#{$width}-from-desktop > .govuk-form-group > *,
         .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width}-from-desktop > fieldset > *,
-        .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width}-from-desktop > fieldset > legend > h1,
-        .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width}-from-desktop > .govuk-form-group > fieldset > *,
-        .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width}-from-desktop > .govuk-form-group > fieldset > legend > h1 {
-            width: govuk-grid-width($width);
-        }
-
-        .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > .govuk-form-group > fieldset > .govuk-form-group > .govuk-fieldset__child--#{$width}-from-desktop {
+        .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width}-from-desktop > .govuk-form-group > fieldset > * {
             width: govuk-grid-width($width);
         }
     }
 }
 
+.govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column > .govuk-form-group > h1,
 .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > fieldset > legend,
 .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column > .govuk-form-group > fieldset > legend {
     width: 100%;

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
@@ -38,12 +38,12 @@
     </header>
     <div class="tpr-main-wrapper">
         <div class="govuk-width-container">
+            @RenderSection("language", required: false)
+            @if (Context.Request.Path != home?.Url())
+            {
+                <govuk-back-link href="@home?.Url()">@Umbraco.GetDictionaryValue("Back link")</govuk-back-link>
+            }
             <main id="main" class="govuk-main-wrapper">
-                @RenderSection("language", required: false)
-                @if (Context.Request.Path != home?.Url())
-                {
-                    <govuk-back-link href="@home?.Url()">@Umbraco.GetDictionaryValue("Back link")</govuk-back-link>
-                }
                 @RenderBody()
             </main>
         </div>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
@@ -36,6 +36,10 @@
       {
         "contentUdi": "umb://element/66a0f09f95ae426da4af813094e9efa2",
         "settingsUdi": "umb://element/2eb09fa3c1a24b55b7c5893e87f0fb0a"
+      },
+      {
+        "contentUdi": "umb://element/e5285d70ccac4d17a92d64b259fa8d44",
+        "settingsUdi": "umb://element/c6180c655e8d42a381d8ed83c6524251"
       }
     ]
   },
@@ -63,7 +67,12 @@
     {
       "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
       "udi": "umb://element/fb7b700c676d4312a439f03c60cb4340",
-      "buttons": "{\r\n  \"layout\": {\r\n    \"Umbraco.BlockList\": [\r\n      {\r\n        \"contentUdi\": \"umb://element/32dc2a6945734e2e88fec827a9aea809\",\r\n        \"settingsUdi\": \"umb://element/d3975356c50d4548a03776ba84409da1\"\r\n      }\r\n    ]\r\n  },\r\n  \"contentData\": [\r\n    {\r\n      \"contentTypeKey\": \"94737fb0-c49c-44db-8a59-6a65f14a0c47\",\r\n      \"udi\": \"umb://element/32dc2a6945734e2e88fec827a9aea809\",\r\n      \"link\": \"[{\\\"name\\\":\\\"Home\\\",\\\"udi\\\":\\\"umb://document/5e682cbeb867491a955f3382446d5663\\\"}]\",\r\n      \"text\": \"Link to next page\"\r\n    }\r\n  ],\r\n  \"settingsData\": [\r\n    {\r\n      \"contentTypeKey\": \"2a5587ef-96fa-41dd-a2be-c5f97e00dfef\",\r\n      \"udi\": \"umb://element/d3975356c50d4548a03776ba84409da1\",\r\n      \"isStartButton\": 0,\r\n      \"cssClasses\": null\r\n    }\r\n  ]\r\n}"
+      "buttons": "{\r\n  \"layout\": {\r\n    \"Umbraco.BlockList\": [\r\n      {\r\n        \"contentUdi\": \"umb://element/9b3a8f4f5e2f42eebdf965441abee485\",\r\n        \"settingsUdi\": \"umb://element/964e029f6cdf410dad070800ad8c03aa\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/aa9b68d9091d41c1a43c37da302b3e8d\",\r\n        \"settingsUdi\": \"umb://element/64522f384142412b800efd06694cac4d\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/020d42dd6e3a40eda3e17414eb17e6cf\",\r\n        \"settingsUdi\": \"umb://element/803bc3471a454eaa8bde16fe712fbf2e\"\r\n      }\r\n    ]\r\n  },\r\n  \"contentData\": [\r\n    {\r\n      \"contentTypeKey\": \"94737fb0-c49c-44db-8a59-6a65f14a0c47\",\r\n      \"udi\": \"umb://element/9b3a8f4f5e2f42eebdf965441abee485\",\r\n      \"link\": \"[{\\\"name\\\":\\\"Home\\\",\\\"udi\\\":\\\"umb://document/5e682cbeb867491a955f3382446d5663\\\"}]\",\r\n      \"text\": \"Link to next page\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"94737fb0-c49c-44db-8a59-6a65f14a0c47\",\r\n      \"udi\": \"umb://element/aa9b68d9091d41c1a43c37da302b3e8d\",\r\n      \"link\": \"[{\\\"name\\\":\\\"Home\\\",\\\"udi\\\":\\\"umb://document/5e682cbeb867491a955f3382446d5663\\\"}]\",\r\n      \"text\": \"Link to next page\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"94737fb0-c49c-44db-8a59-6a65f14a0c47\",\r\n      \"udi\": \"umb://element/020d42dd6e3a40eda3e17414eb17e6cf\",\r\n      \"link\": \"[{\\\"name\\\":\\\"Home\\\",\\\"udi\\\":\\\"umb://document/5e682cbeb867491a955f3382446d5663\\\"}]\",\r\n      \"text\": \"Link to next page\"\r\n    }\r\n  ],\r\n  \"settingsData\": [\r\n    {\r\n      \"contentTypeKey\": \"2a5587ef-96fa-41dd-a2be-c5f97e00dfef\",\r\n      \"udi\": \"umb://element/964e029f6cdf410dad070800ad8c03aa\",\r\n      \"isStartButton\": 0,\r\n      \"typeOfButton\": \"Default\",\r\n      \"columnSize\": null,\r\n      \"columnSizeFromDesktop\": null\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"2a5587ef-96fa-41dd-a2be-c5f97e00dfef\",\r\n      \"udi\": \"umb://element/64522f384142412b800efd06694cac4d\",\r\n      \"isStartButton\": 0,\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"columnSize\": null,\r\n      \"columnSizeFromDesktop\": null\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"2a5587ef-96fa-41dd-a2be-c5f97e00dfef\",\r\n      \"udi\": \"umb://element/803bc3471a454eaa8bde16fe712fbf2e\",\r\n      \"isStartButton\": 0,\r\n      \"typeOfButton\": \"Warning\",\r\n      \"columnSize\": null,\r\n      \"columnSizeFromDesktop\": null\r\n    }\r\n  ]\r\n}"
+    },
+    {
+      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "udi": "umb://element/e5285d70ccac4d17a92d64b259fa8d44",
+      "buttons": ""
     }
   ],
   "settingsData": [
@@ -95,6 +104,10 @@
     {
       "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
       "udi": "umb://element/81252747b25e462d917999d199a1f61f"
+    },
+    {
+      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
+      "udi": "umb://element/c6180c655e8d42a381d8ed83c6524251"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/checkboxes.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/checkboxes.config
@@ -101,11 +101,11 @@
       "cssClasses": null,
       "errorMessageRequired": "Please select at least one checkbox",
       "cssClassesForRow": "govuk-grid-row--tpr-divider-for-fieldset",
-      "columnSize": "[\"full\"]",
+      "columnSize": "[\"two-thirds\"]",
       "columnSizeFromDesktop": null,
-      "cssClassesForError": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForCheckboxes": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForHint": "govuk-fieldset__child--two-thirds-from-desktop"
+      "cssClassesForError": null,
+      "cssClassesForCheckboxes": null,
+      "cssClassesForHint": null
     },
     {
       "contentTypeKey": "67371513-c485-4405-afb4-70367ddb6eb8",
@@ -143,9 +143,9 @@
       "cssClassesForRow": null,
       "columnSize": "[\"full\"]",
       "columnSizeFromDesktop": null,
-      "cssClassesForError": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForCheckboxes": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForHint": "govuk-fieldset__child--two-thirds-from-desktop"
+      "cssClassesForError": null,
+      "cssClassesForCheckboxes": null,
+      "cssClassesForHint": null
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/date-input.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/date-input.config
@@ -75,9 +75,10 @@
       "legendIsPageHeading": 1,
       "modelProperty": "Field1",
       "errorMessageRequired": "This date is required",
-      "columnSize": null,
+      "columnSize": "[\"full\"]",
       "columnSizeFromDesktop": null,
-      "cssClassesForRow": "govuk-grid-row--tpr-divider-for-fieldset"
+      "cssClassesForRow": "govuk-grid-row--tpr-divider-for-fieldset",
+      "cssClasses": null
     },
     {
       "contentTypeKey": "308973a3-4525-445f-9bcd-bdf3d649abb6",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/radios.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/radios.config
@@ -82,9 +82,9 @@
       "columnSize": "[\"two-thirds\"]",
       "columnSizeFromDesktop": null,
       "cssClassesForRow": "govuk-grid-row--tpr-divider-for-fieldset",
-      "cssClassesForHint": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForError": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForRadios": "govuk-fieldset__child--two-thirds-from-desktop"
+      "cssClassesForHint": null,
+      "cssClassesForError": null,
+      "cssClassesForRadios": null
     },
     {
       "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
@@ -109,9 +109,9 @@
       "columnSize": "[\"full\"]",
       "columnSizeFromDesktop": null,
       "cssClassesForRow": "govuk-grid-row--tpr-divider",
-      "cssClassesForHint": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForError": "govuk-fieldset__child--two-thirds-from-desktop",
-      "cssClassesForRadios": "govuk-fieldset__child--two-thirds-from-desktop"
+      "cssClassesForHint": null,
+      "cssClassesForError": null,
+      "cssClassesForRadios": null
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/textarea.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/textarea.config
@@ -86,7 +86,9 @@
       "errorMessageMinLength": "Must be 10 or more characters",
       "rows": 10,
       "labelIsPageHeading": 0,
-      "showCharacterCount": 0
+      "showCharacterCount": 0,
+      "columnSize": null,
+      "columnSizeFromDesktop": null
     },
     {
       "contentTypeKey": "5f3e3369-43cf-47c2-bb76-60055518ae05",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuklinkasbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuklinkasbuttonsettings.config
@@ -41,6 +41,22 @@
       <ValidationRegExpMessage></ValidationRegExpMessage>
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
+    <GenericProperty>
+      <Key>e2ab3a79-1483-4cce-8a7d-ad5dca3f2050</Key>
+      <Name>Type of button</Name>
+      <Alias>typeOfButton</Alias>
+      <Definition>041129bd-598f-4911-9ad8-871020ef95a1</Definition>
+      <Type>Umbraco.RadioButtonList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
   </GenericProperties>
   <Tabs>
     <Tab>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuktextarea.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuktextarea.config
@@ -31,7 +31,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>true</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Use {{name}} to include the page name.]]></Description>
       <SortOrder>1</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuktextinput.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuktextinput.config
@@ -31,7 +31,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>true</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Use {{name}} to include the page name.]]></Description>
       <SortOrder>1</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkLinkAsButton.cshtml
@@ -9,6 +9,11 @@
     var text = Model.Content.Value<string>("text");
     var link = Model.Content.Value<Link>("link");
     var isStartButton = Model.Settings.Value<bool>("isStartButton");
-    var cssClass = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var typeOfButton = Model.Settings.Value<string>("typeOfButton");
+    if (typeOfButton == "Secondary" || typeOfButton == "Warning")
+    {
+        cssClasses = (cssClasses + " govuk-button--" + typeOfButton.ToLowerInvariant()).TrimStart();
+    }
 }
-<govuk-button-link is-start-button="@isStartButton" href="@link.Url" id="@Model.Content.Key" class="@cssClass">@text</govuk-button-link>
+<govuk-button-link is-start-button="@isStartButton" href="@link.Url" id="@Model.Content.Key" class="@cssClasses">@text</govuk-button-link>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextInput.cshtml
@@ -16,6 +16,7 @@
     }
     var prefix = Model.Settings.Value<string>("prefix");
     var suffix = Model.Settings.Value<string>("suffix");
+    var label = Model.Content.Value<string>("label")?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
     var labelIsPageHeading = Model.Settings.Value<bool>("labelIsPageHeading");
     var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
     var hint = GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
@@ -33,9 +34,7 @@
     error-message-compare="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageCompare))"
 >
     <govuk-input name="@modelPropertyName" value="@modelStateEntry?.AttemptedValue" input-class="@cssClasses" input-aria-invalid="@invalid">
-        <govuk-input-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@(
-        Model.Content.Value<string>("label")
-        )</govuk-input-label>
+        <govuk-input-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@label</govuk-input-label>
         @if (!string.IsNullOrWhiteSpace(hint))
         {
             <govuk-input-hint>@Html.Raw(hint)</govuk-input-hint>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextarea.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTextarea.cshtml
@@ -20,6 +20,7 @@
     }
     Int32.TryParse(Model.Settings.Value<string>("rows"), out var rows);
     if (rows < 2) { rows = 5; }
+    var label = Model.Content.Value<string>("label")?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
     var labelIsPageHeading = Model.Settings.Value<bool>("labelIsPageHeading");
     var hint = GovUkTypography.Apply(Model.Content.Value<string>("hint"), new TypographyOptions { RemoveWrappingParagraph = true });
     var invalid = modelStateEntry?.Errors.Any().ToString().ToLowerInvariant() ?? "false";
@@ -42,7 +43,7 @@
         var stringLengthAttr = modelProperty.GetCustomAttributes<StringLengthAttribute>().FirstOrDefault();
         int? maxLength = maxLengthAttr != null ? maxLengthAttr.Length : stringLengthAttr != null ? stringLengthAttr.MaximumLength : null;
         <govuk-character-count name="@modelPropertyName" form-group-class="@(Model.Settings.Value<string>(PropertyAliases.CssClasses))" rows="@rows" max-length="@maxLength" threshold="@threshold" textarea-aria-invalid="@invalid">
-            <govuk-character-count-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@(Model.Content.Value<string>("label"))</govuk-character-count-label>
+            <govuk-character-count-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@label</govuk-character-count-label>
             @if (!string.IsNullOrWhiteSpace(hint))
             {
                 <govuk-character-count-hint>@Html.Raw(hint)</govuk-character-count-hint>
@@ -54,7 +55,7 @@
     else
     {
         <govuk-textarea name="@modelPropertyName" class="@(Model.Settings.Value<string>(PropertyAliases.CssClasses))" rows="@rows" textarea-aria-invalid="@invalid">
-            <govuk-textarea-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@(Model.Content.Value<string>("label"))</govuk-textarea-label>
+            <govuk-textarea-label is-page-heading="@labelIsPageHeading" class="@(labelIsPageHeading ? "govuk-label--l" : null)">@label</govuk-textarea-label>
             @if (!string.IsNullOrWhiteSpace(hint))
             {
                 <govuk-textarea-hint>@Html.Raw(hint)</govuk-textarea-hint>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuklinkasbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuklinkasbuttonsettings.config
@@ -41,6 +41,22 @@
       <ValidationRegExpMessage></ValidationRegExpMessage>
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
+    <GenericProperty>
+      <Key>e2ab3a79-1483-4cce-8a7d-ad5dca3f2050</Key>
+      <Name>Type of button</Name>
+      <Alias>typeOfButton</Alias>
+      <Definition>041129bd-598f-4911-9ad8-871020ef95a1</Definition>
+      <Type>Umbraco.RadioButtonList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
   </GenericProperties>
   <Tabs>
     <Tab>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuktextarea.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuktextarea.config
@@ -31,7 +31,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>true</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Use {{name}} to include the page name.]]></Description>
       <SortOrder>1</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuktextinput.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuktextinput.config
@@ -31,7 +31,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>true</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Use {{name}} to include the page name.]]></Description>
       <SortOrder>1</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>


### PR DESCRIPTION
- The back button should be outside the <main> element according to GOV.UK - update the Umbraco example app
- Support {{name}} to reuse the page name when setting the label as the page heading on text input and textarea, similar to radio and checkbox groups
- When using textarea or text input label as a heading, add the ability to set the h1 to full width while the hint and component are two-thirds, and to have a divider line below the heading. Simplifies the CSS for doing this with radios and checkboxes.
- Support secondary and warning styles for links styled as a button