### PR TITLE
Do not include character count error in error summary - develop

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -6,7 +6,7 @@
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 		<IncludeRazorContentInPack>true</IncludeRazorContentInPack>
 		<Nullable>enable</Nullable>
-		<Version>3.0.0</Version>
+		<Version>3.0.1</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
@@ -111,7 +111,7 @@ function createGovUkValidator() {
       const currentErrors = [].slice.call(list.querySelectorAll("a"));
 
       const updatedErrors = [].slice
-        .call(document.querySelectorAll(".govuk-error-message"))
+        .call(document.querySelectorAll(".govuk-error-message:not(.govuk-character-count__status)"))
         .map(function (error) {
           const link = document.createElement("a");
           const prefix = error.querySelector(".govuk-visually-hidden");


### PR DESCRIPTION
When a user has exceeded the maximum number of characters allowed in a text area, two error messages appear in the error summary.  These error messages describe the same problem, so only one should be there. 

Also, there was an issue with the second error message where it would not link to the text area.
## Before
![image](https://user-images.githubusercontent.com/25232112/230439554-288a7cb0-f955-434b-beec-f6c688ec5eb8.png)
## After
![image](https://user-images.githubusercontent.com/25232112/230439644-b4f57ca8-b455-48e3-973c-49d066c337d7.png)
