### PR TITLE
A date input should not be left with an error border but no error message

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -6,7 +6,7 @@
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 		<IncludeRazorContentInPack>true</IncludeRazorContentInPack>
 		<Nullable>enable</Nullable>
-		<Version>3.1.0</Version>
+		<Version>3.1.1</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.AspNetCore.Extensions/__tests__/govuk-validation-removeOrUpdateError.tests.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/__tests__/govuk-validation-removeOrUpdateError.tests.js
@@ -74,6 +74,69 @@ describe("removeOrUpdateError", () => {
     expect(document.querySelector(".govuk-error-message")).toBeNull();
   });
 
+  it("removes an existing error message from a date input if all three fields are valid", () => {
+    document.body.innerHTML = `<div class="govuk-form-group govuk-form-group--error" id="form-group-for-date-input">
+        <fieldset class="govuk-fieldset" role="group">
+          <p class="govuk-error-message"></p>
+          <div class="govuk-date-input" id="Field1">
+            <div class="govuk-form-group">
+              <input class="govuk-date-input__input govuk-input" id="Field1.Day" />
+            </div>
+            <div class="govuk-form-group">
+              <input class="govuk-date-input__input govuk-input" id="Field1.Month" />
+            </div>
+            <div class="govuk-form-group">
+              <input class="govuk-date-input__input govuk-input" id="Field1.Year" />
+            </div>
+          </div>
+        </fieldset>
+      </div>`;
+
+    const testSubject = govuk();
+    mockCalledFunctions(
+      testSubject,
+      () => document.querySelector(".govuk-error-message"),
+      () => document.getElementById("form-group-for-date-input")
+    );
+
+    testSubject.removeOrUpdateError(document.getElementById("Field1.Day"));
+
+    expect(document.querySelector(".govuk-error-message")).toBeNull();
+  });
+
+  it("does not remove an existing error message from a date input if at least one of the fields is invalid", () => {
+    document.body.innerHTML = `<div class="govuk-form-group govuk-form-group--error" id="form-group-for-date-input">
+        <fieldset class="govuk-fieldset" role="group">
+          <p class="govuk-error-message" id="original-error"></p>
+          <div class="govuk-date-input" id="Field1">
+            <div class="govuk-form-group">
+              <input class="govuk-date-input__input govuk-input" id="Field1.Day" />
+            </div>
+            <div class="govuk-form-group">
+              <input class="govuk-date-input__input govuk-input" id="Field1.Month" />
+            </div>
+            <div class="govuk-form-group">
+              <input class="govuk-date-input__input govuk-input govuk-input--error" id="Field1.Year" aria-invalid="true" />
+            </div>
+          </div>
+        </fieldset>
+      </div>`;
+
+    const testSubject = govuk();
+    mockCalledFunctions(
+      testSubject,
+      () => document.querySelector(".govuk-error-message"),
+      () => document.getElementById("form-group-for-date-input")
+    );
+
+    const originalError = document.getElementById("original-error");
+
+    testSubject.removeOrUpdateError(document.getElementById("Field1.Day"));
+
+    const currentError = document.querySelector(".govuk-error-message");
+    expect(currentError).toBe(originalError);
+  });
+
   it("updates the page title and error summary", () => {
     document.body.innerHTML = '<input class="govuk-input" />';
 

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
@@ -111,7 +111,11 @@ function createGovUkValidator() {
       const currentErrors = [].slice.call(list.querySelectorAll("a"));
 
       const updatedErrors = [].slice
-        .call(document.querySelectorAll(".govuk-error-message:not(.govuk-character-count__status)"))
+        .call(
+          document.querySelectorAll(
+            ".govuk-error-message:not(.govuk-character-count__status)"
+          )
+        )
         .map(function (error) {
           const link = document.createElement("a");
           const prefix = error.querySelector(".govuk-visually-hidden");
@@ -445,31 +449,40 @@ function createGovUkValidator() {
       element.classList.remove("govuk-textarea--error");
       element.classList.remove("govuk-select--error");
 
-      const errorMessage = govuk.errorMessageForElement(element);
-      if (errorMessage) {
-        errorMessage.parentElement.removeChild(errorMessage);
-        let describedBy = element.getAttribute("aria-describedby");
-        if (describedBy) {
-          describedBy = describedBy.split(" ");
-          const idToRemove = describedBy.indexOf(errorMessage.id);
-          if (idToRemove > -1) {
-            describedBy.splice(idToRemove, 1);
-          }
-          if (describedBy.length) {
-            element.setAttribute("aria-describedby", describedBy.join(" "));
-          } else {
-            element.removeAttribute("aria-describedby");
+      const isDateField = element.classList.contains("govuk-date-input__input");
+      const formGroup = govuk.formGroupForElement(element);
+      let nextError = null;
+      if (formGroup) {
+        nextError = formGroup.querySelector(
+          ".govuk-input--error, .govuk-textarea--error, .govuk-select--error"
+        );
+      }
+
+      const isDateFieldWithMoreErrors = isDateField && formGroup && nextError;
+
+      if (!isDateFieldWithMoreErrors) {
+        const errorMessage = govuk.errorMessageForElement(element);
+        if (errorMessage) {
+          errorMessage.parentElement.removeChild(errorMessage);
+          let describedBy = element.getAttribute("aria-describedby");
+          if (describedBy) {
+            describedBy = describedBy.split(" ");
+            const idToRemove = describedBy.indexOf(errorMessage.id);
+            if (idToRemove > -1) {
+              describedBy.splice(idToRemove, 1);
+            }
+            if (describedBy.length) {
+              element.setAttribute("aria-describedby", describedBy.join(" "));
+            } else {
+              element.removeAttribute("aria-describedby");
+            }
           }
         }
       }
       govuk.updateErrorSummary();
       govuk.updateTitle();
 
-      const formGroup = govuk.formGroupForElement(element);
       if (formGroup) {
-        const nextError = formGroup.querySelector(
-          ".govuk-input--error, .govuk-textarea--error, .govuk-select--error"
-        );
         if (!nextError) {
           formGroup.classList.remove("govuk-form-group--error");
         } else {


### PR DESCRIPTION
It's been possible for a date input component to end up like this, with an error bar but no error message:

![Date input showing error bar but no error message](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/1ce72e64-494a-43b8-ac40-974370c7f0f9)

This happens if a date input has a server-side error that is not replicated on the client, and then the user clicks into and out of one of the date fields. The error message is removed when one or more of the other fields within the date are still in an error state.

This update prevents the message being removed until all three fields have been visited. At this point, if the server-side validation is not replicated on the client, client-side validation has been re-run on the whole date field and found to be valid so the error message is removed. 

For `[DateRange]` this leaves another issue, because that validation only happens on the server so a server-side error is incorrectly cleared by client-side validation that does not run the same check. However the fix for that is to implement client-side support for `[DateRange]`, which is a separate issue and a separate future PR.

[AB#159845](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/159845)