### PR TITLE
Improve support for finding blocks by class and updating classes in controllers

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/BlockListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/BlockListController.cs
@@ -1,4 +1,5 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.Umbraco.BlockLists;
 using GovUk.Frontend.Umbraco.ExampleApp.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
@@ -31,7 +32,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
             viewModel.Page.Blocks!.Filter = blocks => blocks.Where(block => block.Settings.Value<string>("cssClassesForRow") != "filter-this");
 
             // Override content in the block list
-            var topLevelBlockToOverride = viewModel.Page.Blocks.First(x => x.Settings.Value<string>("cssClassesForRow") == "override-this");
+            var topLevelBlockToOverride = viewModel.Page.Blocks.First(x => x.GridRowClassList().Contains("override-this"));
             topLevelBlockToOverride.Content.OverrideValue("text", GovukTypography.Apply("<p><strong>This text is overridden.</strong></p>"));
 
             // Override content in a nested block list
@@ -39,7 +40,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
             var col = row.Content.Value<OverridableBlockListModel>("blocks")?.LastOrDefault(x => x.Content.ContentType.Alias == "govukGridColumn");
             if (col != null)
             {
-                var nestedBlockToOverride = col.Content.Value<OverridableBlockListModel>("blocks")?.FirstOrDefault(x => x.Settings.Value<string>("cssClassesForRow") == "override-this");
+                var nestedBlockToOverride = col.Content.Value<OverridableBlockListModel>("blocks")?.FirstOrDefault(x => x.GridRowClassList().Contains("override-this"));
                 if (nestedBlockToOverride != null)
                 {
                     nestedBlockToOverride.Content.OverrideValue("text", GovukTypography.Apply("<p><strong>This text is overridden.</strong></p>"));

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/BlockListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/BlockListController.cs
@@ -32,19 +32,16 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
             viewModel.Page.Blocks!.Filter = blocks => blocks.Where(block => block.Settings.Value<string>("cssClassesForRow") != "filter-this");
 
             // Override content in the block list
-            var topLevelBlockToOverride = viewModel.Page.Blocks.First(x => x.GridRowClassList().Contains("override-this"));
-            topLevelBlockToOverride.Content.OverrideValue("text", GovukTypography.Apply("<p><strong>This text is overridden.</strong></p>"));
+            viewModel.Page.Blocks.First(x => x.GridRowClassList().Contains("override-this"))?
+                .Content.OverrideValue("text", GovukTypography.Apply("<p><strong>This text is overridden.</strong></p>"));
 
             // Override content in a nested block list
             var row = viewModel.Page.Blocks.First(x => x.Content.ContentType.Alias == "govukGridRow");
             var col = row.Content.Value<OverridableBlockListModel>("blocks")?.LastOrDefault(x => x.Content.ContentType.Alias == "govukGridColumn");
             if (col != null)
             {
-                var nestedBlockToOverride = col.Content.Value<OverridableBlockListModel>("blocks")?.FirstOrDefault(x => x.GridRowClassList().Contains("override-this"));
-                if (nestedBlockToOverride != null)
-                {
-                    nestedBlockToOverride.Content.OverrideValue("text", GovukTypography.Apply("<p><strong>This text is overridden.</strong></p>"));
-                }
+                col.Content.Value<OverridableBlockListModel>("blocks")?.FirstOrDefault(x => x.GridRowClassList().Contains("override-this"))?
+                    .Content.OverrideValue("text", GovukTypography.Apply("<p><strong>This text is overridden.</strong></p>"));
             }
 
             return CurrentTemplate(viewModel);

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonSurfaceController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonSurfaceController.cs
@@ -15,36 +15,36 @@ using Umbraco.Cms.Web.Website.Controllers;
 
 namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
-	public class ButtonSurfaceController : SurfaceController
-	{
-		public ButtonSurfaceController(IUmbracoDatabaseFactory umbracoDatabaseFactory,
-			IUmbracoContextAccessor umbracoContextAccessor,
-			ServiceContext context,
-			AppCaches appCaches,
-			IProfilingLogger profilingLogger,
-			IPublishedUrlProvider publishedUrlProvider
-			)
-			: base(umbracoContextAccessor, umbracoDatabaseFactory, context, appCaches, profilingLogger, publishedUrlProvider)
-		{
-		}
+    public class ButtonSurfaceController : SurfaceController
+    {
+        public ButtonSurfaceController(IUmbracoDatabaseFactory umbracoDatabaseFactory,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            ServiceContext context,
+            AppCaches appCaches,
+            IProfilingLogger profilingLogger,
+            IPublishedUrlProvider publishedUrlProvider
+            )
+            : base(umbracoContextAccessor, umbracoDatabaseFactory, context, appCaches, profilingLogger, publishedUrlProvider)
+        {
+        }
 
-		[HttpPost]
-		[ValidateAntiForgeryToken]
-		[ValidateUmbracoFormRouteString]
-		[ModelType(typeof(ButtonViewModel))]
-		public IActionResult Index(ButtonViewModel viewModel)
-		{
-			if (ModelState.IsValid)
-			{
-				if (viewModel?.Page?.NextPage != null)
-				{
-					Response.StatusCode = 303;
-					Response.GetTypedHeaders().Location = new Uri(viewModel.Page.NextPage.Url(), UriKind.RelativeOrAbsolute);
-				}
-			}
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [ValidateUmbracoFormRouteString]
+        [ModelType(typeof(ButtonViewModel))]
+        public IActionResult Index(ButtonViewModel viewModel)
+        {
+            if (ModelState.IsValid)
+            {
+                if (viewModel?.Page?.NextPage != null)
+                {
+                    Response.StatusCode = 303;
+                    Response.GetTypedHeaders().Location = new Uri(viewModel.Page.NextPage.Url(), UriKind.RelativeOrAbsolute);
+                }
+            }
 
-			return View("Button", viewModel);
-		}
+            return View("Button", viewModel);
+        }
 
-	}
+    }
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
@@ -91,8 +91,8 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
                     );
                 }
                 viewModel.Page.Blocks!.Filter = filter;
-                var overridableBlock = viewModel.Page.Blocks.FindBlockByContentTypeAlias(GovukPagination.ModelTypeAlias)!;
-                overridableBlock!.Settings.OverrideValue(nameof(GovukPaginationSettings.TotalItems), pagination.TotalItems);
+                viewModel.Page.Blocks.FindBlockByContentTypeAlias(GovukPagination.ModelTypeAlias)?
+                    .Settings.OverrideValue(nameof(GovukPaginationSettings.TotalItems), pagination.TotalItems);
                 ModelState.SetInitialValue(nameof(viewModel.Items), pagination.TotalItems.ToString(CultureInfo.InvariantCulture));
 
                 viewModel.PageTitle = viewModel.Page.Name;

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
@@ -1,4 +1,5 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.Umbraco.BlockLists;
 using GovUk.Frontend.Umbraco.ExampleApp.Models;
 using GovUk.Frontend.Umbraco.Services;
 using GovUk.Frontend.Umbraco.Validation;
