### PR TITLE
Support numbered list style types in Umbraco 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -6,7 +6,7 @@
 		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
 		<IncludeRazorContentInPack>true</IncludeRazorContentInPack>
 		<Nullable>enable</Nullable>
-		<Version>4.1.0</Version>
+		<Version>4.1.1</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
@@ -319,6 +319,10 @@
 	
 	<ItemGroup>
 	  <UpToDateCheckInput Remove="Styles\_tpr-button-group.scss" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_govuk-list.scss" />
 	</ItemGroup>
 	
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-list.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-list.scss
@@ -1,0 +1,21 @@
+﻿/* Extra list styles not in govuk-frontend, but available in the Umbraco UI and therefore supported */
+.govuk-list--lower-alpha {
+    padding-left: govuk-spacing(4);
+    list-style-type: lower-alpha
+}
+.govuk-list--lower-greek {
+    padding-left: govuk-spacing(4);
+    list-style-type: lower-greek;
+}
+.govuk-list--lower-roman {
+    padding-left: govuk-spacing(4);
+    list-style-type: lower-roman;
+}
+.govuk-list--upper-alpha {
+    padding-left: govuk-spacing(4);
+    list-style-type: upper-alpha;
+}
+.govuk-list--upper-roman {
+    padding-left: govuk-spacing(4);
+    list-style-type: upper-roman;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
@@ -32,6 +32,7 @@
 @import "govuk/components/warning-text";
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";
+@import "_govuk-list.scss";
 @import "_govuk-pagination.scss";
 @import "_govuk-summary-card.scss";
 @import "_govuk-task-list.scss";

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/tpr.scss
@@ -31,6 +31,7 @@
 @import "govuk/components/warning-text";
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";
+@import "_govuk-list.scss";
 @import "_govuk-pagination.scss";
 @import "_govuk-summary-card.scss";
 @import "_govuk-task-list.scss";

--- a/GovUk.Frontend.Umbraco.ExampleApp/appsettings.json
+++ b/GovUk.Frontend.Umbraco.ExampleApp/appsettings.json
@@ -27,7 +27,7 @@
         "ModelsDirectory": "~/Models/ModelsBuilder"
       },
       "RichTextEditor": {
-        "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[class|reversed|start|type],-ul[class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
+        "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
         "CustomConfig": {
           "table_advtab": "false",
           "table_cell_advtab": "false",

--- a/GovUk.Frontend.Umbraco.Tests/GovUkTypographyTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/GovUkTypographyTests.cs
@@ -130,6 +130,37 @@ namespace GovUk.Frontend.Umbraco.Tests
         }
 
         [Test]
+        public void Style_attribute_is_removed_from_ordered_lists()
+        {
+            var html = "<ol style=\"list-style-type: lower-alpha;\"><li>Item 1</li><li>Item 2</li></ol><ol style=\"color: red;\"><li>Item 3</li><li>Item 4</li></ol>";
+
+            var result = GovUkTypography.Apply(html);
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(result);
+            Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//ol").Count);
+            Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
+        }
+
+        [TestCase("lower-alpha")]
+        [TestCase("lower-greek")]
+        [TestCase("lower-roman")]
+        [TestCase("upper-alpha")]
+        [TestCase("upper-roman")]
+        public void Permitted_style_attribute_is_converted_to_class_from_ordered_lists(string listStyleType)
+        {
+            var html = $"<ol style=\"list-style-type: {listStyleType};\"><li>Item 1</li><li>Item 2</li></ol>";
+
+            var result = GovUkTypography.Apply(html);
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(result);
+            Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//ol").Count);
+            Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//ol[contains(@class,'govuk-list--{listStyleType}')]").Count);
+            Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
+        }
+
+        [Test]
         public void Single_wrapping_paragraph_is_removed_if_requested()
         {
             var html = "<p>Some content</p>";

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-		<Version>4.0.1</Version>
+		<Version>4.0.2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.Umbraco/Typography/GovUkTypography.cs
+++ b/GovUk.Frontend.Umbraco/Typography/GovUkTypography.cs
@@ -4,110 +4,148 @@ using System.Linq;
 
 namespace GovUk.Frontend.Umbraco.Typography
 {
-    public static class GovUkTypography
-    {
-        public static string Apply(string? html, TypographyOptions? options = null)
-        {
-            if (!string.IsNullOrWhiteSpace(html))
-            {
-                options = options ?? new TypographyOptions();
+	public static class GovUkTypography
+	{
+		public static string Apply(string? html, TypographyOptions? options = null)
+		{
+			if (!string.IsNullOrWhiteSpace(html))
+			{
+				options = options ?? new TypographyOptions();
 
-                var document = new HtmlDocument();
-                document.LoadHtml(html);
+				var document = new HtmlDocument();
+				document.LoadHtml(html);
 
-                ApplyClass(document, "//a", "govuk-link");
-                if (options.BackgroundType == BackgroundType.Dark)
-                {
-                    ApplyClass(document, "//a", "govuk-link--inverse");
-                }
+				ApplyClass(document, "//a", "govuk-link");
+				if (options.BackgroundType == BackgroundType.Dark)
+				{
+					ApplyClass(document, "//a", "govuk-link--inverse");
+				}
 
-                var allHeadingClasses = new[] { "govuk-heading-xl", "govuk-heading-l", "govuk-heading-m", "govuk-heading-s" };
-                ApplyClass(document, "//h2", "govuk-heading-m", allHeadingClasses);
-                ApplyClass(document, "//h3", "govuk-heading-s", allHeadingClasses);
-                ApplyClass(document, "//p", "govuk-body");
-                ApplyClass(document, "//ul", "govuk-list");
-                ApplyClass(document, "//ul", "govuk-list--bullet");
-                ApplyClass(document, "//ol", "govuk-list");
-                ApplyClass(document, "//ol", "govuk-list--number");
-                ApplyClass(document, "//table", "govuk-table");
-                ApplyClass(document, "//caption", "govuk-table__caption");
-                ApplyClass(document, "//thead", "govuk-table__head");
-                ApplyClass(document, "//tbody", "govuk-table__body");
-                ApplyClass(document, "//tr", "govuk-table__row");
-                ApplyClass(document, "//th", "govuk-table__header");
-                ApplyClass(document, "//td", "govuk-table__cell");
+				var allHeadingClasses = new[] { "govuk-heading-xl", "govuk-heading-l", "govuk-heading-m", "govuk-heading-s" };
+				ApplyClass(document, "//h2", "govuk-heading-m", allHeadingClasses);
+				ApplyClass(document, "//h3", "govuk-heading-s", allHeadingClasses);
+				ApplyClass(document, "//p", "govuk-body");
+				ApplyClass(document, "//ul", "govuk-list");
+				ApplyClass(document, "//ul", "govuk-list--bullet");
+				ApplyClass(document, "//ol", "govuk-list");
+				ApplyClass(document, "//ol", "govuk-list--number");
+				ApplyClass(document, "//table", "govuk-table");
+				ApplyClass(document, "//caption", "govuk-table__caption");
+				ApplyClass(document, "//thead", "govuk-table__head");
+				ApplyClass(document, "//tbody", "govuk-table__body");
+				ApplyClass(document, "//tr", "govuk-table__row");
+				ApplyClass(document, "//th", "govuk-table__header");
+				ApplyClass(document, "//td", "govuk-table__cell");
 
-                if (options.RemoveWrappingParagraph)
-                {
-                    return RemoveWrappingParagraph(document);
-                }
-                else if (options.RemoveWrappingParagraphs)
-                {
-                    return RemoveWrappingParagraphs(document);
-                }
-                else
-                {
-                    return document.DocumentNode.OuterHtml;
-                }
-            }
-            return string.Empty;
-        }
+				ApplyPermittedStylesToOrderedLists(document);
 
-        private static string RemoveWrappingParagraphs(HtmlDocument document)
-        {
-            var paragraphs = document.DocumentNode.Elements("p").ToList();
-            for (var i = 0; i < paragraphs.Count; i++)
-            {
-                foreach (var child in paragraphs[i].ChildNodes)
-                {
-                    document.DocumentNode.InsertBefore(child, paragraphs[i]);
-                }
-                paragraphs[i].Remove();
-            }
-            return document.DocumentNode.OuterHtml;
-        }
+				if (options.RemoveWrappingParagraph)
+				{
+					return RemoveWrappingParagraph(document);
+				}
+				else if (options.RemoveWrappingParagraphs)
+				{
+					return RemoveWrappingParagraphs(document);
+				}
+				else
+				{
+					return document.DocumentNode.OuterHtml;
+				}
+			}
+			return string.Empty;
+		}
 
-        /// <summary>
-        /// TinyMCE automatically surrounds text in a paragraph. Remove that paragraph.
-        /// </summary>
-        /// <param name="html"></param>
-        /// <returns></returns>
-        private static string RemoveWrappingParagraph(HtmlDocument document)
-        {
-            if (document.DocumentNode.ChildNodes.Count == 1 &&
-                document.DocumentNode.FirstChild.NodeType == HtmlNodeType.Element &&
-                document.DocumentNode.FirstChild.Name == "p")
-            {
-                return document.DocumentNode.FirstChild.InnerHtml;
-            }
-            return document.DocumentNode.OuterHtml;
-        }
+		/// <summary>
+		/// The Umbraco UI for ordered lists has a setting for selecting the style of the ordered list, so we need to enable it or it looks broken.
+		/// However it is serialized to the style attribute which we don't want to allow free use of, so convert permitted style attribute values
+		/// to classes for display, and remove any others.
+		/// </summary>
+		/// <param name="document"></param>
+		private static void ApplyPermittedStylesToOrderedLists(HtmlDocument document)
+		{
+			var permittedStyleAttributes = new Dictionary<string, string> {
+				{"list-style-type: lower-alpha;" , "govuk-list--lower-alpha" },
+				{"list-style-type: lower-greek;" , "govuk-list--lower-greek" },
+				{"list-style-type: lower-roman;" , "govuk-list--lower-roman" },
+				{"list-style-type: upper-alpha;" , "govuk-list--upper-alpha" },
+				{"list-style-type: upper-roman;" , "govuk-list--upper-roman" }
+			};
 
-        private static void ApplyClass(HtmlDocument doc, string xpath, string className, IEnumerable<string>? unlessTheseClassesAreApplied = null)
-        {
-            var nodes = doc.DocumentNode.SelectNodes(xpath);
-            if (nodes != null)
-            {
-                foreach (var node in nodes)
-                {
-                    var addClass = true;
-                    if (unlessTheseClassesAreApplied != null)
-                    {
-                        foreach (var unlessClass in unlessTheseClassesAreApplied)
-                        {
-                            if (node.HasClass(unlessClass))
-                            {
-                                addClass = false;
-                                break;
-                            }
-                        }
-                    }
-                    if (addClass)
-                    {
-                        node.AddClass(className);
-                    }
-                }
-            }
-        }
-    }
+			var nodes = document.DocumentNode.SelectNodes("//ol[@style]");
+			if (nodes != null)
+			{
+				foreach (var node in nodes)
+				{
+					foreach (var permittedStyle in permittedStyleAttributes.Keys)
+					{
+						if (node.Attributes["style"].Value.Contains(permittedStyle))
+						{
+							node.RemoveClass("govuk-list--number");
+							node.AddClass(permittedStyleAttributes[permittedStyle]);
+							break;
+						}
+					}
+
+					node.Attributes.Remove("style");
+				}
+			}
+		}
+
+		private static string RemoveWrappingParagraphs(HtmlDocument document)
+		{
+			var paragraphs = document.DocumentNode.Elements("p").ToList();
+			for (var i = 0; i < paragraphs.Count; i++)
+			{
+				foreach (var child in paragraphs[i].ChildNodes)
+				{
+					document.DocumentNode.InsertBefore(child, paragraphs[i]);
+				}
+				paragraphs[i].Remove();
+			}
+			return document.DocumentNode.OuterHtml;
+		}
+
+		/// <summary>
+		/// TinyMCE automatically surrounds text in a paragraph. Remove that paragraph.
+		/// </summary>
+		/// <param name="html"></param>
+		/// <returns></returns>
+		private static string RemoveWrappingParagraph(HtmlDocument document)
+		{
+			if (document.DocumentNode.ChildNodes.Count == 1 &&
+				document.DocumentNode.FirstChild.NodeType == HtmlNodeType.Element &&
+				document.DocumentNode.FirstChild.Name == "p")
+			{
+				return document.DocumentNode.FirstChild.InnerHtml;
+			}
+			return document.DocumentNode.OuterHtml;
+		}
+
+		private static void ApplyClass(HtmlDocument doc, string xpath, string className, IEnumerable<string>? unlessTheseClassesAreApplied = null)
+		{
+			var nodes = doc.DocumentNode.SelectNodes(xpath);
+			if (nodes != null)
+			{
+				foreach (var node in nodes)
+				{
+					var addClass = true;
+					if (unlessTheseClassesAreApplied != null)
+					{
+						foreach (var unlessClass in unlessTheseClassesAreApplied)
+						{
+							if (node.HasClass(unlessClass))
+							{
+								addClass = false;
+								break;
+							}
+						}
+					}
+					if (addClass)
+					{
+						node.AddClass(className);
+					}
+				}
+			}
+		}
+	}
 }

--- a/docs/umbraco/new-umbraco-project.md
+++ b/docs/umbraco/new-umbraco-project.md
@@ -19,7 +19,7 @@
            "ModelsDirectory": "~/Models/ModelsBuilder"
          },
          "RichTextEditor": {
-           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[class|reversed|start|type],-ul[class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
+           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
            "CustomConfig": {
              "table_advtab": "false",
              "table_cell_advtab": "false",


### PR DESCRIPTION
In the Umbraco rich text editor, if you enable the use of ordered lists you enable the selection of different styles of numbering:

![image](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/689ca8f6-77b4-4010-8c7e-fae0182bf0cf)

These numbering styles were being stripped by TinyMCE configuration that disallows the `style` attribute. To enable them, allow the `style` attribute in TinyMCE configuration and strip it out when `GovUkTypography` applies GOV.UK classes instead. Before stripping it, apply classes if one of the style attribute values we're looking for exists.

[AB#165186](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/165186)