### PR TITLE
A partial view to implement GOV.UK guidance on pagination (project refs)

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -260,4 +260,8 @@
 	  <UpToDateCheckInput Remove="Styles\_tpr-summary-card.scss" />
 	</ItemGroup>
 	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_govuk-pagination.scss" />
+	</ItemGroup>
+	
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/Models/PaginationModel.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Models/PaginationModel.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.Models
+{
+    /// <summary>
+    /// Configuration settings for an instance of the GOV.UK Design System Pagination component.
+    /// </summary>
+    public class PaginationModel
+    {
+        /// <summary>
+        /// The current page.
+        /// </summary>
+        public int PageNumber { get; set; } = 1;
+
+        /// <summary>
+        /// The number of items per page. If <c>null</c> then pagination is not active.
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// The total number of items to be paginated.
+        /// </summary>
+        public int TotalItems { get; set; }
+
+        /// <summary>
+        /// The total number of pages based on <see cref="TotalItems"/> and <see cref="PageSize"/>
+        /// </summary>
+        public int TotalPages()
+        {
+            if (!PageSize.HasValue)
+            {
+                return 1;
+            }
+            return (int)Math.Ceiling((decimal)TotalItems / PageSize.Value);
+        }
+
+        /// <summary>
+        /// The label for the navigation landmark that wraps the pagination.
+        /// </summary>
+        public string LandmarkLabel = "results";
+
+        /// <summary>
+        /// The link label which adds context to the 'Previous' link when there is a small number of pages.
+        /// </summary>
+        /// <remarks>{{page}} is replaced with the number of the previous page and {{total}} is replaced with the total number of pages</remarks>
+        public string PreviousPageLabel = "{{page}} of {{total}}";
+
+        /// <summary>
+        /// The link label which adds context to the 'Next' link when there is a small number of pages.
+        /// </summary>
+        /// <remarks>{{page}} is replaced with the number of the next page and {{total}} is replaced with the total number of pages</remarks>
+        public string NextPageLabel = "{{page}} of {{total}}";
+
+        /// <summary>
+        /// The aria-label which gives more context to links which point to individual pages by their page number alone.
+        /// </summary>
+        /// <remarks>{{page}} is replaced with the number of the page</remarks>
+        public string PageVisuallyHiddenText = "Page {{page}}";
+
+        /// <summary>
+        /// The name of the query string parameter used to indicate the current page.
+        /// </summary>
+        public string QueryStringParameter { get; set; } = "page";
+
+        /// <summary>
+        /// The GOV.UK Design System recommends a different styles of pagination for small numbers of pages and large numbers of pages. This threshold controls when the style changes.
+        /// </summary>
+        public int LargeNumberOfPagesThreshold { get; set; } = 10;
+
+        /// <summary>
+        /// The path that page links should target, if different from the path of the current request.
+        /// </summary>
+        public PathString? Path { get; set; }
+
+        /// <summary>
+        /// The querystring that page links should target, if different from the querystring of the current request.
+        /// </summary>
+        public QueryString? QueryString { get; set; }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Models/PaginationModel.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Models/PaginationModel.cs
@@ -28,7 +28,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Models
         /// </summary>
         public int TotalPages()
         {
-            if (!PageSize.HasValue)
+            if (!PageSize.HasValue || PageSize <= 0 || TotalItems <= 0)
             {
                 return 1;
             }

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-pagination.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-pagination.scss
@@ -1,0 +1,15 @@
+﻿/* Fix a bug in GovUk.Frontend.AspNetCore 1.0.0-beta4 where there is a missing space character after the SVG. 
+   Add the spacing using CSS instead. */
+.govuk-pagination--block .govuk-pagination__icon--prev,
+.govuk-pagination--block .govuk-pagination__icon--next {
+    margin-right: 15px;
+}
+
+/* GOV.UK Design System documentation says not to show the ellipsis on small screens but govuk-frontend
+   doesn't implement that.
+*/
+@include govuk-media-query($until: tablet) {
+    .govuk-pagination__item--ellipses {
+        display: none;
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
@@ -31,5 +31,6 @@
 @import "govuk/components/warning-text";
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";
+@import "_govuk-pagination.scss";
 @import "_govuk-summary-card.scss";
 @import "_govuk-task-list.scss";

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
@@ -31,6 +31,7 @@
 @import "govuk/components/warning-text";
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";
+@import "_govuk-pagination.scss";
 @import "_govuk-summary-card.scss";
 @import "_govuk-task-list.scss";
 

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/Pagination.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/Pagination.cshtml
@@ -1,0 +1,90 @@
+﻿@using System.Globalization;
+@using System.Web;
+@addTagHelper *, GovUk.Frontend.AspNetCore
+@model GovUk.Frontend.AspNetCore.Extensions.Models.PaginationModel
+@if (Model != null && Model.PageSize.HasValue && Model.TotalItems > Model.PageSize)
+{
+    var path = Model.Path ?? Context.Request.Path;
+    var queryString = Model.QueryString ?? Context.Request.QueryString;
+    var query = HttpUtility.ParseQueryString(queryString.ToString());
+    query.Remove(Model.QueryStringParameter);
+
+    var totalPages = (int)Math.Ceiling((decimal)Model.TotalItems / Model.PageSize.Value);
+    var previousPage = Model.PageNumber - 1;
+    var nextPage = Model.PageNumber + 1;
+
+    var page1Href = path + (query.Count > 0 ? "?" + query.ToString() : string.Empty);
+    var previousHref = page1Href;
+    if (previousPage > 1)
+    {
+        query[Model.QueryStringParameter] = previousPage.ToString(CultureInfo.InvariantCulture);
+        previousHref = path + "?" + query.ToString();
+    }
+    query[Model.QueryStringParameter] = nextPage.ToString(CultureInfo.InvariantCulture);
+    var nextHref = path + "?" + query.ToString();
+
+    if (totalPages <= Model.LargeNumberOfPagesThreshold)
+    {
+        <govuk-pagination landmark-label="@Model.LandmarkLabel">
+            @if (Model.PageNumber > 1)
+            {
+                var previousLabel = Model.PreviousPageLabel.Replace("{{page}}", previousPage.ToString(CultureInfo.InvariantCulture)).Replace("{{total}}", totalPages.ToString(CultureInfo.InvariantCulture));
+                <govuk-pagination-previous href="@Html.Raw(previousHref)" label-text="@previousLabel" />
+            }
+            @if (Model.PageNumber * Model.PageSize < Model.TotalItems)
+            {
+                var nextLabel = Model.NextPageLabel.Replace("{{page}}", nextPage.ToString(CultureInfo.InvariantCulture)).Replace("{{total}}", totalPages.ToString(CultureInfo.InvariantCulture));
+                <govuk-pagination-next href="@Html.Raw(nextHref)" label-text="@nextLabel" />
+            }
+        </govuk-pagination>
+    }
+    else
+    {
+        <govuk-pagination landmark-label="@Model.LandmarkLabel">
+            @if (Model.PageNumber > 1)
+            {
+                <govuk-pagination-previous href="@Html.Raw(previousHref)" />
+                <govuk-pagination-item visually-hidden-text="@(Model.PageVisuallyHiddenText.Replace("{{page}}", "1"))" href="@Html.Raw(page1Href)">1</govuk-pagination-item>
+                @if (Model.PageNumber > 2)
+                {
+                    if ((previousPage - 1) > 1)
+                    {
+                        if ((previousPage -2) == 1)
+                        {
+                            query[Model.QueryStringParameter] = (previousPage - 1).ToString(CultureInfo.InvariantCulture);
+                            <govuk-pagination-item visually-hidden-text="@(Model.PageVisuallyHiddenText.Replace("{{page}}", (previousPage - 1).ToString(CultureInfo.InvariantCulture)))" href="@Html.Raw(path + "?" + query.ToString())">@(previousPage - 1)</govuk-pagination-item>
+                        }
+                        else
+                        {
+                            <govuk-pagination-ellipsis />
+                        }
+                    }
+                    <govuk-pagination-item visually-hidden-text="@(Model.PageVisuallyHiddenText.Replace("{{page}}", previousPage.ToString(CultureInfo.InvariantCulture)))" href="@Html.Raw(previousHref)">@previousPage</govuk-pagination-item>
+                }
+            }
+            <govuk-pagination-item is-current="true" href="@(Model.Path + Model.QueryString)">@Model.PageNumber</govuk-pagination-item>
+            @if (Model.PageNumber * Model.PageSize < Model.TotalItems)
+            {
+                <govuk-pagination-item visually-hidden-text="@(Model.PageVisuallyHiddenText.Replace("{{page}}", nextPage.ToString(CultureInfo.InvariantCulture)))" href="@Html.Raw(nextHref)">@nextPage</govuk-pagination-item>
+                @if (totalPages > nextPage)
+                {
+                    if (totalPages > nextPage + 1)
+                    {
+                        if (totalPages == nextPage + 2)
+                        {
+                            query[Model.QueryStringParameter] = (nextPage+1).ToString(CultureInfo.InvariantCulture);
+                            <govuk-pagination-item visually-hidden-text="@(Model.PageVisuallyHiddenText.Replace("{{page}}", (nextPage +1).ToString(CultureInfo.InvariantCulture)))" href="@Html.Raw(path + "?" + query.ToString())">@(nextPage + 1)</govuk-pagination-item>
+                        }
+                        else
+                        {
+                            <govuk-pagination-ellipsis />
+                        }
+                    }
+                    query[Model.QueryStringParameter] = totalPages.ToString(CultureInfo.InvariantCulture);
+                    <govuk-pagination-item visually-hidden-text="@(Model.PageVisuallyHiddenText.Replace("{{page}}", totalPages.ToString(CultureInfo.InvariantCulture)))" href="@Html.Raw(path + "?" + query.ToString())">@totalPages</govuk-pagination-item>
+                }
+                <govuk-pagination-next link-href="@Html.Raw(nextHref)" />
+            }
+        </govuk-pagination>
+    }
+ }

--- a/GovUk.Frontend.ExampleApp/Views/Pagination/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Pagination/Index.cshtml
@@ -1,14 +1,78 @@
-﻿@{
+﻿@using GovUk.Frontend.AspNetCore.Extensions.Models;
+@{
+    var pagination = new PaginationModel
+    {
+        PageNumber = 1,
+        PageSize = 10,
+        TotalItems = 50
+    };
+
+    if (Context.Request.Query.ContainsKey("page") && int.TryParse(Context.Request.Query["page"], out var pageNumber))
+    {
+        if (pageNumber >= 0)
+        {
+            pagination.PageNumber = pageNumber;
+        }
+    }
+
+    if (Context.Request.Query.ContainsKey("items") && int.TryParse(Context.Request.Query["items"], out var items))
+    {
+        if (items >= 0)
+        {
+            pagination.TotalItems = items;
+        }
+    }
+
+    var smallOrLarge = (pagination.TotalItems > (pagination.PageSize * 10)) ? "large" : "small";
+
     ViewData["Title"] = "Pagination";
+    if (pagination.TotalPages() > 1) { ViewData["Title"] += $" (page {pagination.PageNumber} of {pagination.TotalPages()})"; }
 }
 
-<span class="govuk-caption-xl">Example application</span>
-<h1 class="govuk-heading-l">@ViewData["Title"]</h1>
+<div class="govuk-grid-row govuk-grid-row--tpr-divider">
+    <div class="govuk-grid-column govuk-grid-column-full">
+        <span class="govuk-caption-xl">Example application</span>
+        <h1 class="govuk-heading-l">Pagination</h1>
+    </div>
+</div>
 
-<govuk-pagination>
-    <govuk-pagination-previous href="#" />
-    <govuk-pagination-item href="#">1</govuk-pagination-item>
-    <govuk-pagination-item href="#" is-current="true">2</govuk-pagination-item>
-    <govuk-pagination-item href="#">3</govuk-pagination-item>
-    <govuk-pagination-next href="#" />
-</govuk-pagination>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column govuk-grid-column-two-thirds-from-desktop">
+        <p class="govuk-body">
+            The GOV.UK Design System recommends using pagination differently depending on how many pages there are.
+            A pagination partial view expects a <i>PaginationModel</i> and applies this and other pagination logic for you.
+            See the Razor source of this page for an example.
+        </p>
+        <p class="govuk-body">
+            There are behaviours not covered by the partial view which you should implement:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>Redirect users to the first page if they enter a URL of a page that no longer exists.</li>
+            <li>Show the page number in the page &lt;title&gt; so that screen reader users know they’ve navigated to a different page. For example, ‘Search results (page 1 of 4)’.</li>
+        </ul>
+
+        @if (pagination.TotalItems > pagination.PageSize)
+        {
+            <h2 class="govuk-heading-m">Pagination for a @smallOrLarge number of pages</h2>
+            <partial name="GOVUK/Pagination" model="pagination" />
+        }
+        else
+        {
+            <h2 class="govuk-heading-m">Pagination for a single page of items</h2>
+            <p class="govuk-body">Pagination should not appear at all when there are not enough items for a second page.</p>
+        }
+
+        <h2 class="govuk-heading-m">Change the number of pages</h2>
+        <p class="govuk-body">This example displays 10 items per page. The pagination style changes when there are more than 10 pages.</p>
+    </div>
+</div>
+<form action="@Context.Request.Path" method="get">
+    <div class="govuk-grid-row govuk-grid-row--tpr-divider">
+        <div class="govuk-grid-column govuk-grid-column-two-thirds-from-desktop">
+            <govuk-input name="items" input-class="govuk-input--width-3" value="@pagination.TotalItems">
+                <govuk-input-label>Number of items</govuk-input-label>
+            </govuk-input>
+        </div>
+    </div>
+    <govuk-button>Submit</govuk-button>
+</form>


### PR DESCRIPTION
Pagination support so far has been just importing the styles and using the basic component from govuk-frontend-aspnetcore.

This adds a partial view which implements the paging logic, including guidance from the GOV.UK Design System, so that it does not need to be reimplemented in each application.

It also updates the example page in the ASP.NET example app to use the new partial view and explain what other implementation steps an application would need.

[AB#151609](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/151609)