### PR TITLE
DateRange attribute was not validating correctly in some daylight savings scenarios

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.Tests/DateRangeAttributeTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.Tests/DateRangeAttributeTests.cs
@@ -1,4 +1,5 @@
-﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
+﻿using FakeTimeZone;
+using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -9,20 +10,112 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
     [TestFixture]
     public class DateRangeAttributeTests
     {
-        private class ExampleModel<T>
+        private readonly TimeZoneInfo UkTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+
+        private class NoDaylightSavingsAtBoundaryModel<T>
         {
-            [DateRange("2023-01-01T00:00:00Z", "2023-12-31T23:59:00Z")]
+            // Range specified as a floating date/time (no time zone) as recommended for this validator, because the user is not inputing a time zone
+            [DateRange("2023-01-01T00:00:00", "2023-12-31T23:59:00")]
+            public T? Date { get; set; }
+
+        }
+
+        private class DaylightSavingsAtBoundaryModel<T>
+        {
+            // Range specified as a floating date/time (no time zone) as recommended for this validator, because the user is not inputing a time zone
+            [DateRange("2023-06-01T00:00:00", "2024-05-31T23:59:00")]
             public T? Date { get; set; }
         }
 
-        [TestCase("2022-12-31T23:59:00Z", false)]
-        [TestCase("2023-01-01T00:00:00Z", true)]
-        [TestCase("2023-12-31T23:59:00Z", true)]
-        [TestCase("2024-01-01T00:00:00Z", false)]
-        public void Validates_DateTime_property(string date, bool expected)
+        private class DaylightSavingsAtBoundaryModelWithTimeZone<T>
+        {
+            // Range specified with a time zone as it's typically returned from a database or DateTime.Now that way
+            [DateRange("2023-06-01T00:00:00Z", "2024-05-31T23:59:00Z")]
+            public T? Date { get; set; }
+        }
+
+        // Values specified as a floating date/time (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2022-12-31T23:59:00", false)]
+        [TestCase("2022-12-31", false)]
+        [TestCase("2023-01-01T00:00:00", true)]
+        [TestCase("2023-01-01", true)]
+        [TestCase("2023-06-01T00:00:00", true)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31T23:59:00", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-01-01T00:00:00", false)]
+        [TestCase("2024-01-01", false)]
+        public void Validates_DateTime_property_UK_runtime_environment_Range_boundary_outside_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(UkTimeZone))
+            {
+                TestDateTime(date, expected);
+            }
+        }
+
+        // Values specified as a floating date/time (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2022-12-31T23:59:00", false)]
+        [TestCase("2022-12-31", false)]
+        [TestCase("2023-01-01T00:00:00", true)]
+        [TestCase("2023-01-01", true)]
+        [TestCase("2023-06-01T00:00:00", true)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31T23:59:00", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-01-01T00:00:00", false)]
+        [TestCase("2024-01-01", false)]
+        public void Validates_DateTime_property_UTC_runtime_environment_Range_boundary_outside_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(TimeZoneInfo.Utc))
+            {
+                TestDateTime(date, expected);
+            }
+        }
+
+        // Values specified as a floating date/time (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2023-05-31T23:59:00", false)]
+        [TestCase("2023-05-31", false)]
+        [TestCase("2023-06-01T00:00:00", true)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31T23:59:00", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-05-31T23:59:00", true)]
+        [TestCase("2024-05-31", true)]
+        [TestCase("2024-06-01T00:00:00", false)]
+        [TestCase("2024-06-01", false)]
+        public void Validates_DateTime_property_UK_runtime_environment_Range_boundary_within_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(UkTimeZone))
+            {
+                TestDateTimeDaylightSavings(date, expected);
+                TestDateTimeDaylightSavingsWithTimeZone(date, expected);
+            }
+        }
+
+        // Values specified as a floating date/time (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2023-05-31T23:59:00", false)]
+        [TestCase("2023-05-31", false)]
+        [TestCase("2023-06-01T00:00:00", true)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31T23:59:00", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-05-31T23:59:00", true)]
+        [TestCase("2024-05-31", true)]
+        [TestCase("2024-06-01T00:00:00", false)]
+        [TestCase("2024-06-01", false)]
+        public void Validates_DateTime_property_UTC_runtime_environment_Range_boundary_within_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(TimeZoneInfo.Utc))
+            {
+                TestDateTimeDaylightSavings(date, expected);
+                TestDateTimeDaylightSavingsWithTimeZone(date, expected);
+            }
+        }
+
+        private static void TestDateTime(string date, bool expected)
         {
             // Arrange
-            var model = new ExampleModel<DateTime>
+            var model = new NoDaylightSavingsAtBoundaryModel<DateTime>
             {
                 Date = DateTime.Parse(date)
             };
@@ -34,14 +127,128 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Tests
             Assert.That(results.Count == 0, Is.EqualTo(expected));
         }
 
