### PR TITLE
Add the nonce provider class for content security policy support …

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Security/INonceProvider.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Security/INonceProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace GovUk.Frontend.AspNetCore.Extensions.Security
+{
+    public interface INonceProvider
+    {
+        string GetNonce();
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Security/NonceProvider.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Security/NonceProvider.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Security.Cryptography;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.Security
+{
+    public class NonceProvider : INonceProvider
+    {
+        private readonly string _nonce;
+        public NonceProvider()
+        {
+            _nonce = GenerateNonce();
+        }
+        public string GetNonce()
+        {
+            return _nonce;
+        }
+
+        private string GenerateNonce()
+        {
+            var nonceBytes = RandomNumberGenerator.GetBytes(20);
+            return Convert.ToBase64String(nonceBytes);
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/ServiceCollectionExtensions.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using GovUk.Frontend.AspNetCore.Extensions.Configuration;
 using GovUk.Frontend.AspNetCore.Extensions.ModelBinding;
+using GovUk.Frontend.AspNetCore.Extensions.Security;
 using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions
             services.AddGovUkFrontend(configureOptions);
             services.AddTransient<IClientSideValidationHtmlEnhancer, ClientSideValidationHtmlEnhancer>();
             services.AddTransient<IModelPropertyResolver, ModelPropertyResolver>();
+            services.AddScoped<INonceProvider, NonceProvider>();
             services.AddSingleton<IStartupFilter, EmbedContentFolderStartupFilter>();
             services.AddMvc(options =>
             {


### PR DESCRIPTION
Currently each consuming project, including [AB#150712](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/150712), is implementing an identical `INonceProvider` to support content security policy. Include that in the base library to avoid the repetition.