### PR TITLE
Enable binding a view model property to a button

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
@@ -103,7 +103,7 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/9476ebde6c114904bfd69eadcea3456c",
-      "text": "<p>The following button styles are supported when using The Pensions Regulator branding. It is possible to configure other combinations in Umbraco, but they are not yet supported.</p>"
+      "text": "<p>The following button styles are supported when using The Pensions Regulator branding. It is possible to configure other combinations in Umbraco, but they are not yet supported.</p>\n<p>You can bind a button to a string property on your view model. On a page with multiple buttons this will let you detect which button was clicked.</p>"
     }
   ],
   "settingsData": [

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -19,6 +19,7 @@
       <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
       <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
       <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
     </Compositions>
     <DefaultTemplate></DefaultTemplate>
     <AllowedTemplates />

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
@@ -3,10 +3,17 @@
 @using GovUk.Frontend.Umbraco.Typography
 @using GovUk.Frontend.Umbraco.Models
 @using GovUk.Frontend.Umbraco;
+@using Microsoft.AspNetCore.Mvc.ModelBinding;
 @using Umbraco.Extensions
 @{
     var text = Model.Content.Value<string>("text");
     var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    ModelStateEntry? modelStateEntry = null;
+    if (!string.IsNullOrEmpty(modelPropertyName))
+    {
+        ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
+    }
     var buttonType = Model.Settings.Value<string>("typeOfButton") == "Secondary" ? "button" : "submit";
     var buttonStyle = Model.Settings.Value<string[]>("styleOfButton") ?? Array.Empty<string>();
     if (buttonStyle.Contains("Secondary")) { buttonStyle[buttonStyle.IndexOf("Secondary")] = "govuk-button--secondary"; }
@@ -14,5 +21,5 @@
     if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--reversed"; }
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
 
-    <govuk-button class="@string.Join(' ', buttonStyle)@cssClasses" type="@buttonType" id="@Model.Content.Key" value="@text">@text</govuk-button>
+    <govuk-button class="@string.Join(' ', buttonStyle)@cssClasses" type="@buttonType" name="@modelPropertyName" id="@Model.Content.Key" value="@text">@text</govuk-button>
 }

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -19,6 +19,7 @@
       <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
       <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
       <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
     </Compositions>
     <DefaultTemplate></DefaultTemplate>
     <AllowedTemplates />


### PR DESCRIPTION
Enable binding a view model property to a button so that we can detect which button was clicked [AB#145273](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/145273)