### PR TITLE
Add the value attribute to buttons

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -19,6 +19,7 @@
       <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
       <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
       <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
     </Compositions>
     <DefaultTemplate></DefaultTemplate>
     <AllowedTemplates />

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
@@ -2,25 +2,33 @@
 @addTagHelper *, GovUk.Frontend.AspNetCore
 @using GovUk.Frontend.Umbraco.Typography
 @using GovUk.Frontend.Umbraco.Models
+@using GovUk.Frontend.Umbraco;
+@using Microsoft.AspNetCore.Mvc.ModelBinding;
 @using Umbraco.Extensions
 @{
     var text = Model.Content.Value<string>("text");
     var classNames = Model.Settings.Value<string>("cssClasses");
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    ModelStateEntry? modelStateEntry = null;
+    if (!string.IsNullOrEmpty(modelPropertyName))
+    {
+        ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
+    }
     switch (Model.Settings.Value<string>("typeOfButton")) {
         case "Secondary":
-            <govuk-button class="govuk-button--secondary @classNames" type="button" id="@Model.Content.Key" value="@text">@text</govuk-button>
+            <govuk-button class="govuk-button--secondary @classNames" type="button" name="@modelPropertyName" id="@Model.Content.Key" value="@text">@text</govuk-button>
             break;
 
         case "Warning":
-            <govuk-button class="govuk-button--warning @classNames" type="button" id="@Model.Content.Key" value="@text">@text</govuk-button>
+            <govuk-button class="govuk-button--warning @classNames" type="button" name="@modelPropertyName" id="@Model.Content.Key" value="@text">@text</govuk-button>
             break;
 
         case "Reversed":
-            <govuk-button class="govuk-button--reversed @classNames" type="button" id="@Model.Content.Key" value="@text">@text</govuk-button>
+            <govuk-button class="govuk-button--reversed @classNames" type="button" name="@modelPropertyName" id="@Model.Content.Key" value="@text">@text</govuk-button>
             break;
 
         default:
-            <govuk-button class="@classNames" type="submit" id="@Model.Content.Key" value="@text">@text</govuk-button>
+            <govuk-button class="@classNames" type="submit" id="@Model.Content.Key" name="@modelPropertyName" value="@text">@text</govuk-button>
             break;
     }
 }

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
@@ -8,19 +8,19 @@
     var classNames = Model.Settings.Value<string>("cssClasses");
     switch (Model.Settings.Value<string>("typeOfButton")) {
         case "Secondary":
-            <govuk-button class="govuk-button--secondary @classNames" type="button" id="@Model.Content.Key">@text</govuk-button>
+            <govuk-button class="govuk-button--secondary @classNames" type="button" id="@Model.Content.Key" value="@text">@text</govuk-button>
             break;
 
         case "Warning":
-            <govuk-button class="govuk-button--warning @classNames" type="button" id="@Model.Content.Key">@text</govuk-button>
+            <govuk-button class="govuk-button--warning @classNames" type="button" id="@Model.Content.Key" value="@text">@text</govuk-button>
             break;
 
         case "Reversed":
-            <govuk-button class="govuk-button--reversed @classNames" type="button" id="@Model.Content.Key">@text</govuk-button>
+            <govuk-button class="govuk-button--reversed @classNames" type="button" id="@Model.Content.Key" value="@text">@text</govuk-button>
             break;
 
         default:
-            <govuk-button class="@classNames" type="submit" id="@Model.Content.Key">@text</govuk-button>
+            <govuk-button class="@classNames" type="submit" id="@Model.Content.Key" value="@text">@text</govuk-button>
             break;
     }
 }

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -19,6 +19,7 @@
       <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
       <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
       <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
     </Compositions>
     <DefaultTemplate></DefaultTemplate>
     <AllowedTemplates />


### PR DESCRIPTION
Add the name and value attributes to buttons, which means code can detect which of multiple buttons on a page was clicked [AB#145273](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/145273)

As a developer, if you need to detect the button, create a string property on your view model and bind multiple buttons to it in Umbraco. When a form is posted the view model property will contain the button text.