### PR TITLE
String length was being validated differently on the client and the server

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -317,8 +317,4 @@
 	  <UpToDateCheckInput Remove="Styles\_tpr-variables.scss" />
 	</ItemGroup>
 	
-	<ItemGroup>
-	  <Folder Include="ModelBinding\" />
-	</ItemGroup>
-	
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -6,7 +6,7 @@
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 		<IncludeRazorContentInPack>true</IncludeRazorContentInPack>
 		<Nullable>enable</Nullable>
-		<Version>3.1.1</Version>
+		<Version>3.1.2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.AspNetCore.Extensions/ModelBinding/NormalisedStringModelBinder.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/ModelBinding/NormalisedStringModelBinder.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.Threading.Tasks;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.ModelBinding
+{
+    /// <remarks>
+    /// When running in a Windows environment, MaxLengthAttribute and StringLengthAttribute treat a new line as two characters, \r\n.
+    /// This does not align with users' expectations or with client-side validation using jQuery validate, so remove the \r to leave 
+    /// a single character.
+    /// </remarks>
+    public class NormalisedStringModelBinder : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            var value = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+            if (!string.IsNullOrEmpty(value.FirstValue))
+            {
+                bindingContext.Result = ModelBindingResult.Success(value.FirstValue.Replace("\r\n", "\n"));
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/ModelBinding/NormalisedStringModelBinderProvider.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/ModelBinding/NormalisedStringModelBinderProvider.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.ModelBinding
+{
+    /// <remarks>
+    /// When running in a Windows environment, MaxLengthAttribute and StringLengthAttribute treat a new line as two characters, \r\n.
+    /// This does not align with users' expectations or with client-side validation using jQuery validate, so register a custom model binder 
+    /// when either of those attributes are in use.
+    /// </remarks>
+    public class NormalisedStringModelBinderProvider : IModelBinderProvider
+    {
+        public IModelBinder? GetBinder(ModelBinderProviderContext context)
+        {
+            Guard.ArgumentNotNull(nameof(context), context);
+
+            if (context.Metadata.UnderlyingOrModelType == typeof(string) &&
+                (context.Metadata.ValidatorMetadata.Any(x => x.GetType() == typeof(MaxLengthAttribute)) ||
+                 context.Metadata.ValidatorMetadata.Any(x => x.GetType() == typeof(StringLengthAttribute))))
+            {
+                return new NormalisedStringModelBinder();
+            }
+
+            return null;
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/ServiceCollectionExtensions.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions
             services.AddSingleton<IStartupFilter, EmbedContentFolderStartupFilter>();
             services.AddMvc(options =>
             {
+                options.ModelBinderProviders.Insert(0, new NormalisedStringModelBinderProvider());
                 options.ModelBinderProviders.Insert(0, new UkPostcodeModelBinderProvider());
             });
 


### PR DESCRIPTION
When running in a Windows environment, `MaxLengthAttribute` and `StringLengthAttribute` treat a new line as two characters, `\r\n`. 

This does not align with users' expectations or with client-side validation using jQuery validate, so remove the `\r` to leave a single character.

[AB#159845](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/159845)
[AB#153013](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/153013)