### PR TITLE
It should be possible to disable a button in Umbraco (develop)

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-button.scss
@@ -31,7 +31,7 @@ $tpr-button-padding: 20px;
     background-image: url(/_content/ThePensionsRegulator.GovUk.Frontend/tpr/chevron_right_eclipse_24dp.svg);
     color: $tpr-colour-eclipse;
 }
-.govuk-button:disabled {
+.govuk-button:disabled, .govuk-button[aria-disabled=true] {
     color: $tpr-colour-white;
     background-color: $tpr-colour-regent-st-blue;
 }
@@ -53,7 +53,7 @@ a.govuk-button--secondary:hover {
     color: $tpr-colour-white;
     background-color: $tpr-colour-royal-blue;
 }
-.govuk-button--secondary:disabled {
+.govuk-button--secondary:disabled, .govuk-button--secondary[aria-disabled=true] {
     color: $tpr-colour-cornflower;
     background-color: $tpr-colour-white;
     border-color: $tpr-colour-cornflower;
@@ -80,7 +80,7 @@ input[type="file"]::file-selector-button {
     color: $tpr-colour-white;
     background-color: $tpr-colour-brick;
 }
-.govuk-button--warning:disabled {
+.govuk-button--warning:disabled, .govuk-button--warning[aria-disabled=true] {
     color: $tpr-colour-white;
     background-color: $tpr-colour-petite-orchid;
 }
@@ -93,7 +93,7 @@ a.govuk-button--warning.govuk-button--secondary:visited {
     border-color: $tpr-colour-fire-brick;
 }
 
-.govuk-button--warning.govuk-button--secondary:hover,
+.govuk-button--warning.govuk-button--secondary:hover:not(:disabled):not([aria-disabled=true]),
 .govuk-button--warning.govuk-button--secondary:active,
 a.govuk-button--warning.govuk-button--secondary:hover,
 a.govuk-button--warning.govuk-button--secondary:active {
@@ -102,7 +102,7 @@ a.govuk-button--warning.govuk-button--secondary:active {
     border-color: transparent;
 }
 
-.govuk-button--warning.govuk-button--secondary:disabled {
+.govuk-button--warning.govuk-button--secondary:disabled, .govuk-button--warning.govuk-button--secondary[aria-disabled=true] {
     color: $tpr-colour-petite-orchid;
     border-color: $tpr-colour-petite-orchid;
 }

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-js-init.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-js-init.js
@@ -1,1 +1,11 @@
-﻿window.GOVUKFrontend.initAll()
+﻿window.GOVUKFrontend.initAll();
+Array.prototype.forEach.call(
+  document.querySelectorAll(".govuk-button[type=submit]"),
+  function (button) {
+    button.addEventListener("click", function (e) {
+      if (e.target.getAttribute("aria-disabled") == "true") {
+        e.preventDefault();
+      }
+    });
+  }
+);

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonController.cs
@@ -1,0 +1,28 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.Umbraco.ExampleApp.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Cms.Web.Common.PublishedModels;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
+{
+    public class ButtonController : RenderController
+    {
+        public ButtonController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        {
+        }
+
+        [ModelType(typeof(ButtonViewModel))]
+        public override IActionResult Index()
+        {
+            var viewModel = new ButtonViewModel
+            {
+                Page = new Button(CurrentPage, null)
+            };
+            return CurrentTemplate(viewModel);
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonSurfaceController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonSurfaceController.cs
@@ -1,0 +1,50 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.Umbraco.ExampleApp.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Web.Common.Filters;
+using Umbraco.Cms.Web.Website.Controllers;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
+{
+	public class ButtonSurfaceController : SurfaceController
+	{
+		public ButtonSurfaceController(IUmbracoDatabaseFactory umbracoDatabaseFactory,
+			IUmbracoContextAccessor umbracoContextAccessor,
+			ServiceContext context,
+			AppCaches appCaches,
+			IProfilingLogger profilingLogger,
+			IPublishedUrlProvider publishedUrlProvider
+			)
+			: base(umbracoContextAccessor, umbracoDatabaseFactory, context, appCaches, profilingLogger, publishedUrlProvider)
+		{
+		}
+
+		[HttpPost]
+		[ValidateAntiForgeryToken]
+		[ValidateUmbracoFormRouteString]
+		[ModelType(typeof(ButtonViewModel))]
+		public IActionResult Index(ButtonViewModel viewModel)
+		{
+			if (ModelState.IsValid)
+			{
+				if (viewModel?.Page?.NextPage != null)
+				{
+					Response.StatusCode = 303;
+					Response.GetTypedHeaders().Location = new Uri(viewModel.Page.NextPage.Url(), UriKind.RelativeOrAbsolute);
+				}
+			}
+
+			return View("Button", viewModel);
+		}
+
+	}
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ButtonViewModel.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ButtonViewModel.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Web.Common.PublishedModels;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Models
+{
+	public class ButtonViewModel
+	{
+		public Button? Page { get; set; }
+	}
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/Button.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/Button.generated.cs
@@ -56,5 +56,13 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		[ImplementPropertyType("blocks")]
 		public virtual global::Umbraco.Cms.Core.Models.Blocks.BlockListModel Blocks => this.Value<global::Umbraco.Cms.Core.Models.Blocks.BlockListModel>(_publishedValueFallback, "blocks");
+
+		///<summary>
+		/// Next page
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "10.4.0+daff988")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("nextPage")]
+		public virtual global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent NextPage => this.Value<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent>(_publishedValueFallback, "nextPage");
 	}
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/Button.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/Button.cshtml
@@ -1,6 +1,11 @@
-﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Button>
+﻿@using GovUk.Frontend.Umbraco.ExampleApp.Controllers;
+@using GovUk.Frontend.Umbraco.ExampleApp.Models;
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ButtonViewModel>
 @section head{
-	<title>@Model.Name</title>
+	<title>@Model.Page!.Name</title>
 }
 
-<partial name="GOVUK/BlockList" model="Model.Blocks" />
+@using (Html.BeginUmbracoForm<ButtonSurfaceController>(nameof(ButtonSurfaceController.Index), new { }, new { novalidate = "novalidate" }))
+{
+	<partial name="GOVUK/BlockList" model="Model.Page.Blocks" />
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
@@ -42,8 +42,8 @@
         "settingsUdi": "umb://element/2eb09fa3c1a24b55b7c5893e87f0fb0a"
       },
       {
-        "contentUdi": "umb://element/84d5fc6250dd4ff084cb3837a819df0a",
-        "settingsUdi": "umb://element/24431dbc7560490db23550fc4bf5a218"
+        "contentUdi": "umb://element/7da467d436234410b7822564ada2a965",
+        "settingsUdi": "umb://element/2d37cdb7e6754577b48d19ac287508e2"
       },
       {
         "contentUdi": "umb://element/baf1f69e39d74032a35473d3dd049b3a",
@@ -68,7 +68,7 @@
     {
       "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
       "udi": "umb://element/66a0f09f95ae426da4af813094e9efa2",
-      "buttons": "{\r\n  \"layout\": {\r\n    \"Umbraco.BlockList\": [\r\n      {\r\n        \"contentUdi\": \"umb://element/b759811136de470c8192a7143bbf8056\",\r\n        \"settingsUdi\": \"umb://element/c5b40f0183cd4839b412a84b16f3393a\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/f980ec15f038472b952147f174667545\",\r\n        \"settingsUdi\": \"umb://element/d78e075f2a284fb3a2a79a161860035c\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/e1f174f2405e4760a2cf52350538284e\",\r\n        \"settingsUdi\": \"umb://element/327ff8c2709a4ccdba6cc49b673358d0\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/ae66c309d6bb4f4f9aa2d1d68d80ddec\",\r\n        \"settingsUdi\": \"umb://element/56010e1aa7064527b2310f52b495f044\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/6bd81e10dad343dabe6c50c8f14225b3\",\r\n        \"settingsUdi\": \"umb://element/224bfd6342fa4404ac1b6cb0489fafa2\"\r\n      }\r\n    ]\r\n  },\r\n  \"contentData\": [\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/b759811136de470c8192a7143bbf8056\",\r\n      \"text\": \"Default button\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"64a0406a-8b4d-46d7-a976-af6d6616dffc\",\r\n      \"udi\": \"umb://element/6bd81e10dad343dabe6c50c8f14225b3\",\r\n      \"text\": \"Cancel\",\r\n      \"link\": \"[{\\\"name\\\":\\\"Home\\\",\\\"udi\\\":\\\"umb://document/5e682cbeb867491a955f3382446d5663\\\"}]\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/f980ec15f038472b952147f174667545\",\r\n      \"text\": \"Secondary button\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/e1f174f2405e4760a2cf52350538284e\",\r\n      \"text\": \"Warning button\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/ae66c309d6bb4f4f9aa2d1d68d80ddec\",\r\n      \"text\": \"Secondary warning button\"\r\n    }\r\n  ],\r\n  \"settingsData\": [\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/c5b40f0183cd4839b412a84b16f3393a\",\r\n      \"typeOfButton\": \"Primary\",\r\n      \"styleOfButton\": \"\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/d78e075f2a284fb3a2a79a161860035c\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\",\r\n      \"styleOfButton\": \"[\\\"Secondary\\\"]\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/327ff8c2709a4ccdba6cc49b673358d0\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"styleOfButton\": \"[\\\"Warning\\\"]\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"236a3fde-d8b7-4b7d-aaad-6f49d2a3ddf2\",\r\n      \"udi\": \"umb://element/224bfd6342fa4404ac1b6cb0489fafa2\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/56010e1aa7064527b2310f52b495f044\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"styleOfButton\": \"[\\\"Secondary\\\",\\\"Warning\\\"]\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\"\r\n    }\r\n  ]\r\n}"
+      "buttons": "{\r\n  \"layout\": {\r\n    \"Umbraco.BlockList\": [\r\n      {\r\n        \"contentUdi\": \"umb://element/b759811136de470c8192a7143bbf8056\",\r\n        \"settingsUdi\": \"umb://element/c5b40f0183cd4839b412a84b16f3393a\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/a2fd2454a4404efdbf7bf5f743c31d51\",\r\n        \"settingsUdi\": \"umb://element/adba8035d957445893a71539509eca97\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/f980ec15f038472b952147f174667545\",\r\n        \"settingsUdi\": \"umb://element/d78e075f2a284fb3a2a79a161860035c\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/f67a867dc52d456bbb7aa859ffe340cd\",\r\n        \"settingsUdi\": \"umb://element/685408f4cb66489bb258356cae7109bd\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/e1f174f2405e4760a2cf52350538284e\",\r\n        \"settingsUdi\": \"umb://element/327ff8c2709a4ccdba6cc49b673358d0\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/b33f034a34394a5ab1d1ac6b5003dee6\",\r\n        \"settingsUdi\": \"umb://element/766361ea6cc94d4491f04a6ab91a4a3d\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/ae66c309d6bb4f4f9aa2d1d68d80ddec\",\r\n        \"settingsUdi\": \"umb://element/56010e1aa7064527b2310f52b495f044\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/0f3c2f136f324c9ea14452c9456ad61c\",\r\n        \"settingsUdi\": \"umb://element/064a92606c19414882a73afae442b6e6\"\r\n      },\r\n      {\r\n        \"contentUdi\": \"umb://element/6bd81e10dad343dabe6c50c8f14225b3\",\r\n        \"settingsUdi\": \"umb://element/224bfd6342fa4404ac1b6cb0489fafa2\"\r\n      }\r\n    ]\r\n  },\r\n  \"contentData\": [\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/b759811136de470c8192a7143bbf8056\",\r\n      \"text\": \"Default button\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"64a0406a-8b4d-46d7-a976-af6d6616dffc\",\r\n      \"udi\": \"umb://element/6bd81e10dad343dabe6c50c8f14225b3\",\r\n      \"text\": \"Cancel\",\r\n      \"link\": \"[{\\\"name\\\":\\\"Home\\\",\\\"udi\\\":\\\"umb://document/5e682cbeb867491a955f3382446d5663\\\"}]\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/f980ec15f038472b952147f174667545\",\r\n      \"text\": \"Secondary button\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/e1f174f2405e4760a2cf52350538284e\",\r\n      \"text\": \"Warning button\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/ae66c309d6bb4f4f9aa2d1d68d80ddec\",\r\n      \"text\": \"Secondary warning button\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/a2fd2454a4404efdbf7bf5f743c31d51\",\r\n      \"text\": \"Default disabled\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/f67a867dc52d456bbb7aa859ffe340cd\",\r\n      \"text\": \"Secondary disabled\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/b33f034a34394a5ab1d1ac6b5003dee6\",\r\n      \"text\": \"Warning disabled\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/0f3c2f136f324c9ea14452c9456ad61c\",\r\n      \"text\": \"Secondary warning disabled\"\r\n    }\r\n  ],\r\n  \"settingsData\": [\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/c5b40f0183cd4839b412a84b16f3393a\",\r\n      \"typeOfButton\": \"Primary\",\r\n      \"styleOfButton\": \"\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/d78e075f2a284fb3a2a79a161860035c\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\",\r\n      \"styleOfButton\": \"[\\\"Secondary\\\"]\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/327ff8c2709a4ccdba6cc49b673358d0\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"styleOfButton\": \"[\\\"Warning\\\"]\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"236a3fde-d8b7-4b7d-aaad-6f49d2a3ddf2\",\r\n      \"udi\": \"umb://element/224bfd6342fa4404ac1b6cb0489fafa2\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/56010e1aa7064527b2310f52b495f044\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"styleOfButton\": \"[\\\"Secondary\\\",\\\"Warning\\\"]\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/adba8035d957445893a71539509eca97\",\r\n      \"typeOfButton\": \"Primary\",\r\n      \"styleOfButton\": \"\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\",\r\n      \"disabled\": \"1\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/685408f4cb66489bb258356cae7109bd\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\",\r\n      \"styleOfButton\": \"[\\\"Secondary\\\"]\",\r\n      \"disabled\": \"1\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/766361ea6cc94d4491f04a6ab91a4a3d\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"styleOfButton\": \"[\\\"Warning\\\"]\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\",\r\n      \"disabled\": \"1\"\r\n    },\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/064a92606c19414882a73afae442b6e6\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"styleOfButton\": \"[\\\"Secondary\\\",\\\"Warning\\\"]\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\",\r\n      \"disabled\": \"1\"\r\n    }\r\n  ]\r\n}"
     },
     {
       "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
@@ -96,14 +96,14 @@
       "heading": ""
     },
     {
-      "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-      "udi": "umb://element/84d5fc6250dd4ff084cb3837a819df0a",
-      "text": "Reversed button"
-    },
-    {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/9476ebde6c114904bfd69eadcea3456c",
       "text": "<p>The following button styles are supported when using The Pensions Regulator branding. It is possible to configure other combinations in Umbraco, but they are not yet supported.</p>\n<p>You can bind a button to a string property on your view model. On a page with multiple buttons this will let you detect which button was clicked.</p>"
+    },
+    {
+      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "udi": "umb://element/7da467d436234410b7822564ada2a965",
+      "buttons": "{\r\n  \"layout\": {\r\n    \"Umbraco.BlockList\": [\r\n      {\r\n        \"contentUdi\": \"umb://element/f6ed5ac1bf784eb8aac8d95f994cd910\",\r\n        \"settingsUdi\": \"umb://element/6c03bb348f304b5cb48eb1f2cf29092e\"\r\n      }\r\n    ]\r\n  },\r\n  \"contentData\": [\r\n    {\r\n      \"contentTypeKey\": \"35584ae7-feb5-4de8-9008-5d2d8cfb34ce\",\r\n      \"udi\": \"umb://element/f6ed5ac1bf784eb8aac8d95f994cd910\",\r\n      \"text\": \"Reversed button\"\r\n    }\r\n  ],\r\n  \"settingsData\": [\r\n    {\r\n      \"contentTypeKey\": \"e683e885-8aa0-4bdd-9eff-56966f353540\",\r\n      \"udi\": \"umb://element/6c03bb348f304b5cb48eb1f2cf29092e\",\r\n      \"typeOfButton\": \"Secondary\",\r\n      \"columnSize\": \"\",\r\n      \"columnSizeFromDesktop\": \"\",\r\n      \"cssClassesForRow\": \"govuk-grid-row--dark-background\",\r\n      \"styleOfButton\": \"[\\\"Reversed\\\"]\"\r\n    }\r\n  ]\r\n}"
     }
   ],
   "settingsData": [
@@ -157,20 +157,21 @@
       "type": "Success"
     },
     {
-      "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-      "udi": "umb://element/24431dbc7560490db23550fc4bf5a218",
-      "typeOfButton": "Secondary",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
-      "cssClassesForRow": "govuk-grid-row--dark-background",
-      "styleOfButton": "[\"Reversed\"]"
-    },
-    {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "udi": "umb://element/70e757e163b84f4dbb697d211904278a"
+    },
+    {
+      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
+      "udi": "umb://element/2d37cdb7e6754577b48d19ac287508e2",
+      "cssClassesForRow": "govuk-grid-row--dark-background",
+      "columnSize": "",
+      "columnSizeFromDesktop": ""
     }
   ]
 }]]></Value>
     </blocks>
+    <nextPage>
+      <Value><![CDATA[umb://document/7ebf39a4dbdd454b92e46e544af2a411]]></Value>
+    </nextPage>
   </Properties>
 </Content>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/button.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/button.config
@@ -38,6 +38,22 @@
       <ValidationRegExpMessage></ValidationRegExpMessage>
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
+    <GenericProperty>
+      <Key>895bafd0-aff9-4710-8319-12af04838bc0</Key>
+      <Name>Next page</Name>
+      <Alias>nextPage</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="content">Content</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
   </GenericProperties>
   <Tabs>
     <Tab>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -27,6 +27,22 @@
   <Structure />
   <GenericProperties>
     <GenericProperty>
+      <Key>0e4b312b-6e89-411f-839c-8770993470e9</Key>
+      <Name>Disabled</Name>
+      <Alias>disabled</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Adds aria-disabled="true" to the button. Your code should expect that the button may be used even in this state.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>dcd92fb5-669f-4be4-b4c0-efd622117d88</Key>
       <Name>Style of button</Name>
       <Alias>styleOfButton</Alias>

--- a/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/GOVUK/GovUkButton.cshtml
@@ -20,6 +20,7 @@
     if (buttonStyle.Contains("Warning")) { buttonStyle[buttonStyle.IndexOf("Warning")] = "govuk-button--warning"; }
     if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--reversed"; }
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
+    var disabled = Model.Settings.Value<bool>("disabled").ToString().ToLower();
 
-    <govuk-button class="@string.Join(' ', buttonStyle)@cssClasses" type="@buttonType" name="@modelPropertyName" id="@Model.Content.Key" value="@text">@text</govuk-button>
+    <govuk-button class="@string.Join(' ', buttonStyle)@cssClasses" type="@buttonType" name="@modelPropertyName" id="@Model.Content.Key" value="@text" aria-disabled="@disabled">@text</govuk-button>
 }

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -27,6 +27,22 @@
   <Structure />
   <GenericProperties>
     <GenericProperty>
+      <Key>0e4b312b-6e89-411f-839c-8770993470e9</Key>
+      <Name>Disabled</Name>
+      <Alias>disabled</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Adds aria-disabled="true" to the button. Your code should expect that the button may be used even in this state.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>dcd92fb5-669f-4be4-b4c0-efd622117d88</Key>
       <Name>Style of button</Name>
       <Alias>styleOfButton</Alias>


### PR DESCRIPTION
Disabling buttons is done using the `aria-disabled` rather than the `disabled` attribute so that they are discoverable by users with vision impairments even when disabled.

Add JavaScript to prevent activating primary buttons for most users when submitting a form to the server. Secondary buttons always require JavaScript so they should handle the disabled behaviour themselves. Primary buttons that need additional JavaScript would also need to handle it themselves to avoid a race condition between two event handlers.

Extends the 'Button' example page with a submit action so that the prevented submit can be tested.

[AB#151932](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/151932)