### PR TITLE
Adjust spacing

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -15,6 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<None Remove="Styles\_govuk-back.scss" />
 		<None Remove="Styles\_govuk-button.scss" />
 		<None Remove="Styles\_govuk-caption.scss" />
 		<None Remove="Styles\_govuk-date-input.scss" />
@@ -34,6 +35,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<EmbeddedResource Include="Styles\_govuk-back.scss" />
 		<EmbeddedResource Include="Styles\_tpr-task-list.scss" />
 		<EmbeddedResource Include="Styles\_govuk-task-list.scss" />
 		<EmbeddedResource Include="Styles\_govuk-caption.scss" />
@@ -233,6 +235,10 @@
 
 	<ItemGroup>
 	  <UpToDateCheckInput Remove="Styles\_govuk-table.scss" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_govuk-back.scss" />
 	</ItemGroup>
 
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-back.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-back.scss
@@ -1,0 +1,17 @@
+﻿@import '_variables.scss';
+@import 'govuk/base';
+
+/* Change GOV.UK back link styles where the TPR brand diverges from the GOV.UK Design System. */
+.govuk-back-link {
+    margin-top: govuk-spacing(7);
+    margin-bottom: 0;
+}
+
+/* If the back link is absent, spacing between the header and the main content comes from .govuk-main-wrapper. 
+   When the back link is present, adjust that to be the desired spacing between the back link and the main content.
+*/
+@include govuk-media-query($from: tablet) {
+    .govuk-back-link + .govuk-main-wrapper {
+        padding-top: govuk-spacing(6);
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
@@ -19,9 +19,15 @@
     .govuk-grid-row, which disrupts GOV.UK grid layout.
 */
 @mixin tpr-divider {
-    @include govuk-responsive-padding(6, "bottom");
+    padding-bottom: govuk-spacing(4);
     border-bottom: 1px solid $tpr-colour-very-light-grey;
-    @include govuk-responsive-margin(6, "bottom");
+    margin-bottom: govuk-spacing(4);
+
+    // Adjust spacing similar to using govuk-responsive-margin, but we can't use that because the target value is not in $govuk-spacing-responsive-scale
+    @include govuk-media-query($from: tablet) {
+        padding-bottom: 36px;
+        margin-bottom: 36px;
+    }
 }
 
 .govuk-grid-row--tpr-divider::after {

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
@@ -112,6 +112,12 @@
     @include tpr-divider;
 }
 
+/* Remove bottom margin in these cases as the tpr-divider creates enough space between the element and the divider. */
+.govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column > .govuk-form-group > h1 > label,
+.govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column > .govuk-form-group > textarea {
+    margin-bottom: 0;
+}
+
 /*
     Columns with alternating white and grey backgrounds.
     Columns should have a *-from-desktop grid width applied, eg govuk-grid-column-one-third-from-desktop for a three column layout.

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
@@ -36,6 +36,7 @@
 @import '_open-sans.scss';
 
 // Override compiled GOV.UK styles to apply differences from the TPR UI Kit
+@import '_govuk-back.scss';
 @import '_govuk-button.scss';
 @import '_govuk-caption.scss';
 @import '_govuk-date-input.scss';


### PR DESCRIPTION
Removes extra spacing when applying .govuk-grid-row--tpr-divider-for-label-as-heading

Adjusts spacing around the back link and divider lines to match TPR UI kit