### PR TITLE
Since adding a setter for BlockListModel.Filter it was not always applied

### DIFF
--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,7 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->
 	<PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
We want a filter to be applied to nested block lists, so that we can hide a radio button within a radios component for example. 

The filter was passed down the tree by the constructor of `OverridableBlockListModel`, so our original pattern of passing an Umbraco ModelsBuilder `BlockListModel` to `new OverridableBlockListModel()` on a custom view model worked.

With recent changes ModelsBuilder now generates an `OverridableBlockListModel` directly, which is very convenient but it means you set the filter after the constructor has run, and it wasn't getting passed down to child block lists.

This PR fixes that.