### PR TITLE
Task list summary was not showing the correct number of tasks

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgridcolumn.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgridcolumn.config
@@ -25,7 +25,7 @@
       <Key>cc5ca7f3-e21e-4479-8400-f31fd8ec39a1</Key>
       <Name>Blocks</Name>
       <Alias>blocks</Alias>
-      <Definition>e0879661-5ada-4a1f-b7df-525e63087866</Definition>
+      <Definition>16ad6190-7e7c-43a3-afbf-082ccf5cef95</Definition>
       <Type>Umbraco.BlockList</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
@@ -1,0 +1,259 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="16ad6190-7e7c-43a3-afbf-082ccf5cef95" Alias="GOV.UK Grid column block list" Level="1">
+  <Info>
+    <Name>GOV.UK Grid column block list</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <DatabaseType>Ntext</DatabaseType>
+  </Info>
+  <Config><![CDATA[{
+  "Blocks": [
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "settingsElementTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "40bb2a3e-3d75-4ec1-9134-e0c46c6f04a0",
+      "settingsElementTypeKey": "29d9a3c9-4047-484a-8816-e233e161fcb0",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "83cb35fb-51da-45cd-913f-1b8bdfd6a1d9",
+      "settingsElementTypeKey": "0bac8213-4607-4547-902a-6a9d84b92633",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "9d15adb9-fb63-4b20-ada3-fc9239a72a8c",
+      "settingsElementTypeKey": "a6689021-cc6e-4d94-8c37-235906ebeff1",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{summary}} (Details)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "f7fc1212-5317-4642-9565-f8b6585508e8",
+      "settingsElementTypeKey": "6930e373-0fce-44ad-89b8-267442675807",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Fieldset)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
+      "settingsElementTypeKey": "98070ce9-d528-4bfc-bd90-e411e5110f56",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Text Input)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "d118b7dc-63c6-4262-9ce9-2e823dc530f0",
+      "settingsElementTypeKey": "5f3e3369-43cf-47c2-bb76-60055518ae05",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Textarea)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "a3a58c3e-673f-4521-b9e7-4b6a667f06b4",
+      "settingsElementTypeKey": "308973a3-4525-445f-9bcd-bdf3d649abb6",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Date input)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "b84a633b-1ee7-4a5c-80bd-4267420ed133",
+      "settingsElementTypeKey": "40da6b15-489b-4249-854a-56954e5917e1",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Radios)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "f1cb27f6-c7f5-4db0-bfff-ef76df811ac7",
+      "settingsElementTypeKey": "67371513-c485-4405-afb4-70367ddb6eb8",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Checkbox)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "a4ef171f-5688-4b05-806f-75a6ce50a842",
+      "settingsElementTypeKey": "57265e01-05ed-4ea3-a28d-e9f77420c018",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Checkboxes)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "bd6069cc-a8c1-456b-8a00-1d180c45c36c",
+      "settingsElementTypeKey": "d43b72b5-edac-42e0-aa09-1b080d7bd6eb",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "32224cf2-f160-4c74-9c07-ed918b263c75",
+      "settingsElementTypeKey": "41ecf378-c886-4f08-9962-7ea6e168276c",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "405470f7-9d54-4891-91c9-2efa8dec0833",
+      "settingsElementTypeKey": "51db3717-0b48-4f1d-afdd-478065a531a5",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "a278e94c-f555-490b-920c-313a7ba17492",
+      "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Select)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
+      "settingsElementTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{text}} (Button)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "settingsElementTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
+      "settingsElementTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{text}} (Link, styled as a button)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "2cb36d91-7480-4234-a5d8-6961a03ada8a",
+      "settingsElementTypeKey": "b34b41a7-261a-41a3-8877-afc4086cc065",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{error}} (Error message)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "901f91c0-f863-4409-9e6f-0ab829714c68",
+      "settingsElementTypeKey": "c7dd4cfd-8e91-46e2-8a57-0834a480cacb",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{$settings.modelProperty}} (Hidden field)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    }
+  ],
+  "ValidationLimit": {
+    "min": null,
+    "max": null
+  },
+  "UseLiveEditing": false,
+  "UseInlineEditingAsDefault": false,
+  "MaxPropertyWidth": null
+}]]></Config>
+</DataType>

--- a/GovUk.Frontend.Umbraco/ElementTypeAliases.cs
+++ b/GovUk.Frontend.Umbraco/ElementTypeAliases.cs
@@ -20,6 +20,7 @@
         public const string PageHeading = "govukPageHeading";
         public const string Radios = "govukRadios";
         public const string Select = "govukSelect";
+        public const string TaskListSummary = "govukTaskListSummary";
         public const string Task = "govukTask";
         public const string Typography = "govukTypography";
         public const string TypographySettings = "govukTypographySettings";

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -370,6 +370,9 @@
 		<Content Update="uSync\v9\DataTypes\GOVUKFieldsetBlockList.config">
 		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</Content>
