### PR TITLE
Simplify the syntax for filtering blocks

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/BlockListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/BlockListController.cs
@@ -28,7 +28,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
             };
 
             // Filter out a block in the block list
-            viewModel.Page.Blocks!.Filter = blocks => blocks.Where(block => block.Settings.Value<string>("cssClassesForRow") != "filter-this");
+            viewModel.Page.Blocks!.Filter = block => block.Settings.Value<string>("cssClassesForRow") != "filter-this";
 
             // Override content in the block list
             viewModel.Page.Blocks.First(x => x.GridRowClassList().Contains("override-this"))?

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
@@ -7,9 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Web;
 using ThePensionsRegulator.Umbraco.BlockLists;
 using Umbraco.Cms.Core.Web;
@@ -65,29 +63,29 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
                     return Redirect(path + (query.Count > 0 ? "?" + query.ToString() : string.Empty));
                 }
 
-                Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>> filter;
+                Func<OverridableBlockListItem, bool> filter;
                 if (pagination.TotalItems > pagination.PageSize)
                 {
                     if (pagination.TotalItems > (pagination.PageSize * pagination.LargeNumberOfPagesThreshold))
                     {
-                        filter = x => x.Where(block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
+                        filter = block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
                             (!block.GridRowClassList().Contains("tpr-pagination-small") &&
-                            !block.GridRowClassList().Contains("tpr-pagination-none"))
+                            !block.GridRowClassList().Contains("tpr-pagination-none")
                         );
                     }
                     else
                     {
-                        filter = x => x.Where(block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
+                        filter = block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
                             (!block.GridRowClassList().Contains("tpr-pagination-none") &&
-                            !block.GridRowClassList().Contains("tpr-pagination-large"))
+                            !block.GridRowClassList().Contains("tpr-pagination-large")
                         );
                     }
                 }
                 else
                 {
-                    filter = x => x.Where(block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
+                    filter = block => block.Content.ContentType.Alias != GovukTypography.ModelTypeAlias ||
                         (!block.GridRowClassList().Contains("tpr-pagination-small") &&
-                        !block.GridRowClassList().Contains("tpr-pagination-large"))
+                        !block.GridRowClassList().Contains("tpr-pagination-large")
                     );
                 }
                 viewModel.Page.Blocks!.Filter = filter;

--- a/GovUk.Frontend.Umbraco/BlockLists/IOverridablePublishedElementExtensions.cs
+++ b/GovUk.Frontend.Umbraco/BlockLists/IOverridablePublishedElementExtensions.cs
@@ -39,7 +39,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
         public static void OverrideCheckboxes(this IOverridablePublishedElement blockContent,
             IEnumerable<CheckboxItemBase> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
-            Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>? filter)
+            Func<OverridableBlockListItem, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideCheckboxes), new List<string> { ElementTypeAliases.Checkboxes }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
 
@@ -100,7 +100,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
         public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent,
             IEnumerable<RadioItemBase> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
-            Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>? filter)
+            Func<OverridableBlockListItem, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideRadioButtons), new List<string> { ElementTypeAliases.Radios }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
 
@@ -161,7 +161,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
         public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
             IEnumerable<SelectOption> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
-            Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>? filter)
+            Func<OverridableBlockListItem, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideSelectOptions), new List<string> { ElementTypeAliases.Select }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
 
@@ -203,7 +203,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
         public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListAction> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
-            Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>? filter)
+            Func<OverridableBlockListItem, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideSummaryListItems), new List<string> { ElementTypeAliases.SummaryCard }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
 
@@ -233,7 +233,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
         public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListItem> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
-            Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>? filter)
+            Func<OverridableBlockListItem, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideSummaryListItems), new List<string> { ElementTypeAliases.SummaryList, ElementTypeAliases.SummaryCard }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
 
