### PR TITLE
Update styling for reversed buttons, and make some constants public

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
@@ -14,6 +14,7 @@ $tpr-button-padding: 20px;
 
 .govuk-button, input[type="file"]::file-selector-button {
     color: $tpr-colour-white;
+    border-width: 1px;
     border-color: transparent;
     line-height: govuk-px-to-rem(24);
     border-radius: 8px;
@@ -95,6 +96,8 @@ input[type="file"]::file-selector-button {
     &:hover:focus,
     &:active:focus {
         color: $tpr-colour-white;
+        background: transparent;
+        border-color: $tpr-colour-white;
     }
 
     &:focus {

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
@@ -86,21 +86,21 @@ input[type="file"]::file-selector-button {
 }
 
 .govuk-button--reversed {
-    background-color: $tpr-colour-white;
+    background-color: transparent;
     background-image: none;
     padding-right: govuk-spacing(4);
-    color: $tpr-colour-eastern-blue;
-    
+    color: $tpr-colour-white;
+    border-color: $tpr-colour-white;
+
     &:hover,
     &:active,
     &:hover:focus,
     &:active:focus {
-        color: $tpr-colour-white;
-        background: transparent;
-        border-color: $tpr-colour-white;
+        color: $tpr-colour-zambezi;
+        background: $tpr-colour-white;
     }
 
     &:focus {
-        color: $tpr-colour-black;  
+        color: $tpr-colour-black;
     }
 }

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-notification-banner.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-notification-banner.scss
@@ -37,6 +37,19 @@
             max-width: none;
         }
 
+        .govuk-button--reversed {
+            background-color: $tpr-colour-white;
+            color: $tpr-colour-eastern-blue;
+
+            &:hover, 
+            &:active, 
+            &:hover:focus, 
+            &:active:focus {
+                background-color: transparent;
+                color: $tpr-colour-white;
+            }
+        }
+
         .govuk-button-group {
             justify-content: center;
         }
@@ -45,7 +58,7 @@
             display: flex;
             justify-content: center;
 
-           
+
             .govuk-button {
                 margin-bottom: 0;
             }
@@ -53,7 +66,7 @@
             .govuk-button-group {
                 justify-content: center;
                 margin-bottom: 0;
-            }    
+            }
         }
     }
 
@@ -62,7 +75,7 @@
     .govuk-notification-banner__link:link,
     .govuk-notification-banner__link,
     .govuk-link:link,
