### PR TITLE
Server-side required field validation for checkbox lists wasn't working

### DIFF
--- a/GovUk.Frontend.ExampleApp/Models/CheckboxesViewModel.cs
+++ b/GovUk.Frontend.ExampleApp/Models/CheckboxesViewModel.cs
@@ -6,7 +6,7 @@ namespace GovUk.Frontend.ExampleApp.Models
     public class CheckboxesViewModel
     {
         [Required(ErrorMessage = "Please select at least one checkbox")]
-        public List<int> Field1 { get; set; } = new();
+        public List<int>? Field1 { get; set; }
 
         [RegularExpression("[0-9]+", ErrorMessage = "The related question must be numbers")]
         public string? Field2 { get; set; }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/CheckboxesViewModel.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/CheckboxesViewModel.cs
@@ -9,7 +9,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Models
         public Checkboxes? Page { get; set; }
 
         [Required(ErrorMessage = nameof(Field1))]
-        public List<string> Field1 { get; set; } = new();
+        public List<string>? Field1 { get; set; }
 
         [RegularExpression("[0-9]+", ErrorMessage = nameof(Field2))]
         public string? Field2 { get; set; }


### PR DESCRIPTION
The cause turned out to be a syntax error only in the example applications, but worth correcting so that they can serve as a reference example.