### PR TITLE
Expose internal mocks on UmbracoTestContext for more flexibility

### DIFF
--- a/GovUk.Frontend.Umbraco.Testing.Tests/GovUk.Frontend.Umbraco.Testing.Tests.csproj
+++ b/GovUk.Frontend.Umbraco.Testing.Tests/GovUk.Frontend.Umbraco.Testing.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GovUk.Frontend.Umbraco.Testing\GovUk.Frontend.Umbraco.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GovUk.Frontend.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
+++ b/GovUk.Frontend.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Security.Claims;
+using System.Security.Principal;
+
+namespace GovUk.Frontend.Umbraco.Testing.Tests
+{
+    [TestFixture]
+    public class UmbracoTestContextTests
+    {
+        [Test]
+        public void Can_mock_authenticated_HttpContext_User()
+        {
+            var testContext = new UmbracoTestContext();
+
+            testContext.CurrentIdentity.Setup(x => x.IsAuthenticated).Returns(true);
+
+            Assert.True(testContext.HttpContext.Object.User.Identity?.IsAuthenticated ?? false);
+        }
+
+        [Test]
+        public void Can_mock_authenticated_HttpContext_User_with_claims()
+        {
+            var testContext = new UmbracoTestContext();
+
+            var identity = new ClaimsIdentity(new Claim[] { new Claim("type1", "value1"), new Claim("type2", "value2") }, "any string makes IsAuthenticated return true");
+            testContext.CurrentPrincipal = new GenericPrincipal(identity, Array.Empty<string>());
+
+            Assert.True(testContext.HttpContext.Object.User.Claims.Count() > 0);
+            Assert.True(testContext.HttpContext.Object.User.Identity?.IsAuthenticated ?? false);
+            Assert.That(testContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
+++ b/GovUk.Frontend.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using System.Security.Principal;
 
 namespace GovUk.Frontend.Umbraco.Testing.Tests
@@ -27,6 +28,27 @@ namespace GovUk.Frontend.Umbraco.Testing.Tests
             Assert.True(testContext.HttpContext.Object.User.Claims.Count() > 0);
             Assert.True(testContext.HttpContext.Object.User.Identity?.IsAuthenticated ?? false);
             Assert.That(testContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
+        }
+
+        private class DummyController : Controller
+        { }
+
+        [Test]
+        public void Can_call_claims_from_controller()
+        {
+            var testContext = new UmbracoTestContext();
+
+            var identity = new ClaimsIdentity(new Claim[] { new Claim("type1", "value1"), new Claim("type2", "value2") }, "any string makes IsAuthenticated return true");
+            testContext.CurrentPrincipal = new GenericPrincipal(identity, Array.Empty<string>());
+
+            var controllerContext = testContext.ControllerContext;
+
+            var controller = new DummyController();
+            controller.ControllerContext = controllerContext;
+
+            var claims = controller.User.Claims;
+
+            Assert.That(claims.Count(), Is.EqualTo(2));
         }
     }
 }

--- a/GovUk.Frontend.Umbraco.Testing.Tests/Usings.cs
+++ b/GovUk.Frontend.Umbraco.Testing.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/GovUk.Frontend.Umbraco.Testing/GovUk.Frontend.Umbraco.Testing.csproj
+++ b/GovUk.Frontend.Umbraco.Testing/GovUk.Frontend.Umbraco.Testing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-	<Version>3.0.0</Version>
+	<Version>3.1.0</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		    This will help identify breaking changes where the major version should change. -->
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.sln
+++ b/GovUk.Frontend.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUk.Frontend.ExampleShare
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUk.Frontend.Umbraco.Testing", "GovUk.Frontend.Umbraco.Testing\GovUk.Frontend.Umbraco.Testing.csproj", "{94C814E0-28CB-48B4-9C31-D29F611EFF4D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Frontend.Umbraco.Testing.Tests", "GovUk.Frontend.Umbraco.Testing.Tests\GovUk.Frontend.Umbraco.Testing.Tests.csproj", "{1EE40980-0B7B-4ABE-9114-FBB0903473DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{94C814E0-28CB-48B4-9C31-D29F611EFF4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94C814E0-28CB-48B4-9C31-D29F611EFF4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{94C814E0-28CB-48B4-9C31-D29F611EFF4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EE40980-0B7B-4ABE-9114-FBB0903473DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EE40980-0B7B-4ABE-9114-FBB0903473DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EE40980-0B7B-4ABE-9114-FBB0903473DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EE40980-0B7B-4ABE-9114-FBB0903473DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
There were several mocks inside `UmbracoTestContext` which you couldn't access to setup methods and properties because they were not exposed outside that class. Expose them for tests to use.

It was possible to mock a user with claims on `HttpContext` but it required knowledge of the internals of `UmbracoTestContext` to do properly. Make it easier by allowing tests to just set the `CurrentPrincipal` to a new one.

Add a new tests project for the test helpers library, and start testing `UmbracoTestContext` by testing the ability to mock a user with claims.

[AB#154422](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/154422)