### PR TITLE
Update govuk-frontend to v4.4.1 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -6,7 +6,7 @@
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 		<IncludeRazorContentInPack>true</IncludeRazorContentInPack>
 		<Nullable>enable</Nullable>
-		<Version>4.0.1</Version>
+		<Version>4.1.0</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
@@ -83,7 +83,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.58.1" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.1" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.1.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-summary-card.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-summary-card.scss
@@ -1,7 +1,7 @@
 ﻿@import 'govuk/base';
 
 // GOV.UK styles for Summary Card from https://github.com/alphagov/govuk-frontend/blob/v4.5.0/src/govuk/components/summary-list/_index.scss
-// Summary Card was introduced in GOV.UK Frontend 4.5.0 but this project currently targets 4.3.0, which is determined by the 
+// Summary Card was introduced in GOV.UK Frontend 4.5.0 but this project currently targets 4.4.1, which is determined by the 
 // GovUk.Frontend.AspNetCore NuGet dependency. Once it is updated to 4.5.0 this file can be removed.
 
 

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-button.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-button.scss
@@ -11,19 +11,18 @@
 // Using a background image means no extra HTML is required and no extra characters are exposed to assistive technology.
 $tpr-button-padding: 20px;
 
-.govuk-button, input[type="file"]::file-selector-button {
-    color: $tpr-colour-white;
+.govuk-button, .govuk-file-upload::file-selector-button {
+    color: $govuk-button-text-colour;
     border-width: 1px;
     border-color: transparent;
     line-height: govuk-px-to-rem(24);
     border-radius: 8px;
     box-shadow: none;
-    background: $tpr-colour-eastern-blue url(/_content/ThePensionsRegulator.GovUk.Frontend/tpr/chevron_right_white_24dp.svg) right center no-repeat;
+    background: $govuk-button-background-colour url(/_content/ThePensionsRegulator.GovUk.Frontend/tpr/chevron_right_white_24dp.svg) right center no-repeat;
     padding-left: $tpr-button-padding;
     padding-right: $tpr-button-padding *2;
 }
-.govuk-button:hover, .govuk-button:active, input[type="file"]::file-selector-button:hover {
-    color: $tpr-colour-white;
+.govuk-button:hover, .govuk-button:active, .govuk-file-upload::file-selector-button:hover {
     background-color: $tpr-colour-violet;
 }
 .govuk-button:focus:not(:active):not(:hover) {
@@ -31,7 +30,6 @@ $tpr-button-padding: 20px;
     color: $tpr-colour-eclipse;
 }
 .govuk-button:disabled, .govuk-button[aria-disabled=true] {
-    color: $tpr-colour-white;
     background-color: $tpr-colour-regent-st-blue;
 }
 
@@ -47,9 +45,11 @@ a.govuk-button--secondary:link, a.govuk-button--secondary:visited {
     color: $tpr-colour-royal-blue;
 }
 
-.govuk-button--secondary:hover, .govuk-button--secondary:active,
+.govuk-button--secondary:hover,
+.govuk-button--secondary:link:active,
+.govuk-button--secondary:visited:active,
 a.govuk-button--secondary:hover {
-    color: $tpr-colour-white;
+    color: $govuk-button-text-colour;
     background-color: $tpr-colour-royal-blue;
 }
 .govuk-button--secondary:disabled, .govuk-button--secondary[aria-disabled=true] {
@@ -72,15 +72,12 @@ input[type="file"]::file-selector-button {
 }
 
 .govuk-button--warning {
-    color: $tpr-colour-white;
     background-color: $tpr-colour-fire-brick;
 }
 .govuk-button--warning:hover, .govuk-button--warning:focus, .govuk-button--warning:active {
-    color: $tpr-colour-white;
     background-color: $tpr-colour-brick;
 }
 .govuk-button--warning:disabled, .govuk-button--warning[aria-disabled=true] {
-    color: $tpr-colour-white;
     background-color: $tpr-colour-petite-orchid;
 }
 
@@ -96,7 +93,7 @@ a.govuk-button--warning.govuk-button--secondary:visited {
 .govuk-button--warning.govuk-button--secondary:active,
 a.govuk-button--warning.govuk-button--secondary:hover,
 a.govuk-button--warning.govuk-button--secondary:active {
-    color: $tpr-colour-white;
+    color: $govuk-button-text-colour;
     background-color: $tpr-colour-fire-brick;
     border-color: transparent;
 }
@@ -110,7 +107,7 @@ a.govuk-button--warning.govuk-button--secondary:active {
     background-color: transparent;
     background-image: none;
     padding-right: govuk-spacing(4);
-    color: $tpr-colour-white;
+    color: $govuk-button-text-colour;
     border-color: $tpr-colour-white;
 
     &:hover,

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-variables.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_tpr-variables.scss
@@ -50,6 +50,8 @@ $govuk-secondary-text-colour: $tpr-colour-zambezi;
 $govuk-input-border-colour: $tpr-colour-eclipse;
 $govuk-focus-colour: $tpr-colour-tangerine-yellow;
 $govuk-error-colour: $tpr-colour-fire-brick;
+$govuk-button-text-colour: $tpr-colour-white;
+$govuk-button-background-colour: $tpr-colour-eastern-blue;
 
 // Change the default typography sizing where the TPR brand diverges from the
 // GOV.UK Design System. GOV.UK code uses the govuk-font() mixin. It passes in the 

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/govuk-frontend-4.3.0.min.js"></script>
+﻿<script src="~/govuk-frontend-4.4.1.min.js"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js"></script>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We add support for:
   - [Back link](https://github.com/gunndabad/govuk-frontend-aspnetcore/blob/main/docs/components/back-link.md)
   - [File upload](https://github.com/gunndabad/govuk-frontend-aspnetcore/blob/main/docs/components/file-upload.md)
 
-We target [GDS Frontend v4.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.0) in line with James Gunn's base project. We also include 'Summary card' from [GDS Frontend v4.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.5.0) and 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
+We target [GDS Frontend v4.4.1](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.1) in line with James Gunn's base project. We also include 'Summary card' from [GDS Frontend v4.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.5.0) and 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
 
 ## ASP.NET projects without Umbraco
 


### PR DESCRIPTION
Updates govuk-frontend to v4.4.1 in line with the latest release of `govuk-aspnetnetcore-frontend`.

Takes advantage of the new SASS variables introduced in [govuk-frontend 4.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.0).

[AB#150712](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/150712)