-    .govuk-link{
+    .govuk-link {
         color: $tpr-colour-white;
         text-decoration-thickness: 1px;
 

--- a/GovUk.Frontend.ExampleApp/Views/Button/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Button/Index.cshtml
@@ -14,6 +14,11 @@
     <a href="/" class="govuk-link">Cancel</a>
 </div>
 
+<div class="govuk-grid-row govuk-grid-row--dark-background">
+    <div class="govuk-grid-column govuk-grid-column-two-thirds">
+        <govuk-button class="govuk-button--reversed" type="button">Reversed button</govuk-button>
+    </div>
+</div>
 
 <govuk-notification-banner>
     <p class="govuk-body">Reversed buttons should be used inside a notification banner.</p>

--- a/GovUk.Frontend.ExampleApp/wwwroot/css/site.css
+++ b/GovUk.Frontend.ExampleApp/wwwroot/css/site.css
@@ -1,3 +1,9 @@
 ﻿.language-switcher { margin: 1rem 0; }
 .languageSelected { border-left: 4px solid #ccc; padding-left: 8px; }
 .languageNotSelected { padding-left: 12px; }
+
+.govuk-grid-row--dark-background {
+    background: gray;
+    padding-top: 15px;
+    margin: 0 0 30px 0;
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
@@ -38,6 +38,10 @@
         "settingsUdi": "umb://element/2eb09fa3c1a24b55b7c5893e87f0fb0a"
       },
       {
+        "contentUdi": "umb://element/84d5fc6250dd4ff084cb3837a819df0a",
+        "settingsUdi": "umb://element/24431dbc7560490db23550fc4bf5a218"
+      },
+      {
         "contentUdi": "umb://element/baf1f69e39d74032a35473d3dd049b3a",
         "settingsUdi": "umb://element/b422ef19f18b4751a89a0e0184b69b48"
       },
@@ -86,6 +90,11 @@
       "blocks": "{\r\n  \"layout\": {\r\n    \"Umbraco.BlockList\": [\r\n      {\r\n        \"contentUdi\": \"umb://element/193cf473f47e485188871eb55590cb04\",\r\n        \"settingsUdi\": \"umb://element/2a96df7379a845a690b75ec46e7d3f9b\"\r\n      }\r\n    ]\r\n  },\r\n  \"contentData\": [\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/193cf473f47e485188871eb55590cb04\",\r\n      \"text\": \"Reversed button\"\r\n    }\r\n  ],\r\n  \"settingsData\": [\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/2a96df7379a845a690b75ec46e7d3f9b\",\r\n      \"columnSize\": null,\r\n      \"columnSizeFromDesktop\": null,\r\n      \"typeOfButton\": \"Reversed\"\r\n    }\r\n  ]\r\n}",
       "text": "<p>Reversed buttons should be used inside a notification banner.</p>",
       "heading": ""
+    },
+    {
+      "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
+      "udi": "umb://element/84d5fc6250dd4ff084cb3837a819df0a",
+      "text": "Reversed button"
     }
   ],
   "settingsData": [
@@ -130,6 +139,14 @@
       "columnSize": "[\"full\"]",
       "columnSizeFromDesktop": null,
       "type": "Success"
+    },
+    {
+      "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
+      "udi": "umb://element/24431dbc7560490db23550fc4bf5a218",
+      "typeOfButton": "Reversed",
+      "columnSize": null,
+      "columnSizeFromDesktop": null,
+      "cssClassesForRow": "govuk-grid-row--dark-background"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/wwwroot/css/site.css
+++ b/GovUk.Frontend.Umbraco.ExampleApp/wwwroot/css/site.css
@@ -1,6 +1,12 @@
 ﻿.languageSelected { border-left: 4px solid #ccc; padding-left: 8px; }
 .languageNotSelected { padding-left: 12px; }
 
+.govuk-grid-row--dark-background {
+    background: gray;
+    padding-top: 15px;
+    margin: 0 0 30px 0;
+}
+
 /*
     Show GOV.UK grid lines - enable using document.body.classList.add("debug-grid") in the DevTools console
 */

--- a/GovUk.Frontend.Umbraco/PropertyAliases.cs
+++ b/GovUk.Frontend.Umbraco/PropertyAliases.cs
@@ -1,26 +1,26 @@
 ﻿namespace GovUk.Frontend.Umbraco
 {
-    internal static class PropertyAliases
+    public static class PropertyAliases
     {
-        internal const string ModelProperty = "modelProperty";
-        internal const string CssClasses = "cssClasses";
-        internal const string CssClassesForRow = "cssClassesForRow";
-        internal const string CssClassesForColumn = "cssClassesForColumn";
-        internal const string ColumnSize = "columnSize";
-        internal const string ColumnSizeFromDesktop = "columnSizeFromDesktop";
-        internal const string ErrorMessageRequired = "errorMessageRequired";
-        internal const string ErrorMessageRegex = "errorMessageRegex";
-        internal const string ErrorMessageEmail = "errorMessageEmail";
-        internal const string ErrorMessagePhone = "errorMessagePhone";
-        internal const string ErrorMessageLength = "errorMessageLength";
-        internal const string ErrorMessageMinLength = "errorMessageMinLength";
-        internal const string ErrorMessageMaxLength = "errorMessageMaxLength";
-        internal const string ErrorMessageRange = "errorMessageRange";
-        internal const string ErrorMessageCompare = "errorMessageCompare";
-        internal const string ErrorMessage = "error";
-        internal const string FieldsetBlocks = "blocks";
-        internal const string FieldsetLegendIsPageHeading = "legendIsPageHeading";
-        internal const string FieldsetErrorsEnabled = "fieldsetErrors";
-        internal const string NotificationBannerBlocks = "blocks";
+        public const string ModelProperty = "modelProperty";
+        public const string CssClasses = "cssClasses";
+        public const string CssClassesForRow = "cssClassesForRow";
+        public const string CssClassesForColumn = "cssClassesForColumn";
+        public const string ColumnSize = "columnSize";
+        public const string ColumnSizeFromDesktop = "columnSizeFromDesktop";
+        public const string ErrorMessageRequired = "errorMessageRequired";
+        public const string ErrorMessageRegex = "errorMessageRegex";
+        public const string ErrorMessageEmail = "errorMessageEmail";
+        public const string ErrorMessagePhone = "errorMessagePhone";
+        public const string ErrorMessageLength = "errorMessageLength";
+        public const string ErrorMessageMinLength = "errorMessageMinLength";
+        public const string ErrorMessageMaxLength = "errorMessageMaxLength";
+        public const string ErrorMessageRange = "errorMessageRange";
+        public const string ErrorMessageCompare = "errorMessageCompare";
+        public const string ErrorMessage = "error";
+        public const string FieldsetBlocks = "blocks";
+        public const string FieldsetLegendIsPageHeading = "legendIsPageHeading";
+        public const string FieldsetErrorsEnabled = "fieldsetErrors";
+        public const string NotificationBannerBlocks = "blocks";
     }
 }

--- a/GovUk.Frontend.Umbraco/Validation/ValidationConstants.cs
+++ b/GovUk.Frontend.Umbraco/Validation/ValidationConstants.cs
@@ -1,7 +1,7 @@
 ﻿namespace GovUk.Frontend.Umbraco.Validation
 {
-    internal class ValidationConstants
+    public class ValidationConstants
     {
-        internal const string FIELDSET_ERROR = "FIELDSET-ERROR";
+        public const string FIELDSET_ERROR = "FIELDSET-ERROR";
     }
 }


### PR DESCRIPTION
Update styling for buttons, changing secondary and reversed buttons

Make some constants public to avoid a problem when using IIS

## Default state

![image](https://user-images.githubusercontent.com/1260550/221670850-acd43b28-9b65-4c84-b7d8-348b818d572f.png)

## Hover/active state (for secondary and reversed)

Note that reversed buttons in this state have Zambezi text colour because that's the colour of body text it needed some default to be specified, but this can be updated for specific scenarios. 

![image](https://user-images.githubusercontent.com/1260550/221671121-248a32f4-e467-4fc9-9a6a-0a1d2d3f8d92.png)

## Focus state (for secondary and reversed)

![image](https://user-images.githubusercontent.com/1260550/221673217-1345b5da-e11a-47e6-bfd5-e839c090b184.png)

## Focus + active state (for secondary and reversed)

![image](https://user-images.githubusercontent.com/1260550/221673392-3f41a3ac-f2f6-42cb-8d25-79ef68d8dd78.png)


AB#144952