### PR TITLE
Fix the check for TPR styles on the TPR header and footer demo page

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRHeader.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRHeader.cshtml
@@ -1,15 +1,17 @@
-﻿@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<HeaderFooterTpr>
+﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<HeaderFooterTpr>
+@using Microsoft.Extensions.Configuration;
+@using Umbraco.Cms.Web.Common.PublishedModels;
 @using GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration
 @using GovUk.Frontend.Umbraco.ExampleApp.Models
 @using GovUk.Frontend.Umbraco.Typography
 @using Umbraco.Cms.Core.Models
 @using Umbraco.Cms.Web.Common
+@inject IConfiguration Configuration
 @{
 	Layout = null;
     var home = Umbraco.ContentSingleAtXPath("//home");
     var settings = Umbraco.ContentSingleAtXPath("//settings");
-    var useTPRstyles = settings?.Value<bool>("useTPRstyles") ?? true;
+    var useTPRstyles = Configuration.GetValue<bool>("TPRStyles");
     var skipLink = string.IsNullOrEmpty(settings?.Value<string>("govukSkipLinkText")) ? "Skip to main content" : settings?.Value<string>("govukSkipLinkText");
     var headerLogoAlt = string.IsNullOrEmpty(settings?.Value<string>("tprHeaderLogoAlt")) ? ComponentGenerator.HeaderLogoDefaultAlt : settings?.Value<string>("tprHeaderLogoAlt");
     var footerLogoAlt = string.IsNullOrEmpty(settings?.Value<string>("tprFooterLogoAlt")) ? ComponentGenerator.FooterLogoDefaultAlt : settings?.Value<string>("tprFooterLogoAlt");

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/the-pensions-regulator-tpr-header-and-footer.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/the-pensions-regulator-tpr-header-and-footer.config
@@ -344,7 +344,7 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/016494c8a2674f5ca8e1df469b9eb52e",
-      "text": "<p>You have switched off TPR styles on the Settings page in the Umbraco backoffice to return to GOV.UK styling, so there is nothing to see on this page.</p>"
+      "text": "<p>You have switched off TPR styles in appsettings.json to return to GOV.UK styling, so there is nothing to see on this page.</p>"
     },
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",


### PR DESCRIPTION
In the Umbraco demo app the page demonstrating the Umbraco header & footer had not been updating following the move of the 'Use TPR styles' setting from Umbraco to appsettings.json. Only the demo app is affected by this fix.