### PR TITLE
It should be possible to configure the header and context bars to not allow HTML

### DIFF
--- a/GovUk.Frontend.Umbraco/Models/TprHeaderLockupModel.cs
+++ b/GovUk.Frontend.Umbraco/Models/TprHeaderLockupModel.cs
@@ -16,6 +16,10 @@ namespace GovUk.Frontend.Umbraco.Models
         public bool ShowSkipLink { get; init; } = true;
         public bool ShowPhaseBanner { get; init; } = true;
         public bool ShowHeader { get; init; } = true;
+        public bool HeaderBarContentAllowHtml { get; init; } = true;
+        public bool Context1AllowHtml { get; init; } = true;
+        public bool Context2AllowHtml { get; init; } = true;
+        public bool Context3AllowHtml { get; init; } = true;
         public virtual string? SkipLinkClass() => null;
         public virtual string? SkipLinkHref() => "#main";
         public virtual string? SkipLinkText() => _settings.Value<string>("govukSkipLinkText");

--- a/GovUk.Frontend.Umbraco/Views/Partials/TPR/TPRHeaderLockup.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Partials/TPR/TPRHeaderLockup.cshtml
@@ -47,12 +47,12 @@
             <tpr-header-bar class="@Model.HeaderBarClass()">
                 <tpr-header-bar-logo alt="@headerLogoAlt" href="@Model.LogoHref()" />
                 <tpr-header-bar-label>@Model.HeaderBarLabel()</tpr-header-bar-label>
-                <tpr-header-bar-content allow-html="true">@Html.Raw(document.DocumentNode.OuterHtml)</tpr-header-bar-content>
+                <tpr-header-bar-content allow-html="@Model.HeaderBarContentAllowHtml">@Html.Raw(document.DocumentNode.OuterHtml)</tpr-header-bar-content>
             </tpr-header-bar>
             <tpr-context-bar class="@Model.ContextBarClass()">
-                <tpr-context-bar-context-1 allow-html="true">@Html.Raw(GovUkTypography.Apply(@Model.Context1(), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-1>
-                <tpr-context-bar-context-2 allow-html="true">@Html.Raw(GovUkTypography.Apply(@Model.Context2(), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-2>
-                <tpr-context-bar-context-3 allow-html="true">@Html.Raw(GovUkTypography.Apply(@Model.Context3(), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-3>
+                <tpr-context-bar-context-1 allow-html="@Model.Context1AllowHtml">@Html.Raw(GovUkTypography.Apply(@Model.Context1(), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-1>
+                <tpr-context-bar-context-2 allow-html="@Model.Context2AllowHtml">@Html.Raw(GovUkTypography.Apply(@Model.Context2(), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-2>
+                <tpr-context-bar-context-3 allow-html="@Model.Context3AllowHtml">@Html.Raw(GovUkTypography.Apply(@Model.Context3(), new TypographyOptions { RemoveWrappingParagraphs = true }))</tpr-context-bar-context-3>
             </tpr-context-bar>
         }
     </header>


### PR DESCRIPTION
It should be possible to configure the header and context bars to not allow HTML when they're known not to require it.

[AB#150712](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/150712)