-        [TestCase("2022-12-31", false)]
-        [TestCase("2023-01-01", true)]
-        [TestCase("2023-12-31", true)]
-        [TestCase("2024-01-01", false)]
-        public void Validates_DateOnly_property(string date, bool expected)
+        private static void TestDateTimeDaylightSavings(string date, bool expected)
         {
             // Arrange
-            var model = new ExampleModel<DateOnly>
+            var model = new DaylightSavingsAtBoundaryModel<DateTime>
+            {
+                Date = DateTime.Parse(date)
+            };
+
+            // Act
+            var results = ValidateModel(model);
+
+            // Assert
+            Assert.That(results.Count == 0, Is.EqualTo(expected));
+        }
+
+        private static void TestDateTimeDaylightSavingsWithTimeZone(string date, bool expected)
+        {
+            // Arrange
+            var model = new DaylightSavingsAtBoundaryModelWithTimeZone<DateTime>
+            {
+                Date = DateTime.Parse(date)
+            };
+
+            // Act
+            var results = ValidateModel(model);
+
+            // Assert
+            Assert.That(results.Count == 0, Is.EqualTo(expected));
+        }
+
+        // Values specified as a floating date (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2022-12-31", false)]
+        [TestCase("2023-01-01", true)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-01-01", false)]
+        public void Validates_DateOnly_property_UK_runtime_environment_Range_boundary_outside_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(UkTimeZone))
+            {
+                TestDateOnly(date, expected);
+            }
+        }
+
+        // Values specified as a floating date (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2022-12-31", false)]
+        [TestCase("2023-01-01", true)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-01-01", false)]
+        public void Validates_DateOnly_property_UTC_runtime_environment_Range_boundary_outside_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(TimeZoneInfo.Utc))
+            {
+                TestDateOnly(date, expected);
+            }
+        }
+
+        // Values specified as a floating date (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2023-05-31", false)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-05-31", true)]
+        [TestCase("2024-06-01", false)]
+        public void Validates_DateOnly_property_UK_runtime_environment_Range_boundary_within_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(UkTimeZone))
+            {
+                TestDateOnlyDaylightSavings(date, expected);
+                TestDateOnlyDaylightSavingsWithTimeZone(date, expected);
+            }
+        }
+
+        // Values specified as a floating date (no time zone) as the user is not able to submit a time zone with the 'Date input' component
+        [TestCase("2023-05-31", false)]
+        [TestCase("2023-06-01", true)]
+        [TestCase("2023-12-31", true)]
+        [TestCase("2024-05-31", true)]
+        [TestCase("2024-06-01", false)]
+        public void Validates_DateOnly_property_UTC_runtime_environment_Range_boundary_within_daylight_savings(string date, bool expected)
+        {
+            using (new FakeLocalTimeZone(TimeZoneInfo.Utc))
+            {
+                TestDateOnlyDaylightSavings(date, expected);
+                TestDateOnlyDaylightSavingsWithTimeZone(date, expected);
+            }
+        }
+
+        private static void TestDateOnly(string date, bool expected)
+        {
+            // Arrange
+            var model = new NoDaylightSavingsAtBoundaryModel<DateOnly>
+            {
+                Date = DateOnly.Parse(date)
+            };
+
+            // Act
+            var results = ValidateModel(model);
+
+            // Assert
+            Assert.That(results.Count == 0, Is.EqualTo(expected));
+        }
+
+        private static void TestDateOnlyDaylightSavings(string date, bool expected)
+        {
+            // Arrange
+            var model = new DaylightSavingsAtBoundaryModel<DateOnly>
+            {
+                Date = DateOnly.Parse(date)
+            };
+
+            // Act
+            var results = ValidateModel(model);
+
+            // Assert
+            Assert.That(results.Count == 0, Is.EqualTo(expected));
+        }
+
+        private static void TestDateOnlyDaylightSavingsWithTimeZone(string date, bool expected)
+        {
+            // Arrange
+            var model = new DaylightSavingsAtBoundaryModelWithTimeZone<DateOnly>
             {
                 Date = DateOnly.Parse(date)
             };

--- a/GovUk.Frontend.AspNetCore.Extensions.Tests/GovUk.Frontend.AspNetCore.Extensions.Tests.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions.Tests/GovUk.Frontend.AspNetCore.Extensions.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeLocalTimeZone" Version="0.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/GovUk.Frontend.AspNetCore.Extensions/Validation/DateRangeAttribute.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Validation/DateRangeAttribute.cs
@@ -21,7 +21,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
         /// <param name="maximum">An ISO 8601 date string in the format YYYY-MM-DD</param>
         public DateRangeAttribute(string minimum, string maximum)
         {
-            if (DateTime.TryParse(minimum, out var parsedMinimum))
+            if (DateTime.TryParse(minimum, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsedMinimum))
             {
                 Minimum = parsedMinimum;
             }
@@ -29,7 +29,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
             {
                 throw new ArgumentException($"{nameof(minimum)} could not be parsed as a {nameof(DateTime)}", nameof(minimum));
             }
-            if (DateTime.TryParse(maximum, out var parsedMaximum))
+            if (DateTime.TryParse(maximum, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsedMaximum))
             {
                 Maximum = parsedMaximum;
             }
@@ -57,7 +57,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
             if (!Minimum.HasValue) { throw new InvalidOperationException($"The {nameof(Minimum)} property cannot be null"); }
             if (!Maximum.HasValue) { throw new InvalidOperationException($"The {nameof(Maximum)} property cannot be null"); }
 
-            var rangeAttribute = new RangeAttribute(typeof(DateTime), Minimum.Value.ToString("o", CultureInfo.InvariantCulture), Maximum.Value.ToString("o", CultureInfo.InvariantCulture));
+            var rangeAttribute = new RangeAttribute(typeof(DateTime), Minimum.Value.ToString("s", CultureInfo.InvariantCulture), Maximum.Value.ToString("s", CultureInfo.InvariantCulture));
             return rangeAttribute.IsValid(value);
         }
     }


### PR DESCRIPTION
[AB#159817](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/159817)