### PR TITLE
When using TPR styles, links within button groups should be bold 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -317,4 +317,8 @@
 	  <UpToDateCheckInput Remove="Styles\_tpr-variables.scss" />
 	</ItemGroup>
 	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_tpr-button-group.scss" />
+	</ItemGroup>
+	
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-button-group.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-button-group.scss
@@ -1,0 +1,7 @@
+﻿@import '_tpr-variables.scss';
+@import 'govuk/base';
+
+// Change GOV.UK button group styles where the TPR brand diverges from the GOV.UK Design System.
+.govuk-button-group .govuk-link {
+    font-weight: $tpr-font-weight-semi-bold;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
@@ -41,6 +41,7 @@
 // Override compiled GOV.UK styles to apply differences from the TPR UI Kit
 @import '_tpr-back.scss';
 @import '_tpr-button.scss';
+@import '_tpr-button-group.scss';
 @import '_tpr-caption.scss';
 @import '_tpr-character-count.scss';
 @import '_tpr-date-input.scss';


### PR DESCRIPTION
When using TPR styles, all links should be semi-bold, but GOV.UK styles were resetting these to `normal`.

[AB#151933](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/151933)