### PR TITLE
Do not hard-code the 'TPR' as a path for partial views in the GOV.UK project

### DIFF
--- a/GovUk.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/GovUk.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ namespace GovUk.Frontend.Umbraco
             services.AddTransient<IPropertyValueFormatter, GovUkTypographyPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, NoParagraphPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, NoParagraphInversePropertyValueFormatter>();
+            services.AddTransient<IPartialViewPathProvider, GovUkPartialViewPathProvider>();
 
             return services;
         }

--- a/GovUk.Frontend.Umbraco/Services/GovUkPartialViewPathProvider.cs
+++ b/GovUk.Frontend.Umbraco/Services/GovUkPartialViewPathProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace GovUk.Frontend.Umbraco.Services
+{
+    /// <inheritdoc/>
+    public class GovUkPartialViewPathProvider : IPartialViewPathProvider
+    {
+        /// <inheritdoc/>
+        public bool IsProvider(IBlockReference<IPublishedElement, IPublishedElement> block) => block?.Content?.ContentType?.Alias?.StartsWith("GOVUK", StringComparison.OrdinalIgnoreCase) ?? false;
+        /// <inheritdoc/>
+        public string BuildPartialViewPath(IBlockReference<IPublishedElement, IPublishedElement> block) => "GOVUK/" + block?.Content?.ContentType?.Alias;
+
+    }
+}

--- a/GovUk.Frontend.Umbraco/Services/IPartialViewPathProvider.cs
+++ b/GovUk.Frontend.Umbraco/Services/IPartialViewPathProvider.cs
@@ -1,0 +1,25 @@
+﻿using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace GovUk.Frontend.Umbraco.Services
+{
+    /// <summary>
+    /// Provides a relative or absolute path to a partial view based on the properties of an object.
+    /// </summary>
+    public interface IPartialViewPathProvider
+    {
+        /// <summary>
+        /// Gets a value indicating whether the provider can provide a partial view path for a block.
+        /// </summary>
+        /// <param name="block">The block.</param>
+        /// <returns>A value indicating whether the provider can provide a partial view path for a block.</returns>
+        bool IsProvider(IBlockReference<IPublishedElement, IPublishedElement> block);
+
+        /// <summary>
+        /// Builds a partial view path based on the properties of the block. Check that <see cref="IsProvider(IBlockReference{IPublishedElement, IPublishedElement})" /> returns <c>true</c> for the block before calling this method.
+        /// </summary>
+        /// <param name="block">The block.</param>
+        /// <returns>A relative or absolute partial view path.</returns>
+        string BuildPartialViewPath(IBlockReference<IPublishedElement, IPublishedElement> block);
+    }
+}

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/BlockList.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/BlockList.cshtml
@@ -1,4 +1,5 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IEnumerable<BlockListItem>>
+@inject IEnumerable<IPartialViewPathProvider> pathProviders;
 @using GovUk.Frontend.AspNetCore.Extensions;
 @using GovUk.Frontend.Umbraco
 @using GovUk.Frontend.Umbraco.Models
@@ -73,7 +74,21 @@
                                                     blocks[i+1].Settings?.Value<string>(PropertyAliases.CssClassesForColumn),
                                                     blocks[i+1].Content.ContentType.Alias));
 
-    var pathToView = (blocks[i].Content.ContentType.Alias.StartsWith("GOVUK", StringComparison.OrdinalIgnoreCase) ? "GOVUK/" : "TPR/") + blocks[i].Content.ContentType.Alias;
+    var pathToView = string.Empty;
+    foreach (var pathProvider in pathProviders)
+    {
+        if (pathProvider.IsProvider(blocks[i]))
+        {
+            pathToView = pathProvider.BuildPartialViewPath(blocks[i]);
+            break;
+        }
+    }
+    if (string.IsNullOrEmpty(pathToView)) 
+    { 
+        throw new InvalidOperationException(
+            $"No {nameof(IPartialViewPathProvider)} was found to provide a path for the block with content key {blocks[i].Content.Key}, of content type {blocks[i].Content.ContentType.Alias}"
+        ); 
+    }
 
     @if (filteredModel.RenderGrid && !isGridRowBlock && !sameAsPrevious) { 
         @:<div class="@rowClass"> 

--- a/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
 using GovUk.Frontend.AspNetCore;
 using GovUk.Frontend.Umbraco;
+using GovUk.Frontend.Umbraco.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using ThePensionsRegulator.Frontend.Services;
 using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
+using ThePensionsRegulator.Frontend.Umbraco.Services;
 using ThePensionsRegulator.Umbraco.PropertyEditors;
 
 namespace ThePensionsRegulator.Frontend.Umbraco
@@ -31,6 +33,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             services.AddTransient<IPropertyValueFormatter, HostNameInRichTextEditorPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, HostNameInMultiUrlPickerPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, NoParagraphsPropertyValueFormatter>();
+            services.AddTransient<IPartialViewPathProvider, TprPartialViewPathProvider>();
 
             return services;
         }

--- a/ThePensionsRegulator.Frontend.Umbraco/Services/TprPartialViewPathProvider.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Services/TprPartialViewPathProvider.cs
@@ -1,0 +1,17 @@
+﻿using GovUk.Frontend.Umbraco.Services;
+using System;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Services
+{
+    /// <inheritdoc/>
+    public class TprPartialViewPathProvider : IPartialViewPathProvider
+    {
+        /// <inheritdoc/>
+        public bool IsProvider(IBlockReference<IPublishedElement, IPublishedElement> block) => block?.Content?.ContentType?.Alias?.StartsWith("TPR", StringComparison.OrdinalIgnoreCase) ?? false;
+        /// <inheritdoc/>
+        public string BuildPartialViewPath(IBlockReference<IPublishedElement, IPublishedElement> block) => "TPR/" + block?.Content?.ContentType?.Alias;
+
+    }
+}


### PR DESCRIPTION
Instead this introduces the concept of an `IPartialViewPathProvider`. The GOV.UK project registers an implementation that finds GOV.UK views in the GOVUK folder, and the TPR project registers an implementation that finds TPR views in a TPR folder.

The interface accepts the whole block as an argument even though we're only using the alias. Accepting the whole block opens up the possibility of later rendering different views for a block depending on some property selected in the Umbraco UI.