+		<Content Update="uSync\v9\DataTypes\GOVUKGridColumnBlockList.config">
+		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</Content>
 		<Content Update="uSync\v9\DataTypes\GOVUKGridColumnSize.config">
 		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</Content>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/BlockList.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/BlockList.cshtml
@@ -1,8 +1,10 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IEnumerable<BlockListItem>>
+@using GovUk.Frontend.AspNetCore.Extensions;
 @using GovUk.Frontend.Umbraco
 @using GovUk.Frontend.Umbraco.Models
 @using GovUk.Frontend.Umbraco.Services
 @using System.Text.RegularExpressions
+@using GovUk.Frontend.Umbraco.Validation;
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 @using Umbraco.Cms.Core.Models.Blocks
 @using Umbraco.Extensions
@@ -12,6 +14,20 @@
     if (!blocks.Any()) { return; }
     string? previousRowClass = null, previousColumnClass = null;
     bool? previousIsGridRowBlock = null;
+
+    // Task list summaries automatically count the tasks they summarise. However, the status of each task is likely to be set in the controller,
+    // and this is the last point where we have access to the overridden properties of the tasks before rendering the task list summary.
+    // So we have to query the tasks here and pass the result down to the task list summary, which we can do using ModelState.
+    var taskListSummaries = blocks.FindBlocks(x => x.Content.ContentType.Alias == ElementTypeAliases.TaskListSummary);
+    if (taskListSummaries.Any())
+    {
+        var tasks = blocks.FindBlocks(x => x.Content.ContentType.Alias == ElementTypeAliases.Task);
+        var taskStatuses = tasks.Select(x => ((OverridableBlockListItem)x).Settings.Value<string>("status")).Where(x => !string.IsNullOrEmpty(x)).Select(x => Enum.Parse<TaskListTaskStatus>(x!.Replace(" ", string.Empty), true));
+        foreach (var taskListSummary in taskListSummaries)
+        {
+            ViewContext.ModelState.SetInitialValue(taskListSummary.Content.Key.ToString(), string.Join(",", taskStatuses));
+        }
+    }
 }
 @* Renders a partial view for each block.
    Renders blocks within a GOV.UK grid row, except where that block is a 'govukGridRow' in which case that task is delegated.

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTaskListSummary.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkTaskListSummary.cshtml
@@ -5,10 +5,22 @@
 @using GovUk.Frontend.Umbraco.Typography
 @using GovUk.Frontend.Umbraco.Models
 @using GovUk.Frontend.Umbraco;
+@using Microsoft.AspNetCore.Mvc.ModelBinding;
 @using Umbraco.Extensions
 @{
-    var tasks = Umbraco.AssignedContentItem.FindBlocks(x => x.Content.ContentType.Alias == ElementTypeAliases.Task);
-    var taskStatuses = tasks.Select(x => x.Settings.Value<string>("status")).Where(x => !string.IsNullOrEmpty(x)).Select(x => Enum.Parse<TaskListTaskStatus>(x!.Replace(" ",string.Empty), true)).ToList();
+    // Get task statuses from ModelState, put there by BlockList.cshtml. We can't go to Model.AssignedContentItem to find the tasks
+    // because that will give us the original BlockListItem, and we need the OverridableBlockListItem that may have been updated in the controller.
+    List<TaskListTaskStatus> taskStatuses = new();
+    ModelStateEntry? modelStateEntry = null;
+    var modelPropertyName = Model.Content.Key.ToString();
+    if (!string.IsNullOrEmpty(modelPropertyName))
+    {
+        if (ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry) && !string.IsNullOrEmpty(modelStateEntry.AttemptedValue))
+        {
+            taskStatuses = modelStateEntry.AttemptedValue.Split(",").Select(x => Enum.Parse<TaskListTaskStatus>(x)).ToList();
+        }            
+    }
+
     var totalActionableTasks = taskStatuses.Count(x => x != TaskListTaskStatus.NotApplicable);
     var completedTasks = taskStatuses.Count(x => x == TaskListTaskStatus.Completed);
 

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridcolumn.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridcolumn.config
@@ -25,7 +25,7 @@
       <Key>cc5ca7f3-e21e-4479-8400-f31fd8ec39a1</Key>
       <Name>Blocks</Name>
       <Alias>blocks</Alias>
-      <Definition>e0879661-5ada-4a1f-b7df-525e63087866</Definition>
+      <Definition>16ad6190-7e7c-43a3-afbf-082ccf5cef95</Definition>
       <Type>Umbraco.BlockList</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
