### PR TITLE
Add test for accessing Claims from controller #154422

### DIFF
--- a/GovUk.Frontend.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
+++ b/GovUk.Frontend.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using System.Security.Principal;
 
 namespace GovUk.Frontend.Umbraco.Testing.Tests
@@ -27,6 +28,27 @@ namespace GovUk.Frontend.Umbraco.Testing.Tests
             Assert.True(testContext.HttpContext.Object.User.Claims.Count() > 0);
             Assert.True(testContext.HttpContext.Object.User.Identity?.IsAuthenticated ?? false);
             Assert.That(testContext.CurrentPrincipal, Is.EqualTo(Thread.CurrentPrincipal));
+        }
+
+        private class DummyController : Controller
+        { }
+
+        [Test]
+        public void Can_call_claims_from_controller()
+        {
+            var testContext = new UmbracoTestContext();
+
+            var identity = new ClaimsIdentity(new Claim[] { new Claim("type1", "value1"), new Claim("type2", "value2") }, "any string makes IsAuthenticated return true");
+            testContext.CurrentPrincipal = new GenericPrincipal(identity, Array.Empty<string>());
+
+            var controllerContext = testContext.ControllerContext;
+
+            var controller = new DummyController();
+            controller.ControllerContext = controllerContext;
+
+            var claims = controller.User.Claims;
+
+            Assert.That(claims.Count(), Is.EqualTo(2));
         }
     }
 }


### PR DESCRIPTION
Because
- We need to test that the UmbracoTestContext has been set up so that we can access the claims from a controller

The test also serves a documentation on how to use the claims with the UmbracoTestContext and a controller