@@ -70,23 +71,23 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
                     if (pagination.TotalItems > (pagination.PageSize * pagination.LargeNumberOfPagesThreshold))
                     {
                         filter = x => x.Where(block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
-                            (block.Settings.Value<string>(nameof(GovukTypographySettings.CssClassesForRow)) != "tpr-pagination-small" &&
-                            block.Settings.Value<string>(nameof(GovukTypographySettings.CssClassesForRow)) != "tpr-pagination-none")
+                            (!block.GridRowClassList().Contains("tpr-pagination-small") &&
+                            !block.GridRowClassList().Contains("tpr-pagination-none"))
                         );
                     }
                     else
                     {
                         filter = x => x.Where(block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
-                            (block.Settings.Value<string>(nameof(GovukTypographySettings.CssClassesForRow)) != "tpr-pagination-none" &&
-                            block.Settings.Value<string>(nameof(GovukTypographySettings.CssClassesForRow)) != "tpr-pagination-large")
+                            (!block.GridRowClassList().Contains("tpr-pagination-none") &&
+                            !block.GridRowClassList().Contains("tpr-pagination-large"))
                         );
                     }
                 }
                 else
                 {
                     filter = x => x.Where(block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
-                        (block.Settings.Value<string>(nameof(GovukTypographySettings.CssClassesForRow)) != "tpr-pagination-small" &&
-                        block.Settings.Value<string>(nameof(GovukTypographySettings.CssClassesForRow)) != "tpr-pagination-large")
+                        (!block.GridRowClassList().Contains("tpr-pagination-small") &&
+                        !block.GridRowClassList().Contains("tpr-pagination-large"))
                     );
                 }
                 viewModel.Page.Blocks!.Filter = filter;

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryCardController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryCardController.cs
@@ -9,25 +9,21 @@ using Umbraco.Cms.Web.Common.PublishedModels;
 
 namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
-	public class SummaryCardController : RenderController
-	{
-		public SummaryCardController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
-		{
-		}
+    public class SummaryCardController : RenderController
+    {
+        public SummaryCardController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        {
+        }
 
-		[ModelType(typeof(SummaryCard))]
-		public override IActionResult Index()
-		{
-			var viewModel = new SummaryCard(CurrentPage, null);
+        [ModelType(typeof(SummaryCard))]
+        public override IActionResult Index()
+        {
+            var viewModel = new SummaryCard(CurrentPage, null);
 
-			// Override content in the block list
-			var target = viewModel.Blocks!.FindBlockByClass("full-name");
-			if (target != null)
-			{
-				target.Content.OverrideValue(nameof(GovukSummaryListItem.ItemValue), "Sarah Smith");
-			}
+            // Override content in the block list
+            viewModel.Blocks!.FindBlockByClass("full-name")?.Content.OverrideValue(nameof(GovukSummaryListItem.ItemValue), "Sarah Smith");
 
-			return CurrentTemplate(viewModel);
-		}
-	}
+            return CurrentTemplate(viewModel);
+        }
+    }
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryCardController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryCardController.cs
@@ -1,34 +1,33 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.Umbraco.BlockLists;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.Extensions.Logging;
-using ThePensionsRegulator.Umbraco.BlockLists;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
 
 namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
-    public class SummaryCardController : RenderController
-    {
-        public SummaryCardController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
-        {
-        }
+	public class SummaryCardController : RenderController
+	{
+		public SummaryCardController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+		{
+		}
 
-        [ModelType(typeof(SummaryCard))]
-        public override IActionResult Index()
-        {
-            var viewModel = new SummaryCard(CurrentPage, null);
+		[ModelType(typeof(SummaryCard))]
+		public override IActionResult Index()
+		{
+			var viewModel = new SummaryCard(CurrentPage, null);
 
-            // Override content in the block list
-            var target = viewModel.Blocks!.FindBlock(x => x.Content.ContentType.Alias == GovukSummaryListItem.ModelTypeAlias &&
-                                                         x.Settings.Value<string>(nameof(GovukSummaryListItemSettings.CssClasses))!.Contains("full-name"));
-            if (target != null)
-            {
-                target.Content.OverrideValue(nameof(GovukSummaryListItem.ItemValue), "Sarah Smith");
-            }
+			// Override content in the block list
+			var target = viewModel.Blocks!.FindBlockByClass("full-name");
+			if (target != null)
+			{
+				target.Content.OverrideValue(nameof(GovukSummaryListItem.ItemValue), "Sarah Smith");
+			}
 
-            return CurrentTemplate(viewModel);
-        }
-    }
+			return CurrentTemplate(viewModel);
+		}
+	}
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
@@ -1,36 +1,35 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions;
 using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.Umbraco.BlockLists;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.Extensions.Logging;
-using ThePensionsRegulator.Umbraco.BlockLists;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
 
 namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
-    public class TaskListController : RenderController
-    {
-        public TaskListController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
-        {
-        }
+	public class TaskListController : RenderController
+	{
+		public TaskListController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+		{
+		}
 
-        [ModelType(typeof(TaskList))]
-        public override IActionResult Index()
-        {
-            var viewModel = new TaskList(CurrentPage, null);
+		[ModelType(typeof(TaskList))]
+		public override IActionResult Index()
+		{
+			var viewModel = new TaskList(CurrentPage, null);
 
-            // Override content in the block list
-            var target = viewModel.Blocks!.FindBlock(x => x.Content.ContentType.Alias == GovukTask.ModelTypeAlias &&
-                                                         x.Settings.Value<string>(nameof(GovukTaskSettings.CssClasses))!.Contains("yet-another-thing"));
-            if (target != null)
-            {
-                target.Settings.OverrideValue(nameof(GovukTaskSettings.Status), TaskListTaskStatus.Completed.ToString());
-                target.Settings.OverrideValue(nameof(GovukTaskSettings.StatusText), "Done");
-            }
+			// Override content in the block list
+			var target = viewModel.Blocks!.FindBlockByClass("yet-another-thing");
+			if (target != null)
+			{
+				target.Settings.OverrideValue(nameof(GovukTaskSettings.Status), TaskListTaskStatus.Completed.ToString());
+				target.Settings.OverrideValue(nameof(GovukTaskSettings.StatusText), "Done");
+			}
 
-            return CurrentTemplate(viewModel);
-        }
-    }
+			return CurrentTemplate(viewModel);
+		}
+	}
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
@@ -10,26 +10,26 @@ using Umbraco.Cms.Web.Common.PublishedModels;
 
 namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
-	public class TaskListController : RenderController
-	{
-		public TaskListController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
-		{
-		}
+    public class TaskListController : RenderController
+    {
+        public TaskListController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        {
+        }
 
-		[ModelType(typeof(TaskList))]
-		public override IActionResult Index()
-		{
-			var viewModel = new TaskList(CurrentPage, null);
+        [ModelType(typeof(TaskList))]
+        public override IActionResult Index()
+        {
+            var viewModel = new TaskList(CurrentPage, null);
 
-			// Override content in the block list
-			var target = viewModel.Blocks!.FindBlockByClass("yet-another-thing");
-			if (target != null)
-			{
-				target.Settings.OverrideValue(nameof(GovukTaskSettings.Status), TaskListTaskStatus.Completed.ToString());
-				target.Settings.OverrideValue(nameof(GovukTaskSettings.StatusText), "Done");
-			}
+            // Override content in the block list
+            var target = viewModel.Blocks!.FindBlockByClass("yet-another-thing");
+            if (target != null)
+            {
+                target.Settings.OverrideValue(nameof(GovukTaskSettings.Status), TaskListTaskStatus.Completed.ToString());
+                target.Settings.OverrideValue(nameof(GovukTaskSettings.StatusText), "Done");
+            }
 
-			return CurrentTemplate(viewModel);
-		}
-	}
+            return CurrentTemplate(viewModel);
+        }
+    }
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ButtonViewModel.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ButtonViewModel.cs
@@ -2,8 +2,8 @@
 
 namespace GovUk.Frontend.Umbraco.ExampleApp.Models
 {
-	public class ButtonViewModel
-	{
-		public Button? Page { get; set; }
-	}
+    public class ButtonViewModel
+    {
+        public Button? Page { get; set; }
+    }
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukcssclasses.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukcssclasses.config
@@ -29,7 +29,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Applied to the outermost HTML element of the component.]]></Description>
       <SortOrder>5</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgrid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgrid.config
@@ -29,7 +29,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Applied to the grid row which contains this component and other adjacent components that have the same setting.]]></Description>
       <SortOrder>0</SortOrder>
       <Tab Alias="grid">Grid</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgridcolumnclasses.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgridcolumnclasses.config
@@ -61,7 +61,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Applied to the grid column which contains this component and other adjacent components that have the same setting.]]></Description>
       <SortOrder>4</SortOrder>
       <Tab Alias="grid">Grid</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco/BlockLists/BlockListItemExtensions.cs
