### PR TITLE
Fix bug where you had to click a link in the error summary twice

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/__tests__/govuk-validation-updateErrorSummary.tests.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/__tests__/govuk-validation-updateErrorSummary.tests.js
@@ -46,8 +46,8 @@ describe("updateSummary", () => {
     govuk().updateErrorSummary();
 
     expect(
-      document.querySelector(".govuk-error-summary > .govuk-list").childNodes
-        .length
+      document.querySelector(".govuk-error-summary > .govuk-list")
+        .childElementCount
     ).toBe(2);
     expect(
       document.querySelector(".govuk-error-summary a[href='#new1']")


### PR DESCRIPTION
If your focus was in a validatable field and you clicked a link in the error summary, it didn't work because the link was being removed and recreated. 

With this PR unchanged links are left alone so they can be followed. Rather than removing and recreating all errors, new errors are inserted at the correct place in the error summary.

AB#148747

Also replaces some use of the obsolete `var` keyword with `const`.