### PR TITLE
Run IContextAwareHostUpdater on all text components

### DIFF
--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTypography.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTypography.cshtml
@@ -1,14 +1,26 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<OverridableBlockListItem>;
 @addTagHelper *, GovUk.Frontend.AspNetCore
 @using GovUk.Frontend.Umbraco.Models
+@using GovUk.Frontend.Umbraco.Services;
 @using GovUk.Frontend.Umbraco.Typography
 @using HtmlAgilityPack
 @using Umbraco.Extensions
+@inject IContextAwareHostUpdater hostUpdater
 @{
     var html = Model.Content.Value<string>("text");
-    html = GovUkTypography.Apply(html);
+    if (string.IsNullOrWhiteSpace(html)) { return; }
+
+    var document = new HtmlDocument();
+    document.LoadHtml(GovUkTypography.Apply(html));
+    var links = document.DocumentNode.SelectNodes("//a");
+    if (links != null)
+    {
+        foreach (var link in links)
+        {
+            var attribute = link.Attributes["href"];
+            attribute.Value = hostUpdater.UpdateHost(attribute.Value, Context.Request.Host.Host);
+        }
+    }
+
 }
-@if (!string.IsNullOrWhiteSpace(html))
-{
-    @(Html.Raw(html))
-}
+@(Html.Raw(document.DocumentNode.OuterHtml))


### PR DESCRIPTION
If you want links to auto-update the hostname, currently you have to predict which fields will have a link in them and implement that logic in the controller. 

This change just does it for all text components so it doesn't get forgotten. 

[AB#148746](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/148746)