### PR TITLE
An empty TPR context bar should render nothing

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.Tests/TprContextBarTagHelperTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.Tests/TprContextBarTagHelperTests.cs
@@ -1,0 +1,120 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration;
+using GovUk.Frontend.AspNetCore.Extensions.TagHelpers;
+using GovUk.Frontend.AspNetCore.HtmlGeneration;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.Tests
+{
+    [TestFixture]
+    public class TprContextBarTagHelperTests
+    {
+        [Test]
+        public async Task All_3_contexts_empty_does_not_render_bar()
+        {
+            // Arrange
+            var tagHelper = new TprContextBarTagHelper();
+            var attributes = new TagHelperAttributeList();
+            var context = new TagHelperContext(attributes, new Dictionary<object, object>(), Guid.NewGuid().ToString());
+            var output = new TagHelperOutput("tpr-context-bar", attributes, (result, encoder) =>
+            {
+                return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+            });
+
+            // Act
+            await tagHelper.ProcessAsync(context, output);
+            using var result = new StringWriter();
+            output.WriteTo(result, HtmlEncoder.Create());
+
+            // Assert
+            Assert.True(string.IsNullOrEmpty(result.ToString()));
+        }
+
+        [Test]
+        public async Task Context_1_content_is_rendered()
+        {
+            // Arrange
+            var htmlGenerator = new Mock<IGovUkHtmlGenerator>();
+            htmlGenerator.Setup(x => x.GenerateTprContextBar(It.IsAny<TprContextBar>())).Returns(new TagBuilder(TprContextBarTagHelper.TagName));
+            const string CONTEXT_1_CONTENT = "<tpr-context-bar-context-1>Example</tpr-context-bar-context-1>";
+
+            var tagHelper = new TprContextBarTagHelper(htmlGenerator.Object);
+            var attributes = new TagHelperAttributeList();
+            var tagHelperContext = new TagHelperContext(attributes, new Dictionary<object, object>(), Guid.NewGuid().ToString());
+            var output = new TagHelperOutput("tpr-context-bar", attributes, (result, encoder) =>
+            {
+                var contextBarContext = (TprContextBarContext)tagHelperContext.Items[typeof(TprContextBarContext)];
+                contextBarContext.SetContext(1, new AttributeDictionary(), new HtmlString(CONTEXT_1_CONTENT), false);
+
+                return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+            });
+
+            // Act
+            await tagHelper.ProcessAsync(tagHelperContext, output);
+
+            // Assert
+            htmlGenerator.Verify(x => x.GenerateTprContextBar(It.Is<TprContextBar>(bar => bar.Context1Content != null && bar.Context1Content.ToHtmlString() == CONTEXT_1_CONTENT)), Times.Once);
+        }
+
+        [Test]
+        public async Task Context_2_content_is_rendered()
+        {
+            // Arrange
+            var htmlGenerator = new Mock<IGovUkHtmlGenerator>();
+            htmlGenerator.Setup(x => x.GenerateTprContextBar(It.IsAny<TprContextBar>())).Returns(new TagBuilder(TprContextBarTagHelper.TagName));
+            const string CONTEXT_2_CONTENT = "<tpr-context-bar-context-2>Example</tpr-context-bar-context-2>";
+
+            var tagHelper = new TprContextBarTagHelper(htmlGenerator.Object);
+            var attributes = new TagHelperAttributeList();
+            var tagHelperContext = new TagHelperContext(attributes, new Dictionary<object, object>(), Guid.NewGuid().ToString());
+            var output = new TagHelperOutput("tpr-context-bar", attributes, (result, encoder) =>
+            {
+                var contextBarContext = (TprContextBarContext)tagHelperContext.Items[typeof(TprContextBarContext)];
+                contextBarContext.SetContext(2, new AttributeDictionary(), new HtmlString(CONTEXT_2_CONTENT), false);
+
+                return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+            });
+
+            // Act
+            await tagHelper.ProcessAsync(tagHelperContext, output);
+
+            // Assert
+            htmlGenerator.Verify(x => x.GenerateTprContextBar(It.Is<TprContextBar>(bar => bar.Context2Content != null && bar.Context2Content.ToHtmlString() == CONTEXT_2_CONTENT)), Times.Once);
+        }
+
+        [Test]
+        public async Task Context_3_content_is_rendered()
+        {
+            // Arrange
+            var htmlGenerator = new Mock<IGovUkHtmlGenerator>();
+            htmlGenerator.Setup(x => x.GenerateTprContextBar(It.IsAny<TprContextBar>())).Returns(new TagBuilder(TprContextBarTagHelper.TagName));
+            const string CONTEXT_3_CONTENT = "<tpr-context-bar-context-3>Example</tpr-context-bar-context-3>";
+
+            var tagHelper = new TprContextBarTagHelper(htmlGenerator.Object);
+            var attributes = new TagHelperAttributeList();
+            var tagHelperContext = new TagHelperContext(attributes, new Dictionary<object, object>(), Guid.NewGuid().ToString());
+            var output = new TagHelperOutput("tpr-context-bar", attributes, (result, encoder) =>
+            {
+                var contextBarContext = (TprContextBarContext)tagHelperContext.Items[typeof(TprContextBarContext)];
+                contextBarContext.SetContext(3, new AttributeDictionary(), new HtmlString(CONTEXT_3_CONTENT), false);
+
+                return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+            });
+
+            // Act
+            await tagHelper.ProcessAsync(tagHelperContext, output);
+
+            // Assert
+            htmlGenerator.Verify(x => x.GenerateTprContextBar(It.Is<TprContextBar>(bar => bar.Context3Content != null && bar.Context3Content.ToHtmlString() == CONTEXT_3_CONTENT)), Times.Once);
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/IGovUkHtmlGenerator.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/IGovUkHtmlGenerator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace GovUk.Frontend.AspNetCore.Extensions
 {
-    internal interface IGovUkHtmlGenerator
+    public interface IGovUkHtmlGenerator
     {
         TagBuilder GenerateTprBackToTop(string href, IHtmlContent content, AttributeDictionary? attributes);
         TagBuilder GenerateTprBackToMenu(string href, IHtmlContent content, AttributeDictionary? attributes);

--- a/GovUk.Frontend.AspNetCore.Extensions/InternalsVisibleTo.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GovUk.Frontend.AspNetCore.Extensions.Tests")]

--- a/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarTagHelper.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/TagHelpers/TprContextBarTagHelper.cs
@@ -65,6 +65,10 @@ namespace GovUk.Frontend.AspNetCore.Extensions.TagHelpers
                 output.MergeAttributes(tagBuilder);
                 output.Content.SetHtmlContent(tagBuilder.InnerHtml);
             }
+            else
+            {
+                output.SuppressOutput();
+            }
         }
     }
 }


### PR DESCRIPTION
If no context information is provided to a TPR context bar is should not be rendered. In fact it was rendering this invalid HTML:

`<tpr-context-bar></tpr-context-bar>` 

Fix that, and add tests for the output of that tag helper.

I have not incremented the package version for the bug fix because I expect other PRs to complete with a feature-level increment.

[AB#150712](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/150712)