### PR TITLE
AB#156517 Textarea character count fix

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -6,7 +6,7 @@
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 		<IncludeRazorContentInPack>true</IncludeRazorContentInPack>
 		<Nullable>enable</Nullable>
-		<Version>3.1.2</Version>
+		<Version>3.1.3</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-grid.scss
@@ -101,6 +101,7 @@
     @include govuk-media-query($from: desktop) {
         .govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column-#{$width}-from-desktop > .govuk-form-group > *,
         .govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column-#{$width}-from-desktop > .govuk-character-count > .govuk-form-group > *,
+        .govuk-grid-row--tpr-divider-for-label-as-heading > .govuk-grid-column-#{$width}-from-desktop >.govuk-character-count > .govuk-character-count__message,
         .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width}-from-desktop > fieldset > *,
         .govuk-grid-row--tpr-divider-for-fieldset > .govuk-grid-column-#{$width}-from-desktop > .govuk-form-group > fieldset > * {
             width: govuk-grid-width($width);


### PR DESCRIPTION
Prior to fix: 
![image](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/49045512/d89fad61-f4ba-4c69-b532-c07f721944af)
After fix was implemented:
![image](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/49045512/ffcaf3e8-aab5-4004-9564-0ff1aca4df3d)
Description:
Css class for textarea character count message was not being selected due to no matching selector. This led the div to be in an unexpected location.

To correct this, a new selector was added to capture this div in its position and apply the correct styling.
