### PR TITLE
Update System.Security.Cryptography.Pkcs to fix vulnerability 

### DIFF
--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,6 +18,10 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
+    <Version>1.0.1</Version>
+	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
+	     This will help identify breaking changes where the major version should change. -->
+	<PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
     <PackageReference Include="Umbraco.Cms.Core" Version="10.4.2" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="10.4.2" />
   </ItemGroup>


### PR DESCRIPTION
Vulnerability alert: https://github.com/advisories/GHSA-555c-2p6r-68mm

This was fixed previously in #162 but having factored out some functionality into a new package since then, it needs moving up a level.

[AB#161107](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/161107)