### PR TITLE
CSS was not being generated from SASS in pipeline builds

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -6,7 +6,7 @@
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 		<IncludeRazorContentInPack>true</IncludeRazorContentInPack>
 		<Nullable>enable</Nullable>
-		<Version>4.0.0</Version>
+		<Version>4.0.1</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
@@ -29,4 +29,20 @@ govuk
 		<WriteLinesToFile File="$(ProjectDir)Styles\.gitignore" Lines="@(ThePensionsRegulatorGovUkFrontendGitIgnore)" Overwrite="True"/>
 	</Target>
 
+	<!-- In pipeline builds if a CSS file exists AspNetCore.SassCompiler won't overwrite it with the generated version, 
+	     so look for SCSS files which will generate CSS files, and delete the equivalent CSS file first -->
+	<Target Name="ThePensionsRegulatorGovUkFrontend_CleanGeneratedCss" BeforeTargets="Compile Sass">
+		<ItemGroup>
+			<ScssSourceFiles Include="$(MSBuildProjectDirectory)\Styles\*.scss" Exclude="$(MSBuildProjectDirectory)\Styles\_tpr-variables.scss"/>
+		</ItemGroup>
+		<ItemGroup>
+			<FilesToDeleteStep1 Include="@(ScssSourceFiles->Replace('$(MSBuildProjectDirectory)\Styles', '$(MSBuildProjectDirectory)\wwwroot\css'))" />
+		</ItemGroup>
+		<ItemGroup>
+			<FilesToDeleteStep2 Include="@(FilesToDeleteStep1->Replace('.scss', '.css'))" />
+		</ItemGroup>
+
+		<Delete Files="@(FilesToDeleteStep2)"  />
+	</Target>
+
 </Project>


### PR DESCRIPTION
It's not clear why this was happening in pipeline builds and not locally, but:

1. [ThePensionsRegulator.GovUk.Frontend.Umbraco.targets](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/blob/develop/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets) generates a placeholder `/wwwroot/css/site.css` file, to avoid a 404 in the Umbraco rich text editor
2. In a pipeline build, when `AspNetCore.SassCompiler` comes to generate `/wwwroot/css/site.css` from `/Styles/site.scss` it sees the existing file and does not overwrite it
3. The placeholder CSS file is therefore included in the build output instead of the generated file

This PR fixes that issue by looking for candidate files in the `/Styles` folder that would generate a CSS file, and then deleting that CSS file if it exists. This happens before the 'Compile Sass' target defined by `AspNetCore.SassCompiler` ensuring that there is no file present to prevent `AspNetCore.SassCompiler` from generating the desired CSS.