@@ -1,0 +1,259 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="16ad6190-7e7c-43a3-afbf-082ccf5cef95" Alias="GOV.UK Grid column block list" Level="1">
+  <Info>
+    <Name>GOV.UK Grid column block list</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <DatabaseType>Ntext</DatabaseType>
+  </Info>
+  <Config><![CDATA[{
+  "Blocks": [
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "settingsElementTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "40bb2a3e-3d75-4ec1-9134-e0c46c6f04a0",
+      "settingsElementTypeKey": "29d9a3c9-4047-484a-8816-e233e161fcb0",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "83cb35fb-51da-45cd-913f-1b8bdfd6a1d9",
+      "settingsElementTypeKey": "0bac8213-4607-4547-902a-6a9d84b92633",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "9d15adb9-fb63-4b20-ada3-fc9239a72a8c",
+      "settingsElementTypeKey": "a6689021-cc6e-4d94-8c37-235906ebeff1",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{summary}} (Details)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "f7fc1212-5317-4642-9565-f8b6585508e8",
+      "settingsElementTypeKey": "6930e373-0fce-44ad-89b8-267442675807",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Fieldset)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
+      "settingsElementTypeKey": "98070ce9-d528-4bfc-bd90-e411e5110f56",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Text Input)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "d118b7dc-63c6-4262-9ce9-2e823dc530f0",
+      "settingsElementTypeKey": "5f3e3369-43cf-47c2-bb76-60055518ae05",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Textarea)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "a3a58c3e-673f-4521-b9e7-4b6a667f06b4",
+      "settingsElementTypeKey": "308973a3-4525-445f-9bcd-bdf3d649abb6",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Date input)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "b84a633b-1ee7-4a5c-80bd-4267420ed133",
+      "settingsElementTypeKey": "40da6b15-489b-4249-854a-56954e5917e1",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Radios)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "f1cb27f6-c7f5-4db0-bfff-ef76df811ac7",
+      "settingsElementTypeKey": "67371513-c485-4405-afb4-70367ddb6eb8",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Checkbox)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "a4ef171f-5688-4b05-806f-75a6ce50a842",
+      "settingsElementTypeKey": "57265e01-05ed-4ea3-a28d-e9f77420c018",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{legend}} (Checkboxes)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "bd6069cc-a8c1-456b-8a00-1d180c45c36c",
+      "settingsElementTypeKey": "d43b72b5-edac-42e0-aa09-1b080d7bd6eb",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "32224cf2-f160-4c74-9c07-ed918b263c75",
+      "settingsElementTypeKey": "41ecf378-c886-4f08-9962-7ea6e168276c",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "405470f7-9d54-4891-91c9-2efa8dec0833",
+      "settingsElementTypeKey": "51db3717-0b48-4f1d-afdd-478065a531a5",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "a278e94c-f555-490b-920c-313a7ba17492",
+      "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{label}} (Select)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
+      "settingsElementTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{text}} (Button)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "settingsElementTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
+      "view": null,
+      "stylesheet": null,
+      "label": null,
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
+      "settingsElementTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{text}} (Link, styled as a button)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "2cb36d91-7480-4234-a5d8-6961a03ada8a",
+      "settingsElementTypeKey": "b34b41a7-261a-41a3-8877-afc4086cc065",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{error}} (Error message)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    },
+    {
+      "backgroundColor": null,
+      "iconColor": null,
+      "thumbnail": null,
+      "contentElementTypeKey": "901f91c0-f863-4409-9e6f-0ab829714c68",
+      "settingsElementTypeKey": "c7dd4cfd-8e91-46e2-8a57-0834a480cacb",
+      "view": null,
+      "stylesheet": null,
+      "label": "{{$settings.modelProperty}} (Hidden field)",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false
+    }
+  ],
+  "ValidationLimit": {
+    "min": null,
+    "max": null
+  },
+  "UseLiveEditing": false,
+  "UseInlineEditingAsDefault": false,
+  "MaxPropertyWidth": null
+}]]></Config>
+</DataType>

--- a/docs/components/task-list-summary.md
+++ b/docs/components/task-list-summary.md
@@ -31,4 +31,4 @@ This is part of the [Task list pages](https://design-system.service.gov.uk/patte
 
 ## Umbraco
 
-When you add a 'Task list summary' component to a block list in Umbraco, it will automatically display the count of tasks for all 'Task list' components on the same page.
+When you add a 'Task list summary' component to a block list in Umbraco, it will automatically display the count of tasks for all 'Task list' components in the same block list or its descendants.


### PR DESCRIPTION
Task list summary automatically displays a count of total and completed tasks, but it was not taking account of statuses overridden in a controller, which will be the most common scenario. It was looking at the original block list rather than the overridden version, so update views to pass data from the overridden version down to the task list summary.

During testing I also noticed that the 'Grid column' component did not allow a set of child components that was consistent with 'Grid row' so I updated that.