### PR TITLE
Push to nuget.org must come from a release branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
   - name: YARN_CACHE_FOLDER
     value: $(Pipeline.Workspace)/.yarn
   - name: allowPush
-    value: $[in(variables['Build.SourceBranch'], 'refs/heads/release', 'refs/heads/develop')]
+    value: $[startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')]
 
 resources:
   repositories:


### PR DESCRIPTION
The criteria for pushing packages to nuget needed tweaking for the first release.