+++ b/GovUk.Frontend.Umbraco/BlockLists/BlockListItemExtensions.cs
@@ -1,36 +1,36 @@
 ﻿using ThePensionsRegulator.Umbraco;
-using ThePensionsRegulator.Umbraco.BlockLists;
+using Umbraco.Cms.Core.Models.Blocks;
 
 namespace GovUk.Frontend.Umbraco.BlockLists
 {
 	public static class BlockListItemExtensions
 	{
 		/// <summary>
-		/// For a block with a "cssClasses" property in its settings, gets the classes as an overridable list.
+		/// For a block with a "cssClasses" property in its settings, gets the classes as a list.
 		/// </summary>
 		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
 		/// <returns>An overridable list of classes.</returns>
-		public static TokenList ClassList(this OverridableBlockListItem blockListItem)
+		public static TokenList ClassList(this BlockListItem blockListItem)
 		{
 			return new TokenList(blockListItem.Settings, PropertyAliases.CssClasses);
 		}
 
 		/// <summary>
-		/// For a block with a "cssClassesForRow" property in its settings, gets the classes as an overridable list.
+		/// For a block with a "cssClassesForRow" property in its settings, gets the classes as a list.
 		/// </summary>
 		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
 		/// <returns>An overridable list of classes.</returns>
-		public static TokenList ClassListForGridRow(this OverridableBlockListItem blockListItem)
+		public static TokenList ClassListForGridRow(this BlockListItem blockListItem)
 		{
 			return new TokenList(blockListItem.Settings, PropertyAliases.CssClassesForRow);
 		}
 
 		/// <summary>
-		/// For a block with a "cssClassesForColumn" property in its settings, gets the classes as an overridable list.
+		/// For a block with a "cssClassesForColumn" property in its settings, gets the classes as a list.
 		/// </summary>
 		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
 		/// <returns>An overridable list of classes.</returns>
-		public static TokenList ClassListForGridColumn(this OverridableBlockListItem blockListItem)
+		public static TokenList ClassListForGridColumn(this BlockListItem blockListItem)
 		{
 			return new TokenList(blockListItem.Settings, PropertyAliases.CssClassesForColumn);
 		}

--- a/GovUk.Frontend.Umbraco/BlockLists/BlockListItemExtensions.cs
+++ b/GovUk.Frontend.Umbraco/BlockLists/BlockListItemExtensions.cs
@@ -1,0 +1,38 @@
+﻿using ThePensionsRegulator.Umbraco;
+using ThePensionsRegulator.Umbraco.BlockLists;
+
+namespace GovUk.Frontend.Umbraco.BlockLists
+{
+	public static class BlockListItemExtensions
+	{
+		/// <summary>
+		/// For a block with a "cssClasses" property in its settings, gets the classes as an overridable list.
+		/// </summary>
+		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
+		/// <returns>An overridable list of classes.</returns>
+		public static TokenList ClassList(this OverridableBlockListItem blockListItem)
+		{
+			return new TokenList(blockListItem.Settings, PropertyAliases.CssClasses);
+		}
+
+		/// <summary>
+		/// For a block with a "cssClassesForRow" property in its settings, gets the classes as an overridable list.
+		/// </summary>
+		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
+		/// <returns>An overridable list of classes.</returns>
+		public static TokenList ClassListForGridRow(this OverridableBlockListItem blockListItem)
+		{
+			return new TokenList(blockListItem.Settings, PropertyAliases.CssClassesForRow);
+		}
+
+		/// <summary>
+		/// For a block with a "cssClassesForColumn" property in its settings, gets the classes as an overridable list.
+		/// </summary>
+		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
+		/// <returns>An overridable list of classes.</returns>
+		public static TokenList ClassListForGridColumn(this OverridableBlockListItem blockListItem)
+		{
+			return new TokenList(blockListItem.Settings, PropertyAliases.CssClassesForColumn);
+		}
+	}
+}

--- a/GovUk.Frontend.Umbraco/BlockLists/BlockListItemExtensions.cs
+++ b/GovUk.Frontend.Umbraco/BlockLists/BlockListItemExtensions.cs
@@ -20,7 +20,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// </summary>
 		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
 		/// <returns>An overridable list of classes.</returns>
-		public static TokenList ClassListForGridRow(this BlockListItem blockListItem)
+		public static TokenList GridRowClassList(this BlockListItem blockListItem)
 		{
 			return new TokenList(blockListItem.Settings, PropertyAliases.CssClassesForRow);
 		}
@@ -30,7 +30,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// </summary>
 		/// <param name="blockListItem">A block with a "cssClasses" property in its settings.</param>
 		/// <returns>An overridable list of classes.</returns>
-		public static TokenList ClassListForGridColumn(this BlockListItem blockListItem)
+		public static TokenList GridColumnClassList(this BlockListItem blockListItem)
 		{
 			return new TokenList(blockListItem.Settings, PropertyAliases.CssClassesForColumn);
 		}

--- a/GovUk.Frontend.Umbraco/BlockLists/BlockListModelExtensions.cs
+++ b/GovUk.Frontend.Umbraco/BlockLists/BlockListModelExtensions.cs
@@ -100,6 +100,52 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		}
 
 		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridRowClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridRowClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
+		{
+			return blockList.FindBlockByGridRowClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridColumnClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridColumnClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
+		{
+			return blockList.FindBlockByGridColumnClass(className, null);
+		}
+
+		/// <summary>
 		/// Recursively find the first block in a block list that has the expected class in the 'cssClasses' Umbraco property in the block's settings
 		/// </summary>
 		/// <param name="blockList">The block list to search</param>
@@ -120,6 +166,52 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		public static BlockListItem? FindBlockByClass(this IEnumerable<BlockListItem> blockList, string className)
 		{
 			return blockList.FindBlockByClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridRowClass(this IEnumerable<BlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridRowClass(this IEnumerable<BlockListItem> blockList, string className)
+		{
+			return blockList.FindBlockByGridRowClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridColumnClass(this IEnumerable<BlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridColumnClass(this IEnumerable<BlockListItem> blockList, string className)
+		{
+			return blockList.FindBlockByGridColumnClass(className, null);
 		}
 
 		/// <summary>
@@ -148,6 +240,56 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		}
 
 		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridRowClass(this IEnumerable<OverridableBlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<OverridableBlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlock(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridRowClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlockByGridRowClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridColumnClass(this IEnumerable<OverridableBlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<OverridableBlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlock(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByGridColumnClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlockByGridColumnClass(className, null);
+		}
+
+		/// <summary>
 		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClasses' Umbraco property in the block's settings
 		/// </summary>
 		/// <param name="blockLists">The block lists to search</param>
@@ -173,6 +315,56 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		}
 
 		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridRowClass(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<BlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlock(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridRowClass(this IEnumerable<BlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlockByGridRowClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridColumnClass(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<BlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlock(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByGridColumnClass(this IEnumerable<BlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlockByGridColumnClass(className, null);
+		}
+
+		/// <summary>
 		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
 		/// </summary>
 		/// <param name="blockList">The block list to search</param>
@@ -181,7 +373,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
 		public static IEnumerable<OverridableBlockListItem> FindBlocksByClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
 		{
-			return blockList.FindBlocks(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+			return blockList.FindBlocks(x => x.ClassList().Contains(className), publishedValueFallback);
 		}
 
 		/// <summary>
@@ -192,7 +384,53 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
 		public static IEnumerable<OverridableBlockListItem> FindBlocksByClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
 		{
-			return blockList.FindBlocks(x => ((OverridableBlockListItem)x).ClassList().Contains(className), null);
+			return blockList.FindBlocks(x => x.ClassList().Contains(className), null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridRowClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlocks(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridRowClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
+		{
+			return blockList.FindBlocks(x => x.GridRowClassList().Contains(className), null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridColumnClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlocks(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridColumnClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
+		{
+			return blockList.FindBlocks(x => x.GridColumnClassList().Contains(className), null);
 		}
 
 		/// <summary>
@@ -216,6 +454,52 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		public static IEnumerable<BlockListItem> FindBlocksByClass(this IEnumerable<BlockListItem> blockList, string className)
 		{
 			return blockList.FindBlocks(x => x.ClassList().Contains(className), null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridRowClass(this IEnumerable<BlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlocks(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridRowClass(this IEnumerable<BlockListItem> blockList, string className)
+		{
+			return blockList.FindBlocks(x => x.GridRowClassList().Contains(className), null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridColumnClass(this IEnumerable<BlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlocks(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridColumnClass(this IEnumerable<BlockListItem> blockList, string className)
+		{
+			return blockList.FindBlocks(x => x.GridColumnClassList().Contains(className), null);
 		}
 
 		/// <summary>
@@ -244,6 +528,56 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		}
 
 		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridRowClass(this IEnumerable<OverridableBlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<OverridableBlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlocks(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridRowClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlocksByGridRowClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridColumnClass(this IEnumerable<OverridableBlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<OverridableBlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlocks(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByGridColumnClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlocksByGridColumnClass(className, null);
+		}
+
+		/// <summary>
 		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
 		/// </summary>
 		/// <param name="blockLists">The block lists to search</param>
@@ -266,6 +600,56 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		public static IEnumerable<BlockListItem> FindBlocksByClass(this IEnumerable<BlockListModel> blockLists, string className)
 		{
 			return blockLists.FindBlocksByClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridRowClass(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<BlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlocks(x => x.GridRowClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForRow' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridRowClass(this IEnumerable<BlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlocksByGridRowClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridColumnClass(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<BlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlocks(x => x.GridColumnClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClassesForColumn' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByGridColumnClass(this IEnumerable<BlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlocksByGridColumnClass(className, null);
 		}
 	}
 }

--- a/GovUk.Frontend.Umbraco/BlockLists/BlockListModelExtensions.cs
+++ b/GovUk.Frontend.Umbraco/BlockLists/BlockListModelExtensions.cs
@@ -57,12 +57,12 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// Recursively find the first block in a set of block lists that is bound to a model property using the 'Model property' Umbraco property in the block's settings
 		/// </summary>
 		/// <param name="blockLists">The block lists to search</param>
-		/// <param name="className">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
+		/// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
 		/// <param name="publishedValueFallback">The published value fallback strategy</param>
 		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-		public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListModel> blockLists, string propertyName, IPublishedValueFallback? publishedValueFallback)
 		{
-			return blockLists.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == className, publishedValueFallback);
+			return blockLists.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == propertyName, publishedValueFallback);
 		}
 
 		/// <summary>
@@ -85,7 +85,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
 		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
 		{
-			return blockList.FindBlock(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+			return blockList.FindBlock(x => x.ClassList().Contains(className), publishedValueFallback);
 		}
 
 		/// <summary>
@@ -95,6 +95,29 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// <param name="className">The name of the class to search for</param>
 		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
 		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
+		{
+			return blockList.FindBlockByClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByClass(this IEnumerable<BlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => x.ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByClass(this IEnumerable<BlockListItem> blockList, string className)
 		{
 			return blockList.FindBlockByClass(className, null);
 		}
@@ -110,7 +133,18 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		{
 			var blocks = new List<OverridableBlockListItem>();
 			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
-			return blocks.FindBlock(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+			return blocks.FindBlock(x => x.ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlockByClass(className, null);
 		}
 
 		/// <summary>
@@ -120,7 +154,20 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// <param name="className">The name of the class to search for</param>
 		/// <param name="publishedValueFallback">The published value fallback strategy</param>
 		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		public static BlockListItem? FindBlockByClass(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<BlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlock(x => x.ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByClass(this IEnumerable<BlockListModel> blockLists, string className)
 		{
 			return blockLists.FindBlockByClass(className, null);
 		}
@@ -149,6 +196,29 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		}
 
 		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByClass(this IEnumerable<BlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlocks(x => x.ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByClass(this IEnumerable<BlockListItem> blockList, string className)
+		{
+			return blockList.FindBlocks(x => x.ClassList().Contains(className), null);
+		}
+
+		/// <summary>
 		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
 		/// </summary>
 		/// <param name="blockLists">The block lists to search</param>
@@ -159,7 +229,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		{
 			var blocks = new List<OverridableBlockListItem>();
 			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
-			return blocks.FindBlocks(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+			return blocks.FindBlocks(x => x.ClassList().Contains(className), publishedValueFallback);
 		}
 
 		/// <summary>
@@ -169,6 +239,31 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 		/// <param name="className">The name of the class to search for</param>
 		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
 		public static IEnumerable<OverridableBlockListItem> FindBlocksByClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlocksByClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByClass(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<BlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlocks(x => x.ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<BlockListItem> FindBlocksByClass(this IEnumerable<BlockListModel> blockLists, string className)
 		{
 			return blockLists.FindBlocksByClass(className, null);
 		}

--- a/GovUk.Frontend.Umbraco/BlockLists/BlockListModelExtensions.cs
+++ b/GovUk.Frontend.Umbraco/BlockLists/BlockListModelExtensions.cs
@@ -5,75 +5,172 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace GovUk.Frontend.Umbraco.BlockLists
 {
-    public static class BlockListModelExtensions
-    {
-        /// <summary>
-        /// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
-        /// </summary>
-        /// <param name="blockList">The block list to search</param>
-        /// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
-        /// <param name="publishedValueFallback">The published value fallback strategy</param>
-        /// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-        public static OverridableBlockListItem? FindBlockByBoundProperty(this IEnumerable<OverridableBlockListItem> blockList, string propertyName, IPublishedValueFallback? publishedValueFallback)
-        {
-            return blockList.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == propertyName, publishedValueFallback);
-        }
+	public static class BlockListModelExtensions
+	{
+		/// <summary>
+		/// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByBoundProperty(this IEnumerable<OverridableBlockListItem> blockList, string propertyName, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == propertyName, publishedValueFallback);
+		}
 
-        /// <summary>
-        /// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
-        /// </summary>
-        /// <param name="blockList">The block list to search</param>
-        /// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
-        /// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-        public static OverridableBlockListItem? FindBlockByBoundProperty(this IEnumerable<OverridableBlockListItem> blockList, string propertyName)
-        {
-            return blockList.FindBlockByBoundProperty(propertyName, null);
-        }
+		/// <summary>
+		/// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByBoundProperty(this IEnumerable<OverridableBlockListItem> blockList, string propertyName)
+		{
+			return blockList.FindBlockByBoundProperty(propertyName, null);
+		}
 
-        /// <summary>
-        /// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
-        /// </summary>
-        /// <param name="blockList">The block list to search</param>
-        /// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
-        /// <param name="publishedValueFallback">The published value fallback strategy</param>
-        /// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-        public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListItem> blockList, string propertyName, IPublishedValueFallback? publishedValueFallback)
-        {
-            return blockList.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == propertyName, publishedValueFallback);
-        }
+		/// <summary>
+		/// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListItem> blockList, string propertyName, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == propertyName, publishedValueFallback);
+		}
 
-        /// <summary>
-        /// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
-        /// </summary>
-        /// <param name="blockList">The block list to search</param>
-        /// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
-        /// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-        public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListItem> blockList, string propertyName)
-        {
-            return blockList.FindBlockByBoundProperty(propertyName, null);
-        }
+		/// <summary>
+		/// Recursively find the first block in a block list that is bound to a model property using the 'Model property' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListItem> blockList, string propertyName)
+		{
+			return blockList.FindBlockByBoundProperty(propertyName, null);
+		}
 
-        /// <summary>
-        /// Recursively find the first block in a set of block lists that is bound to a model property using the 'Model property' Umbraco property in the block's settings
-        /// </summary>
-        /// <param name="blockLists">The block lists to search</param>
-        /// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
-        /// <param name="publishedValueFallback">The published value fallback strategy</param>
-        /// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-        public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListModel> blockLists, string propertyName, IPublishedValueFallback? publishedValueFallback)
-        {
-            return blockLists.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == propertyName, publishedValueFallback);
-        }
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that is bound to a model property using the 'Model property' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockLists.FindBlock(x => x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString() == className, publishedValueFallback);
+		}
 
-        /// <summary>
-        /// Recursively find the first block in a set of block lists that is bound to a model property using the 'Model property' Umbraco property in the block's settings
-        /// </summary>
-        /// <param name="blockLists">The block lists to search</param>
-        /// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
-        /// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
-        public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListModel> blockLists, string propertyName)
-        {
-            return blockLists.FindBlockByBoundProperty(propertyName, null);
-        }
-    }
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that is bound to a model property using the 'Model property' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="propertyName">The name of the property on the view model (use <c>nameof(model.MyProperty)</c>)</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static BlockListItem? FindBlockByBoundProperty(this IEnumerable<BlockListModel> blockLists, string propertyName)
+		{
+			return blockLists.FindBlockByBoundProperty(propertyName, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlock(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a block list that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
+		{
+			return blockList.FindBlockByClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<OverridableBlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlock(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the first block in a set of block lists that has the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static OverridableBlockListItem? FindBlockByClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlockByClass(className, null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByClass(this IEnumerable<OverridableBlockListItem> blockList, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			return blockList.FindBlocks(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a block list and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockList">The block list to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>An IEnumerable of 0 or more matching blocks</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByClass(this IEnumerable<OverridableBlockListItem> blockList, string className)
+		{
+			return blockList.FindBlocks(x => ((OverridableBlockListItem)x).ClassList().Contains(className), null);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <param name="publishedValueFallback">The published value fallback strategy</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByClass(this IEnumerable<OverridableBlockListModel> blockLists, string className, IPublishedValueFallback? publishedValueFallback)
+		{
+			var blocks = new List<OverridableBlockListItem>();
+			foreach (var blockList in blockLists) { blocks.AddRange(blockList); }
+			return blocks.FindBlocks(x => ((OverridableBlockListItem)x).ClassList().Contains(className), publishedValueFallback);
+		}
+
+		/// <summary>
+		/// Recursively find the blocks in a set of block lists and any decendant block lists that have the expected class in the 'cssClasses' Umbraco property in the block's settings
+		/// </summary>
+		/// <param name="blockLists">The block lists to search</param>
+		/// <param name="className">The name of the class to search for</param>
+		/// <returns>The first matching block, or <c>null</c> if no blocks are matched</returns>
+		public static IEnumerable<OverridableBlockListItem> FindBlocksByClass(this IEnumerable<OverridableBlockListModel> blockLists, string className)
+		{
+			return blockLists.FindBlocksByClass(className, null);
+		}
+	}
 }

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukcssclasses.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukcssclasses.config
@@ -29,7 +29,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Applied to the outermost HTML element of the component.]]></Description>
       <SortOrder>5</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgrid.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgrid.config
@@ -29,7 +29,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Applied to the grid row which contains this component and other adjacent components that have the same setting.]]></Description>
       <SortOrder>0</SortOrder>
       <Tab Alias="grid">Grid</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridcolumnclasses.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridcolumnclasses.config
@@ -61,7 +61,7 @@
       <Type>Umbraco.TextBox</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[]]></Description>
+      <Description><![CDATA[Applied to the grid column which contains this component and other adjacent components that have the same setting.]]></Description>
       <SortOrder>4</SortOrder>
       <Tab Alias="grid">Grid</Tab>
       <Variations>Nothing</Variations>

--- a/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
@@ -68,7 +68,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		}
 
 		[Test]
-		public void Can_find_by_index()
+		public void Can_find_index_of_token()
 		{
 			var tokenList = CreateOverridableTokenList();
 

--- a/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using ThePensionsRegulator.Umbraco.Testing;
+using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace ThePensionsRegulator.Umbraco.Tests
 {
@@ -8,17 +9,24 @@ namespace ThePensionsRegulator.Umbraco.Tests
 	{
 		private const string PROPERTY_ALIAS = "alias";
 
-		private (TokenList TokenList, Mock<IOverridablePublishedElement> Settings) CreateTokenList()
+		private (TokenList TokenList, Mock<IPublishedElement> PublishedElement) CreateReadOnlyTokenList()
 		{
-			var settings = UmbracoBlockListFactory.CreateContentOrSettings()
-					.SetupUmbracoTextboxPropertyValue(PROPERTY_ALIAS, "  example-a example-b    example-c  ");
-			return (new TokenList(settings.Object, PROPERTY_ALIAS), settings);
+			var publishedElement = UmbracoContentFactory.CreateContent<IPublishedElement>();
+			publishedElement.SetupUmbracoTextboxPropertyValue(PROPERTY_ALIAS, "  example-a example-b    example-c  ");
+			return (new TokenList(publishedElement.Object, PROPERTY_ALIAS), publishedElement);
+		}
+
+		private (TokenList TokenList, Mock<IOverridablePublishedElement> Settings) CreateOverridableTokenList()
+		{
+			var publishedElement = UmbracoContentFactory.CreateContent<IOverridablePublishedElement>();
+			publishedElement.SetupUmbracoTextboxPropertyValue(PROPERTY_ALIAS, "  example-a example-b    example-c  ");
+			return (new TokenList(publishedElement.Object, PROPERTY_ALIAS), publishedElement);
 		}
 
 		[Test]
 		public void Class_list_is_tokenised()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			Assert.That(tokenList.TokenList.Count, Is.EqualTo(3));
 			Assert.That(tokenList.TokenList[0], Is.EqualTo("example-a"));
@@ -31,7 +39,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		[TestCase("example", false)]
 		public void Contains_checks_whole_tokens_only(string checkFor, bool expected)
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			var result = tokenList.TokenList.Contains(checkFor);
 
@@ -40,7 +48,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
 
 		public void Can_copy_to_array()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			var result = new string[tokenList.TokenList.Count];
 			tokenList.TokenList.CopyTo(result, 0);
@@ -53,7 +61,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		[Test]
 		public void Can_find_by_index()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			var result = tokenList.TokenList.IndexOf("example-b");
 
@@ -63,7 +71,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		[Test]
 		public void Can_add_token()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			tokenList.TokenList.Add("example-d");
 
@@ -71,9 +79,20 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		}
 
 		[Test]
+		public void Add_token_throws_if_read_only()
+		{
+			var tokenList = CreateReadOnlyTokenList();
+
+			Assert.Throws<NotSupportedException>(delegate
+			{
+				tokenList.TokenList.Add("example-d");
+			});
+		}
+
+		[Test]
 		public void Can_insert_at_index()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			tokenList.TokenList.Insert(1, "example-d");
 
@@ -81,9 +100,20 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		}
 
 		[Test]
+		public void Insert_at_index_throws_if_read_only()
+		{
+			var tokenList = CreateReadOnlyTokenList();
+
+			Assert.Throws<NotSupportedException>(delegate
+			{
+				tokenList.TokenList.Insert(1, "example-d");
+			});
+		}
+
+		[Test]
 		public void Can_remove_token()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			tokenList.TokenList.Remove("example-b");
 
@@ -91,9 +121,21 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		}
 
 		[Test]
+		public void Remove_token_throws_if_read_only()
+		{
+			var tokenList = CreateReadOnlyTokenList();
+
+			Assert.Throws<NotSupportedException>(delegate
+			{
+				tokenList.TokenList.Remove("example-b");
+			});
+		}
+
+
+		[Test]
 		public void Can_remove_at_index()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			tokenList.TokenList.RemoveAt(1);
 
@@ -101,9 +143,20 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		}
 
 		[Test]
+		public void Remove_at_index_throws_if_read_only()
+		{
+			var tokenList = CreateReadOnlyTokenList();
+
+			Assert.Throws<NotSupportedException>(delegate
+			{
+				tokenList.TokenList.RemoveAt(1);
+			});
+		}
+
+		[Test]
 		public void Can_clear_tokens()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			tokenList.TokenList.Clear();
 
@@ -111,9 +164,20 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		}
 
 		[Test]
+		public void Clear_tokens_throws_if_read_only()
+		{
+			var tokenList = CreateReadOnlyTokenList();
+
+			Assert.Throws<NotSupportedException>(delegate
+			{
+				tokenList.TokenList.Clear();
+			});
+		}
+
+		[Test]
 		public void ToString_returns_tokens()
 		{
-			var tokenList = CreateTokenList();
+			var tokenList = CreateOverridableTokenList();
 
 			var result = tokenList.TokenList.ToString();
 

--- a/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
@@ -1,0 +1,123 @@
+﻿using Moq;
+using ThePensionsRegulator.Umbraco.Testing;
+
+namespace ThePensionsRegulator.Umbraco.Tests
+{
+	[TestFixture]
+	public class TokenListTests
+	{
+		private const string PROPERTY_ALIAS = "alias";
+
+		private (TokenList TokenList, Mock<IOverridablePublishedElement> Settings) CreateTokenList()
+		{
+			var settings = UmbracoBlockListFactory.CreateContentOrSettings()
+					.SetupUmbracoTextboxPropertyValue(PROPERTY_ALIAS, "  example-a example-b    example-c  ");
+			return (new TokenList(settings.Object, PROPERTY_ALIAS), settings);
+		}
+
+		[Test]
+		public void Class_list_is_tokenised()
+		{
+			var tokenList = CreateTokenList();
+
+			Assert.That(tokenList.TokenList.Count, Is.EqualTo(3));
+			Assert.That(tokenList.TokenList[0], Is.EqualTo("example-a"));
+			Assert.That(tokenList.TokenList[1], Is.EqualTo("example-b"));
+			Assert.That(tokenList.TokenList[2], Is.EqualTo("example-c"));
+		}
+
+		[TestCase("example-b", true)]
+		[TestCase("example-d", false)]
+		[TestCase("example", false)]
+		public void Contains_checks_whole_tokens_only(string checkFor, bool expected)
+		{
+			var tokenList = CreateTokenList();
+
+			var result = tokenList.TokenList.Contains(checkFor);
+
+			Assert.That(result, Is.EqualTo(expected));
+		}
+
+		public void Can_copy_to_array()
+		{
+			var tokenList = CreateTokenList();
+
+			var result = new string[tokenList.TokenList.Count];
+			tokenList.TokenList.CopyTo(result, 0);
+
+			Assert.That(result[0], Is.EqualTo("example-a"));
+			Assert.That(result[1], Is.EqualTo("example-b"));
+			Assert.That(result[2], Is.EqualTo("example-c"));
+		}
+
+		[Test]
+		public void Can_find_by_index()
+		{
+			var tokenList = CreateTokenList();
+
+			var result = tokenList.TokenList.IndexOf("example-b");
+
+			Assert.That(result, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void Can_add_token()
+		{
+			var tokenList = CreateTokenList();
+
+			tokenList.TokenList.Add("example-d");
+
+			tokenList.Settings.Verify(x => x.OverrideValue(PROPERTY_ALIAS, "example-a example-b example-c example-d"), Times.Once);
+		}
+
+		[Test]
+		public void Can_insert_at_index()
+		{
+			var tokenList = CreateTokenList();
+
+			tokenList.TokenList.Insert(1, "example-d");
+
+			tokenList.Settings.Verify(x => x.OverrideValue(PROPERTY_ALIAS, "example-a example-d example-b example-c"), Times.Once);
+		}
+
+		[Test]
+		public void Can_remove_token()
+		{
+			var tokenList = CreateTokenList();
+
+			tokenList.TokenList.Remove("example-b");
+
+			tokenList.Settings.Verify(x => x.OverrideValue(PROPERTY_ALIAS, "example-a example-c"), Times.Once);
+		}
+
+		[Test]
+		public void Can_remove_at_index()
+		{
+			var tokenList = CreateTokenList();
+
+			tokenList.TokenList.RemoveAt(1);
+
+			tokenList.Settings.Verify(x => x.OverrideValue(PROPERTY_ALIAS, "example-a example-c"), Times.Once);
+		}
+
+		[Test]
+		public void Can_clear_tokens()
+		{
+			var tokenList = CreateTokenList();
+
+			tokenList.TokenList.Clear();
+
+			tokenList.Settings.Verify(x => x.OverrideValue(PROPERTY_ALIAS, string.Empty), Times.Once);
+		}
+
+		[Test]
+		public void ToString_returns_tokens()
+		{
+			var tokenList = CreateTokenList();
+
+			var result = tokenList.TokenList.ToString();
+
+			Assert.That(result, Is.EqualTo("example-a example-b example-c"));
+		}
+	}
+}

--- a/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/TokenListTests.cs
@@ -24,6 +24,15 @@ namespace ThePensionsRegulator.Umbraco.Tests
 		}
 
 		[Test]
+		public void Null_publishedElement_returns_empty_TokenList()
+		{
+			var list = new TokenList(null, PROPERTY_ALIAS);
+
+			Assert.That(list.Count, Is.EqualTo(0));
+			Assert.That(list.ToString(), Is.EqualTo(string.Empty));
+		}
+
+		[Test]
 		public void Class_list_is_tokenised()
 		{
 			var tokenList = CreateOverridableTokenList();

--- a/ThePensionsRegulator.Umbraco/TokenList.cs
+++ b/ThePensionsRegulator.Umbraco/TokenList.cs
@@ -49,19 +49,16 @@ namespace ThePensionsRegulator.Umbraco
 				raw = _regex.Replace(raw, _separator).Trim();
 				_tokens.AddRange(raw.Split(_separator));
 			}
-			else
-			{
-				_tokens.Clear();
-			}
 			_tokensCurrent = true;
 		}
 
 		/// <summary>
-		/// Determines the index of a specific token in the list.
+		/// Gets or sets the token at the specified index.
 		/// </summary>
-		/// <param name="index">The token to locate in the list.</param>
-		/// <returns>The index of the token if found in the list; otherwise, -1.</returns>
-		/// <exception cref="NotSupportedException">Thrown when setting if the list is read-only.</exception>
+		/// <param name="index">The zero-based index of the token to get or set..</param>
+		/// <returns>The token at the specified index.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if the index is not a valid index in the list.</exception>
+		/// <exception cref="NotSupportedException">Thrown if the property is set and the list is read-only.</exception>
 		public string this[int index]
 		{
 			get

--- a/ThePensionsRegulator.Umbraco/TokenList.cs
+++ b/ThePensionsRegulator.Umbraco/TokenList.cs
@@ -10,7 +10,7 @@ namespace ThePensionsRegulator.Umbraco
 	/// </summary>
 	public class TokenList : IList<string>
 	{
-		private readonly IPublishedElement _publishedElement;
+		private readonly IPublishedElement? _publishedElement;
 		private readonly IOverridablePublishedElement? _overridablePublishedElement;
 		private readonly string _propertyName;
 		private readonly List<string> _tokens = new();
@@ -26,15 +26,14 @@ namespace ThePensionsRegulator.Umbraco
 		/// <param name="propertyName">The name of the Umbraco property where the tokens are stored.</param>
 		/// <param name="separator">The string with which tokens are separated in the property value.</param>
 		/// <exception cref="ArgumentException">Thrown is <c>propertyName</c> is <c>null</c> or an empty string.</exception>
-		/// <exception cref="ArgumentNullException">Thrown if <c>publishedElement</c> is <c>null</c>.</exception>
-		public TokenList(IPublishedElement publishedElement, string propertyName, string separator = " ")
+		public TokenList(IPublishedElement? publishedElement, string propertyName, string separator = " ")
 		{
 			if (string.IsNullOrEmpty(propertyName))
 			{
 				throw new ArgumentException($"'{nameof(propertyName)}' cannot be null or empty.", nameof(propertyName));
 			}
 
-			_publishedElement = publishedElement ?? throw new ArgumentNullException(nameof(publishedElement));
+			_publishedElement = publishedElement;
 			_overridablePublishedElement = _publishedElement as IOverridablePublishedElement;
 			_isReadOnly = _overridablePublishedElement == null;
 			_propertyName = propertyName;
@@ -43,12 +42,16 @@ namespace ThePensionsRegulator.Umbraco
 
 		private void Tokenise()
 		{
-			var raw = _isReadOnly ? _publishedElement.Value<string>(_propertyName) : _overridablePublishedElement!.Value<string>(_propertyName);
+			var raw = _isReadOnly ? _publishedElement?.Value<string>(_propertyName) : _overridablePublishedElement!.Value<string>(_propertyName);
 			_tokens.Clear();
 			if (!string.IsNullOrEmpty(raw))
 			{
 				raw = _regex.Replace(raw, _separator).Trim();
 				_tokens.AddRange(raw.Split(_separator));
+			}
+			else
+			{
+				_tokens.Clear();
 			}
 			_tokensCurrent = true;
 		}

--- a/ThePensionsRegulator.Umbraco/TokenList.cs
+++ b/ThePensionsRegulator.Umbraco/TokenList.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections;
 using System.Text.RegularExpressions;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
 
 namespace ThePensionsRegulator.Umbraco
 {
@@ -8,11 +10,13 @@ namespace ThePensionsRegulator.Umbraco
 	/// </summary>
 	public class TokenList : IList<string>
 	{
-		private readonly IOverridablePublishedElement _publishedElement;
+		private readonly IPublishedElement _publishedElement;
+		private readonly IOverridablePublishedElement? _overridablePublishedElement;
 		private readonly string _propertyName;
 		private readonly List<string> _tokens = new();
 		private bool _tokensCurrent = false;
 		private Regex _regex = new Regex(@"\s+", RegexOptions.Compiled);
+		private readonly bool _isReadOnly;
 		private readonly string _separator;
 
 		/// <summary>
@@ -23,7 +27,7 @@ namespace ThePensionsRegulator.Umbraco
 		/// <param name="separator">The string with which tokens are separated in the property value.</param>
 		/// <exception cref="ArgumentException">Thrown is <c>propertyName</c> is <c>null</c> or an empty string.</exception>
 		/// <exception cref="ArgumentNullException">Thrown if <c>publishedElement</c> is <c>null</c>.</exception>
-		public TokenList(IOverridablePublishedElement publishedElement, string propertyName, string separator = " ")
+		public TokenList(IPublishedElement publishedElement, string propertyName, string separator = " ")
 		{
 			if (string.IsNullOrEmpty(propertyName))
 			{
@@ -31,13 +35,15 @@ namespace ThePensionsRegulator.Umbraco
 			}
 
 			_publishedElement = publishedElement ?? throw new ArgumentNullException(nameof(publishedElement));
+			_overridablePublishedElement = _publishedElement as IOverridablePublishedElement;
+			_isReadOnly = _overridablePublishedElement == null;
 			_propertyName = propertyName;
 			_separator = separator;
 		}
 
 		private void Tokenise()
 		{
-			var raw = _publishedElement.Value<string>(_propertyName);
+			var raw = _isReadOnly ? _publishedElement.Value<string>(_propertyName) : _overridablePublishedElement!.Value<string>(_propertyName);
 			_tokens.Clear();
 			if (!string.IsNullOrEmpty(raw))
 			{
@@ -52,6 +58,7 @@ namespace ThePensionsRegulator.Umbraco
 		/// </summary>
 		/// <param name="index">The token to locate in the list.</param>
 		/// <returns>The index of the token if found in the list; otherwise, -1.</returns>
+		/// <exception cref="NotSupportedException">Thrown when setting if the list is read-only.</exception>
 		public string this[int index]
 		{
 			get
@@ -62,9 +69,10 @@ namespace ThePensionsRegulator.Umbraco
 			}
 			set
 			{
+				if (_isReadOnly) { throw new NotSupportedException($"The {nameof(TokenList)} is read-only."); }
 				if (!_tokensCurrent) { Tokenise(); }
 				_tokens[index] = value;
-				_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+				_overridablePublishedElement!.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
 			}
 		}
 
@@ -84,30 +92,34 @@ namespace ThePensionsRegulator.Umbraco
 		/// <summary>
 		/// Gets a value indicating whether the list is read-only.
 		/// </summary>
-		/// <returns>false</returns>
-		public bool IsReadOnly => false;
+		/// <returns>true if the list is read-only; otherwise, false</returns>
+		public bool IsReadOnly => _isReadOnly;
 
 		/// <summary>
 		/// Adds a token to the list.
 		/// </summary>
 		/// <param name="token">The token to add to the list</param>
+		/// <exception cref="NotSupportedException">Thrown if the list is read-only.</exception>
 		public void Add(string token)
 		{
+			if (_isReadOnly) { throw new NotSupportedException($"The {nameof(TokenList)} is read-only."); }
 			if (!_tokensCurrent) { Tokenise(); }
 			if (!_tokens.Contains(token))
 			{
 				_tokens.Add(token);
-				_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+				_overridablePublishedElement!.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
 			}
 		}
 
 		/// <summary>
 		/// Removes all tokens from the list.
 		/// </summary>
+		/// <exception cref="NotSupportedException">Thrown if the list is read-only.</exception>
 		public void Clear()
 		{
+			if (_isReadOnly) { throw new NotSupportedException($"The {nameof(TokenList)} is read-only."); }
 			_tokens.Clear();
-			_publishedElement.OverrideValue(_propertyName, string.Empty);
+			_overridablePublishedElement!.OverrideValue(_propertyName, string.Empty);
 		}
 
 		/// <summary>
@@ -162,11 +174,13 @@ namespace ThePensionsRegulator.Umbraco
 		/// </summary>
 		/// <param name="index">The zero-based index at which the token should be inserted.</param>
 		/// <param name="token">The token to insert into the list.</param>
+		/// <exception cref="NotSupportedException">Thrown if the list is read-only.</exception>
 		public void Insert(int index, string token)
 		{
+			if (_isReadOnly) { throw new NotSupportedException($"The {nameof(TokenList)} is read-only."); }
 			if (!_tokensCurrent) { Tokenise(); }
 			_tokens.Insert(index, token);
-			_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+			_overridablePublishedElement!.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
 		}
 
 		/// <summary>
@@ -174,11 +188,13 @@ namespace ThePensionsRegulator.Umbraco
 		/// </summary>
 		/// <param name="token">The token to remove from the list.</param>
 		/// <returns>true if the token was successfully removed; otherwise, false. This method also returns false if the token is not found.</returns>
+		/// <exception cref="NotSupportedException">Thrown if the list is read-only.</exception>
 		public bool Remove(string token)
 		{
+			if (_isReadOnly) { throw new NotSupportedException($"The {nameof(TokenList)} is read-only."); }
 			if (!_tokensCurrent) { Tokenise(); }
 			var result = _tokens.Remove(token);
-			if (result) { _publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray())); }
+			if (result) { _overridablePublishedElement!.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray())); }
 			return result;
 		}
 
@@ -186,11 +202,13 @@ namespace ThePensionsRegulator.Umbraco
 		/// Removes the list item at the specified index.
 		/// </summary>
 		/// <param name="index">The zero-based index of the item to remove.</param>
+		/// <exception cref="NotSupportedException">Thrown if the list is read-only.</exception>
 		public void RemoveAt(int index)
 		{
+			if (_isReadOnly) { throw new NotSupportedException($"The {nameof(TokenList)} is read-only."); }
 			if (!_tokensCurrent) { Tokenise(); }
 			_tokens.RemoveAt(index);
-			_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+			_overridablePublishedElement!.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
 		}
 
 		/// <summary>

--- a/ThePensionsRegulator.Umbraco/TokenList.cs
+++ b/ThePensionsRegulator.Umbraco/TokenList.cs
@@ -1,0 +1,216 @@
+﻿using System.Collections;
+using System.Text.RegularExpressions;
+
+namespace ThePensionsRegulator.Umbraco
+{
+	/// <summary>
+	/// Exposes a property of an <see cref="IOverridablePublishedElement"/> as a list of tokens.
+	/// </summary>
+	public class TokenList : IList<string>
+	{
+		private readonly IOverridablePublishedElement _publishedElement;
+		private readonly string _propertyName;
+		private readonly List<string> _tokens = new();
+		private bool _tokensCurrent = false;
+		private Regex _regex = new Regex(@"\s+", RegexOptions.Compiled);
+		private readonly string _separator;
+
+		/// <summary>
+		/// Creates a new <see cref="TokenList"/>
+		/// </summary>
+		/// <param name="publishedElement">The Umbraco content or element containing the property with the tokenised value.</param>
+		/// <param name="propertyName">The name of the Umbraco property where the tokens are stored.</param>
+		/// <param name="separator">The string with which tokens are separated in the property value.</param>
+		/// <exception cref="ArgumentException">Thrown is <c>propertyName</c> is <c>null</c> or an empty string.</exception>
+		/// <exception cref="ArgumentNullException">Thrown if <c>publishedElement</c> is <c>null</c>.</exception>
+		public TokenList(IOverridablePublishedElement publishedElement, string propertyName, string separator = " ")
+		{
+			if (string.IsNullOrEmpty(propertyName))
+			{
+				throw new ArgumentException($"'{nameof(propertyName)}' cannot be null or empty.", nameof(propertyName));
+			}
+
+			_publishedElement = publishedElement ?? throw new ArgumentNullException(nameof(publishedElement));
+			_propertyName = propertyName;
+			_separator = separator;
+		}
+
+		private void Tokenise()
+		{
+			var raw = _publishedElement.Value<string>(_propertyName);
+			_tokens.Clear();
+			if (!string.IsNullOrEmpty(raw))
+			{
+				raw = _regex.Replace(raw, _separator).Trim();
+				_tokens.AddRange(raw.Split(_separator));
+			}
+			_tokensCurrent = true;
+		}
+
+		/// <summary>
+		/// Determines the index of a specific token in the list.
+		/// </summary>
+		/// <param name="index">The token to locate in the list.</param>
+		/// <returns>The index of the token if found in the list; otherwise, -1.</returns>
+		public string this[int index]
+		{
+			get
+			{
+				if (!_tokensCurrent) { Tokenise(); }
+				return _tokens[index];
+
+			}
+			set
+			{
+				if (!_tokensCurrent) { Tokenise(); }
+				_tokens[index] = value;
+				_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+			}
+		}
+
+		/// <summary>
+		/// Gets the number of tokens contained in the list.
+		/// </summary>
+		/// <returns>The number of tokens contained in the list.</returns>
+		public int Count
+		{
+			get
+			{
+				if (!_tokensCurrent) { Tokenise(); }
+				return _tokens.Count;
+			}
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether the list is read-only.
+		/// </summary>
+		/// <returns>false</returns>
+		public bool IsReadOnly => false;
+
+		/// <summary>
+		/// Adds a token to the list.
+		/// </summary>
+		/// <param name="token">The token to add to the list</param>
+		public void Add(string token)
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			if (!_tokens.Contains(token))
+			{
+				_tokens.Add(token);
+				_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+			}
+		}
+
+		/// <summary>
+		/// Removes all tokens from the list.
+		/// </summary>
+		public void Clear()
+		{
+			_tokens.Clear();
+			_publishedElement.OverrideValue(_propertyName, string.Empty);
+		}
+
+		/// <summary>
+		/// Determines whether the list contains a specific token.
+		/// </summary>
+		/// <param name="token">The token to locate in the list.</param>
+		/// <returns>true if the token is found in the list; otherwise, false.</returns>
+		public bool Contains(string token)
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			return _tokens.Contains(token);
+		}
+
+
+		/// <summary>
+		/// Copies the tokens to a System.Array, starting at a particular System.Array index.
+		/// </summary>
+		/// <param name="array">The one-dimensional System.Array that is the destination of the tokens copied. The System.Array must have zero-based indexing.</param>
+		/// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
+		/// <exception cref="ArgumentNullException">array is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">arrayIndex is less than 0.</exception>
+		/// <exception cref="ArgumentException">The number of tokens is greater than the available space from arrayIndex to the end of the destination array.</exception>
+		public void CopyTo(string[] array, int arrayIndex)
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			_tokens.CopyTo(array, arrayIndex);
+		}
+
+		/// <summary>
+		/// Returns an enumerator that iterates through the tokens.
+		/// </summary>
+		/// <returns>An enumerator that can be used to iterate through the tokens.</returns>
+		public IEnumerator<string> GetEnumerator()
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			return _tokens.GetEnumerator();
+		}
+
+		/// <summary>
+		/// Determines the index of a specific token in the list.
+		/// </summary>
+		/// <param name="token">The token to locate in the list.</param>
+		/// <returns>The index of token if found in the list; otherwise, -1.</returns>
+		public int IndexOf(string token)
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			return _tokens.IndexOf(token);
+		}
+
+		/// <summary>
+		/// Inserts a token to the list at the specified index.
+		/// </summary>
+		/// <param name="index">The zero-based index at which the token should be inserted.</param>
+		/// <param name="token">The token to insert into the list.</param>
+		public void Insert(int index, string token)
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			_tokens.Insert(index, token);
+			_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+		}
+
+		/// <summary>
+		/// Removes the first occurrence of a specific token from the list.
+		/// </summary>
+		/// <param name="token">The token to remove from the list.</param>
+		/// <returns>true if the token was successfully removed; otherwise, false. This method also returns false if the token is not found.</returns>
+		public bool Remove(string token)
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			var result = _tokens.Remove(token);
+			if (result) { _publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray())); }
+			return result;
+		}
+
+		/// <summary>
+		/// Removes the list item at the specified index.
+		/// </summary>
+		/// <param name="index">The zero-based index of the item to remove.</param>
+		public void RemoveAt(int index)
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			_tokens.RemoveAt(index);
+			_publishedElement.OverrideValue(_propertyName, string.Join(_separator, _tokens.ToArray()));
+		}
+
+		/// <summary>
+		/// Returns an enumerator that iterates through the tokens.
+		/// </summary>
+		/// <returns>An enumerator that can be used to iterate through the tokens.</returns>
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		/// <summary>
+		/// Returns the list of tokens separated by the separator specified in the constructor.
+		/// </summary>
+		/// <returns>The list of tokens separated by the separator specified in the constructor.</returns>
+		public override string ToString()
+		{
+			if (!_tokensCurrent) { Tokenise(); }
+			return string.Join(_separator, _tokens.ToArray());
+		}
+	}
+}


### PR DESCRIPTION
**This is a follow-up to #181, so that should be merged before reviewing this.**

For solutions using `ThePensionsRegulator.GovUk.Umbraco` this PR adds the ability to do things like:

```csharp
var block = blockList.FindBlockByClass("my-class-name");
if (block.ClassList().Contains("change-me")) 
{
    block.ClassList().Add("my-new-class");
}

var blocks = blockList.FindBlocksByClass("my-class-name");
foreach (var block in blocks)
{
    block.ClassList().Remove("my-old-class");
}
```

There are also versions to find blocks by classes in the 'CSS classes for row' and 'CSS classes for column' fields.

Full functionality is only available for an `OverridableBlockListItem`, but read-only methods such as `block.ClassList().Contains("my-class-name")` will also work for `BlockListItem`.

Help text is also added in the back office to explain where classes are applied to.