@@ -261,7 +261,7 @@ namespace GovUk.Frontend.Umbraco.BlockLists
 
         private static OverridableBlockListModel CreateSummaryListActionBlocks(IEnumerable<SummaryListAction> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
-            Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>? filter)
+            Func<OverridableBlockListItem, bool>? filter)
         {
             var blockListItems = new List<OverridableBlockListItem>();
             foreach (var item in items)

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkCheckboxes.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkCheckboxes.cshtml
@@ -54,7 +54,7 @@
                     {
                         <govuk-checkboxes-error-message>@(string.Join(". ", modelStateEntry.Errors.Where(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR).Select(x => x.ErrorMessage)))</govuk-checkboxes-error-message>
                     }
-                    foreach (var block in checkboxes.Filter(checkboxes))
+                    foreach (var block in checkboxes.FilteredBlocks())
                     {
                         if (block.Content.ContentType.Alias == ElementTypeAliases.CheckboxesDivider)
                         {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkRadios.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkRadios.cshtml
@@ -54,7 +54,7 @@
                 {
                     <govuk-radios-error-message>@(string.Join(". ", modelStateEntry.Errors.Where(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR).Select(x => x.ErrorMessage)))</govuk-radios-error-message>
                 }
-                @foreach (var block in radioButtons.Filter(radioButtons))
+                @foreach (var block in radioButtons.FilteredBlocks())
                 {
                     if (block.Content.ContentType.Alias == ElementTypeAliases.RadiosDivider)
                     {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryCard.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryCard.cshtml
@@ -14,7 +14,7 @@
         headingLevel = 2;
     }
     var cardActionsModel = Model.Content?.Value<OverridableBlockListModel>(PropertyAliases.SummaryCardActions)!;
-    var cardActions = cardActionsModel.Filter(cardActionsModel);
+    var cardActions = cardActionsModel.FilteredBlocks();
     var listItems = Model.Content?.Value<OverridableBlockListModel>(PropertyAliases.SummaryCardListItems)!;
 }
 <govuk-summary-card id="@Model.Content?.Key" class="@cssClasses">
@@ -33,14 +33,14 @@
         </govuk-summary-card-actions>
     }
     <govuk-summary-list>
-        @foreach (var listItem in listItems.Filter(listItems))
+        @foreach (var listItem in listItems.FilteredBlocks())
         {
             <govuk-summary-list-row class="@(listItem.Settings.Value<string>(PropertyAliases.CssClasses))">
                 <govuk-summary-list-row-key>@(listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey))</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@(listItem.Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue))</govuk-summary-list-row-value>
                 @{
                     var rowActionsModel = listItem.Content.Value<OverridableBlockListModel>(PropertyAliases.SummaryListItemActions)!;
-                    var rowActions = rowActionsModel.Filter(rowActionsModel);
+                    var rowActions = rowActionsModel.FilteredBlocks();
                     if (rowActions.Any())
                     {
                         <govuk-summary-list-row-actions>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryList.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryList.cshtml
@@ -11,14 +11,14 @@
     var listItems = Model.Content.Value<OverridableBlockListModel>(PropertyAliases.SummaryListItems)!;
 }
 <govuk-summary-list id="@Model.Content.Key" class="@cssClasses">
-    @foreach (var listItem in listItems.Filter(listItems))
+    @foreach (var listItem in listItems.FilteredBlocks())
     {
         <govuk-summary-list-row class="@(listItem.Settings.Value<string>(PropertyAliases.CssClasses))">
             <govuk-summary-list-row-key>@(listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey))</govuk-summary-list-row-key>
             <govuk-summary-list-row-value>@(listItem.Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue))</govuk-summary-list-row-value>
             @{
                 var actionsModel = listItem.Content.Value<OverridableBlockListModel>(PropertyAliases.SummaryListItemActions)!;
-                var actions = actionsModel.Filter(actionsModel);
+                var actions = actionsModel.FilteredBlocks();
                 if (actions.Any()) 
                 {
                     <govuk-summary-list-row-actions>

--- a/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
@@ -9,10 +9,10 @@ namespace ThePensionsRegulator.Frontend
     {
         public static IServiceCollection AddTprFrontend(this IServiceCollection services)
         {
-            return services.AddTprFrontendExtensions(options => { options.AddImportsToHtml = false; });
+            return services.AddTprFrontend(options => { options.AddImportsToHtml = false; });
         }
 
-        public static IServiceCollection AddTprFrontendExtensions(
+        public static IServiceCollection AddTprFrontend(
             this IServiceCollection services,
             Action<GovUkFrontendAspNetCoreOptions> options)
         {

--- a/ThePensionsRegulator.Umbraco.Tests/OverridableBlockListModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/OverridableBlockListModelTests.cs
@@ -102,7 +102,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
             // Arrange
             var blockLists = CreateThreeNestedOverridableBlockLists();
 
-            var filter = new Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>(x => x.Reverse());
+            var filter = new Func<OverridableBlockListItem, bool>(block => true);
 
             // Act
             var model = new OverridableBlockListModel(blockLists.ParentBlockList, filter);
@@ -123,7 +123,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
             // Arrange
             var blockLists = CreateThreeNestedOverridableBlockLists();
 
-            var filter = new Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>(x => x.Reverse());
+            var filter = new Func<OverridableBlockListItem, bool>(block => true);
 
             // Act
             var model = new OverridableBlockListModel(blockLists.ParentBlockList, null);
@@ -146,7 +146,7 @@ namespace ThePensionsRegulator.Umbraco.Tests
                                     )
                                 );
 
-            blockList.Filter = blocks => Array.Empty<OverridableBlockListItem>();
+            blockList.Filter = block => false;
 
             // Act + Assert
             Assert.That(() => blockList[0], Throws.Nothing);

--- a/ThePensionsRegulator.Umbraco/BlockLists/OverridableBlockListModel.cs
+++ b/ThePensionsRegulator.Umbraco/BlockLists/OverridableBlockListModel.cs
@@ -15,7 +15,7 @@ namespace ThePensionsRegulator.Umbraco.BlockLists
     public class OverridableBlockListModel : IEnumerable<OverridableBlockListItem>
     {
         private readonly List<OverridableBlockListItem> _items = new();
-        private static Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>> DefaultFilter = (x => x);
+        private static Func<OverridableBlockListItem, bool> DefaultFilter = (x => true);
 
         /// <summary>
         /// Creates a new <see cref="OverridableBlockListModel"/> with no items.
@@ -30,7 +30,7 @@ namespace ThePensionsRegulator.Umbraco.BlockLists
         /// <param name="blockListItems">A block list (typically a <see cref="BlockListModel"/>).</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <param name="publishedElementFactory">Factory method to create an <see cref="IPublishedElement"/> that supports overriding property values.</param>
-        public OverridableBlockListModel(IEnumerable<BlockListItem> blockListItems, Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>>? filter = null, Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
+        public OverridableBlockListModel(IEnumerable<BlockListItem> blockListItems, Func<OverridableBlockListItem, bool>? filter = null, Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
         {
             if (blockListItems is null)
             {
@@ -96,12 +96,12 @@ namespace ThePensionsRegulator.Umbraco.BlockLists
             }
         }
 
-        private Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>> _filter = DefaultFilter;
+        private Func<OverridableBlockListItem, bool> _filter = DefaultFilter;
 
         /// <summary>
         /// The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.
         /// </summary>
-        public Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>> Filter
+        public Func<OverridableBlockListItem, bool> Filter
         {
             get { return _filter; }
             set
@@ -112,7 +112,7 @@ namespace ThePensionsRegulator.Umbraco.BlockLists
             }
         }
 
-        private void CopyFilterToDecendantBlockLists(IEnumerable<OverridableBlockListItem> blockListItems, Func<IEnumerable<OverridableBlockListItem>, IEnumerable<OverridableBlockListItem>> filter)
+        private void CopyFilterToDecendantBlockLists(IEnumerable<OverridableBlockListItem> blockListItems, Func<OverridableBlockListItem, bool> filter)
         {
             foreach (var blockListItem in blockListItems)
             {
@@ -134,7 +134,7 @@ namespace ThePensionsRegulator.Umbraco.BlockLists
         /// <returns></returns>
         public IEnumerable<OverridableBlockListItem> FilteredBlocks()
         {
-            return Filter(_items);
+            return _items.Where(Filter);
         }
 
         /// <summary>

--- a/docs/umbraco/filter-blocks.md
+++ b/docs/umbraco/filter-blocks.md
@@ -8,10 +8,9 @@ using ThePensionsRegulator.Umbraco.BlockLists
 
 var viewModel = new MyDocumentType(CurrentPage, null);
 
-viewModel.Blocks!.Filter = model =>
-    model.Where(block =>
+viewModel.Blocks!.Filter = block =>
         block.Content.ContentType.Alias != GovukRadio.ModelTypeAlias ||
-        ((GovukRadio)block.Content).Value != "not-relevant");
+        ((GovukRadio)block.Content).Value != "not-relevant";
 
 /// View
 <partial name="GOVUK/BlockList" model="Model.Blocks" />


### PR DESCRIPTION
Having reviewed every use of block filtering in our applications it was clear that the syntax for filtering was overly complex. We always run a `.Where` query on the blocks which requires calling code to supply a nested lambda statement. 

The PR changes the syntax to run `.Where` internally so calling code only needs to supply the inner lambda. The filter receives a single block and returns true to include it or false to exclude it. This aligns with the syntax for similar features like [JavaScript's array.filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).

Updating existing code is simple - just remove the outer lambda.

```csharp
// Before
model.Blocks.Filter = blocks => (block => block.Value<bool>("isIncluded"))

// After
model.Blocks.Filter = block => block.Value<bool>("isIncluded")
```