### PR TITLE
Allow links and line breaks in the TPR context bar 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprContextBar.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/ComponentGenerator.TprContextBar.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
 {
@@ -8,30 +7,34 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
     {
         internal const string TprContextBarElement = "div";
 
-        public virtual TagBuilder GenerateTprContextBar(
-            string? context1,
-            string? context2,
-            string? context3,
-            AttributeDictionary? attributes)
+        public virtual TagBuilder GenerateTprContextBar(TprContextBar tprContextBar)
         {
             var tagBuilder = new TagBuilder(TprContextBarElement);
-            if (attributes != null) tagBuilder.MergeAttributes(attributes);
+            if (tprContextBar.ContextBarAttributes != null) tagBuilder.MergeAttributes(tprContextBar.ContextBarAttributes);
             tagBuilder.MergeCssClass("tpr-context");
 
             var inner = new TagBuilder("div");
             inner.MergeCssClass("govuk-width-container");
             inner.MergeCssClass("tpr-context__inner");
 
-            var hasContext1 = !string.IsNullOrWhiteSpace(context1);
-            var hasContext2 = !string.IsNullOrWhiteSpace(context2);
-            var hasContext3 = !string.IsNullOrWhiteSpace(context3);
+            var hasContext1 = !string.IsNullOrWhiteSpace(tprContextBar.Context1Content?.ToString());
+            var hasContext2 = !string.IsNullOrWhiteSpace(tprContextBar.Context2Content?.ToString());
+            var hasContext3 = !string.IsNullOrWhiteSpace(tprContextBar.Context3Content?.ToString());
 
             var context1Element = new TagBuilder("div");
+            if (tprContextBar.Context1Attributes != null) { context1Element.MergeAttributes(tprContextBar.Context1Attributes); }
             context1Element.MergeCssClass("govuk-body");
             context1Element.MergeCssClass("tpr-context__context-1");
             if (hasContext1)
             {
-                context1Element.InnerHtml.Append(context1!);
+                if (tprContextBar.Context1AllowHtml)
+                {
+                    context1Element.InnerHtml.AppendHtml(tprContextBar.Context1Content!);
+                }
+                else
+                {
+                    context1Element.InnerHtml.Append(tprContextBar.Context1Content!.ToString()!);
+                }
             }
             inner.InnerHtml.AppendHtml(context1Element);
 
@@ -47,23 +50,41 @@ namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
             }
 
             var context2Element = new TagBuilder("div");
+            if (tprContextBar.Context2Attributes != null) { context2Element.MergeAttributes(tprContextBar.Context2Attributes); }
             context2Element.MergeCssClass("govuk-body");
             context2Element.MergeCssClass("tpr-context__context-2");
             if (hasContext2)
             {
-                context2Element.InnerHtml.Append(context2!);
+                if (tprContextBar.Context2AllowHtml)
+                {
+                    var context2Inner = new TagBuilder("div");
+                    context2Inner.InnerHtml.AppendHtml(tprContextBar.Context2Content!);
+                    context2Element.InnerHtml.AppendHtml(context2Inner);
+                }
+                else
+                {
+                    context2Element.InnerHtml.Append(tprContextBar.Context2Content!.ToString()!);
+                }
             }
             context23container.InnerHtml.AppendHtml(context2Element);
 
             if (hasContext3)
             {
                 var context3Element = new TagBuilder("div");
+                if (tprContextBar.Context3Attributes != null) { context3Element.MergeAttributes(tprContextBar.Context3Attributes); }
                 context3Element.MergeCssClass("govuk-body");
                 context3Element.MergeCssClass("tpr-context__context-3");
 
                 var context3InnerElement = new TagBuilder("div");
                 context3InnerElement.MergeCssClass("tpr-context__context-3-inner");
-                context3InnerElement.InnerHtml.Append(context3!);
+                if (tprContextBar.Context3AllowHtml)
+                {
+                    context3InnerElement.InnerHtml.AppendHtml(tprContextBar.Context3Content!);
+                }
+                else
+                {
+                    context3InnerElement.InnerHtml.Append(tprContextBar.Context3Content!.ToString()!);
+                }
                 context3Element.InnerHtml.AppendHtml(context3InnerElement);
                 context23container.InnerHtml.AppendHtml(context3Element);
             }

--- a/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/TprContextBar.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/HtmlGeneration/TprContextBar.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
+{
+    public class TprContextBar
+    {
+        public AttributeDictionary? ContextBarAttributes { get; set; }
+        public AttributeDictionary? Context1Attributes { get; set; }
+        public IHtmlContent? Context1Content { get; set; }
+        public bool Context1AllowHtml { get; set; }
+        public AttributeDictionary? Context2Attributes { get; set; }
+        public IHtmlContent? Context2Content { get; set; }
+        public bool Context2AllowHtml { get; set; }
+        public AttributeDictionary? Context3Attributes { get; set; }
+        public IHtmlContent? Context3Content { get; set; }
+        public bool Context3AllowHtml { get; set; }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/IGovUkHtmlGenerator.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/IGovUkHtmlGenerator.cs
@@ -12,7 +12,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions
         TagBuilder GenerateBackToMenu(string href, IHtmlContent content, AttributeDictionary? attributes);
         TagBuilder GenerateTprHeaderBar(string? logoHref, string logoAlt, string? label, IHtmlContent? content, AttributeDictionary? attributes);
         TagBuilder GenerateTprFooterBar(string? logoHref, string logoAlt, IHtmlContent? content, string copyright, AttributeDictionary? attributes);
-        TagBuilder GenerateTprContextBar(string? context1, string? context2, string? context3, AttributeDictionary? attributes);
+        TagBuilder GenerateTprContextBar(TprContextBar tprContextBar);
         TagBuilder GenerateTaskList(AttributeDictionary? attributes, IEnumerable<TaskListTask> tasks);
         TagBuilder GenerateTaskListSummary(TaskListSummary taskListSummary);
         TagBuilder GenerateSummaryCard(SummaryCard summaryCard);

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-header.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-header.scss
@@ -162,6 +162,14 @@ $tpr-header-left-width-xl: 200px;
     margin: 0;
 }
 
+.tpr-context .govuk-link:link, .tpr-context .govuk-link:visited {
+    color: $tpr-colour-white;
+}
+.tpr-context .govuk-link:focus {
+    color: $govuk-focus-text-colour;
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $tpr-colour-blue-marguerite;
+}
+
 // Required when the text inside .tpr-context__context-2 is short.
 .tpr-context__container {
     width: 100%; 

--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
+{
+    internal class TprContextBarContext
+    {
+        private (AttributeDictionary Attributes, IHtmlContent Content, bool AllowHtml)[] _content = new (AttributeDictionary, IHtmlContent, bool)[3];
+
+        public AttributeDictionary Context1Attributes => _content[0].Attributes;
+        public IHtmlContent? Context1Content => _content[0].Content;
+        public bool Context1AllowHtml => _content[0].AllowHtml;
+        public AttributeDictionary Context2Attributes => _content[1].Attributes;
+        public IHtmlContent? Context2Content => _content[1].Content;
+        public bool Context2AllowHtml => _content[1].AllowHtml;
+        public AttributeDictionary Context3Attributes => _content[2].Attributes;
+        public IHtmlContent? Context3Content => _content[2].Content;
+        public bool Context3AllowHtml => _content[2].AllowHtml;
+
+        public void SetContext(int contextBarContextId, AttributeDictionary attributes, IHtmlContent content, bool allowHtml)
+        {
+            Guard.ArgumentValid(nameof(contextBarContextId), $"{nameof(contextBarContextId)} must be between 1 and 3", contextBarContextId >= 1 && contextBarContextId <= 3);
+            Guard.ArgumentNotNull(nameof(content), content);
+
+            if (_content[contextBarContextId - 1].Content != null)
+            {
+                throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                    TprContextBarTagHelper.TagName + "-context-" + contextBarContextId,
+                    TprContextBarTagHelper.TagName);
+            }
+
+            _content[contextBarContextId - 1] = (attributes, content, allowHtml);
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext1TagHelper.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext1TagHelper.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
+{
+    /// <summary>
+    /// Represents the context 1 area within the TPR context bar component.
+    /// </summary>
+    [HtmlTargetElement(TagName, ParentTag = TprContextBarTagHelper.TagName)]
+    public class TprContextBarContext1TagHelper : TprContextBarContextTagHelperBase
+    {
+        internal const string TagName = "tpr-context-bar-context-1";
+
+        public TprContextBarContext1TagHelper() : base(1) { }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext2TagHelper.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext2TagHelper.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
+{
+    /// <summary>
+    /// Represents the context 2 area within the TPR context bar component.
+    /// </summary>
+    [HtmlTargetElement(TagName, ParentTag = TprContextBarTagHelper.TagName)]
+    public class TprContextBarContext2TagHelper : TprContextBarContextTagHelperBase
+    {
+        internal const string TagName = "tpr-context-bar-context-2";
+
+        public TprContextBarContext2TagHelper() : base(2) { }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext3TagHelper.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContext3TagHelper.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
+{
+    /// <summary>
+    /// Represents the context 3 area within the TPR context bar component.
+    /// </summary>
+    [HtmlTargetElement(TagName, ParentTag = TprContextBarTagHelper.TagName)]
+    public class TprContextBarContext3TagHelper : TprContextBarContextTagHelperBase
+    {
+        internal const string TagName = "tpr-context-bar-context-3";
+
+        public TprContextBarContext3TagHelper() : base(3) { }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContextTagHelperBase.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarContextTagHelperBase.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Threading.Tasks;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
+{
+    /// <summary>
+    /// Represents a context within the TPR context bar component.
+    /// </summary>
+    public abstract class TprContextBarContextTagHelperBase : TagHelper
+    {
+        private readonly int _contextBarContextId;
+
+        /// <summary>
+        /// Gets or sets whether to allow HTML content.
+        /// </summary>
+        [HtmlAttributeName("allow-html")]
+        public bool AllowHtml { get; set; }
+
+        protected TprContextBarContextTagHelperBase(int contextBarContextId)
+        {
+            _contextBarContextId = contextBarContextId;
+        }
+
+        /// <inheritdoc/>
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var barContext = context.GetContextItem<TprContextBarContext>();
+
+            var childContent = await output.GetChildContentAsync();
+
+            barContext.SetContext(_contextBarContextId, output.Attributes.ToAttributeDictionary(), childContent.Snapshot(), AllowHtml);
+
+            output.SuppressOutput();
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarTagHelper.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarTagHelper.cs
@@ -1,6 +1,9 @@
 using GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using System;
+using System.Threading.Tasks;
 
 namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
 {
@@ -8,6 +11,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
     /// Generates a TPR context bar component
     /// </summary>
     [HtmlTargetElement(TagName)]
+    [RestrictChildren(TprContextBarContext1TagHelper.TagName, TprContextBarContext2TagHelper.TagName, TprContextBarContext3TagHelper.TagName)]
     [OutputElementHint(ComponentGenerator.TprContextBarElement)]
     public class TprContextBarTagHelper : TagHelper
     {
@@ -35,27 +39,53 @@ namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
         /// <summary>
         /// The text displayed at the left of the context bar.
         /// </summary>
+        [Obsolete($"Use {TprContextBarContext1TagHelper.TagName} child tag helper")]
         [HtmlAttributeName(Context1AttributeName)]
         public string? Context1 { get; set; }
 
         /// <summary>
         /// The text displayed in the middle of the context bar.
         /// </summary>
+        [Obsolete($"Use {TprContextBarContext2TagHelper.TagName} child tag helper")]
         [HtmlAttributeName(Context2AttributeName)]
         public string? Context2 { get; set; }
 
         /// <summary>
         /// The text displayed at the right of the context bar.
         /// </summary>
+        [Obsolete($"Use {TprContextBarContext3TagHelper.TagName} child tag helper")]
         [HtmlAttributeName(Context3AttributeName)]
         public string? Context3 { get; set; }
 
         /// <inheritdoc/>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
-            if (!string.IsNullOrWhiteSpace(Context1) || !string.IsNullOrWhiteSpace(Context2) || !string.IsNullOrWhiteSpace(Context3))
+            var barContext = new TprContextBarContext();
+
+            using (context.SetScopedContextItem(barContext))
             {
-                var tagBuilder = _htmlGenerator.GenerateTprContextBar(Context1, Context2, Context3, output.Attributes.ToAttributeDictionary());
+                await output.GetChildContentAsync();
+            }
+
+            var context1Content = barContext.Context1Content != null ? barContext.Context1Content : new HtmlString(Context1);
+            var context2Content = barContext.Context2Content != null ? barContext.Context2Content : new HtmlString(Context2);
+            var context3Content = barContext.Context3Content != null ? barContext.Context3Content : new HtmlString(Context3);
+
+            if (!string.IsNullOrWhiteSpace(context1Content.ToString()) || !string.IsNullOrWhiteSpace(context2Content.ToString()) || !string.IsNullOrWhiteSpace(context3Content.ToString()))
+            {
+                var tagBuilder = _htmlGenerator.GenerateTprContextBar(new TprContextBar
+                {
+                    ContextBarAttributes = output.Attributes.ToAttributeDictionary(),
+                    Context1Attributes = barContext.Context1Attributes,
+                    Context1Content = context1Content,
+                    Context1AllowHtml = barContext.Context1AllowHtml,
+                    Context2Attributes = barContext.Context2Attributes,
+                    Context2Content = context2Content,
+                    Context2AllowHtml = barContext.Context2AllowHtml,
+                    Context3Attributes = barContext.Context3Attributes,
+                    Context3Content = context3Content,
+                    Context3AllowHtml = barContext.Context3AllowHtml
+                });
 
                 output.TagName = tagBuilder.TagName;
                 output.TagMode = TagMode.StartTagAndEndTag;

--- a/GovUk.Frontend.ExampleApp/Views/Shared/_Layout.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Shared/_Layout.cshtml
@@ -19,7 +19,11 @@
             <a class="govuk-link" href="#">A link</a>
             <a class="govuk-link" href="#">Another link</a>
         </tpr-header-bar>
-        <tpr-context-bar context-1="Example app" context-2="Something being edited with a very long name that will always wrap even at full width" context-3="ID: 12345678" />
+        <tpr-context-bar>
+            <tpr-context-bar-context-1>Example app</tpr-context-bar-context-1>
+            <tpr-context-bar-context-2>Something being edited with a very long name that will always wrap even at full width</tpr-context-bar-context-2>
+            <tpr-context-bar-context-3>ID: 12345678</tpr-context-bar-context-3>
+        </tpr-context-bar>
         @RenderSection("language", required: false)
     </header>
     <div class="tpr-main-wrapper">

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
@@ -34,7 +34,11 @@
         <tpr-header-bar logo-alt="@headerLogoAlt" logo-href="@(home?.Value<Link>("tprHeaderLogoHref")?.Url)" label="@(home?.Value<string?>("tprHeaderLabel"))">
             @Html.Raw(GovUkTypography.Apply(home?.Value("tprHeaderContent")?.ToString(), new TypographyOptions{ RemoveWrappingParagraphs = true }))
         </tpr-header-bar>
-        <tpr-context-bar context-1="@(home?.Value<string>("tprContext1"))" context-2="@(home?.Value<string>("tprContext2"))" context-3="@(home?.Value<string>("tprContext3"))" />
+        <tpr-context-bar>
+            <tpr-context-bar-context-1 allow-html="true">@Html.Raw(GovUkTypography.Apply(home?.Value<string>("tprContext1"), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-1>
+            <tpr-context-bar-context-2 allow-html="true">@Html.Raw(GovUkTypography.Apply(home?.Value<string>("tprContext2"), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-2>
+            <tpr-context-bar-context-3 allow-html="true">@Html.Raw(GovUkTypography.Apply(home?.Value<string>("tprContext3"), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-3>
+        </tpr-context-bar>
     </header>
     <div class="tpr-main-wrapper">
         <div class="govuk-width-container">

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprcontextbar1.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprcontextbar1.config
@@ -25,8 +25,8 @@
       <Key>fee49ef6-eeb6-4ce1-8877-2f801428e393</Key>
       <Name>Context 1</Name>
       <Alias>tprContext1</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Umbraco.TinyMCE</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[Typically the name of the application or the mode it's in.]]></Description>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprcontextbar2.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprcontextbar2.config
@@ -25,8 +25,8 @@
       <Key>188adfab-e29d-4863-97dd-f25ad5f606aa</Key>
       <Name>Context 2</Name>
       <Alias>tprContext2</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Umbraco.TinyMCE</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[Typically the name of the entity being edited in the application.]]></Description>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprcontextbar3.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprcontextbar3.config
@@ -25,8 +25,8 @@
       <Key>e166aa7c-231d-4d06-b4a3-3ccaa76ed17c</Key>
       <Name>Context 3</Name>
       <Alias>tprContext3</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Umbraco.TinyMCE</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[Typically a reference number for the entity being edited in the application.]]></Description>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/tprcontextbar1.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/tprcontextbar1.config
@@ -25,8 +25,8 @@
       <Key>fee49ef6-eeb6-4ce1-8877-2f801428e393</Key>
       <Name>Context 1</Name>
       <Alias>tprContext1</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Umbraco.TinyMCE</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[Typically the name of the application or the mode it's in.]]></Description>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/tprcontextbar2.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/tprcontextbar2.config
@@ -25,8 +25,8 @@
       <Key>188adfab-e29d-4863-97dd-f25ad5f606aa</Key>
       <Name>Context 2</Name>
       <Alias>tprContext2</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Umbraco.TinyMCE</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[Typically the name of the entity being edited in the application.]]></Description>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/tprcontextbar3.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/tprcontextbar3.config
@@ -25,8 +25,8 @@
       <Key>e166aa7c-231d-4d06-b4a3-3ccaa76ed17c</Key>
       <Name>Context 3</Name>
       <Alias>tprContext3</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Umbraco.TinyMCE</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[Typically a reference number for the entity being edited in the application.]]></Description>


### PR DESCRIPTION
Separate requirements have arisen to support links in the 'Context 2' area and a line break in the 'Context 3' area of the TPR header.

This PR enables this as a non-breaking change. The existing `context-*` properties remain but are deprecated. New child tag helpers replace them, and support an `allow-html` attribute that prevents escaping the HTML when required.

In Umbraco the property editors for all three context bar regions are changed to a rich text editor with minimal formatting buttons. and the example app shows a header with HTML enabled.

## Context bar including a link and line break
![Context bar including a link and line break](https://user-images.githubusercontent.com/1260550/225957284-1a0da55c-85bb-4496-8df5-9893d9a07087.png)

## Context bar including a link in its focus state
![Context bar including a link in its focus state](https://user-images.githubusercontent.com/1260550/225957386-b415b87f-0c1d-45e6-9454-9841b8979aff.png)


[AB#148981](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/148981)