### PR TITLE
Prevent additional validation errors for forms built with the block grid editor

### DIFF
--- a/GovUk.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/GovUk.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using GovUk.Frontend.AspNetCore.Extensions;
 using GovUk.Frontend.Umbraco.ModelBinding;
 using GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters;
 using GovUk.Frontend.Umbraco.Services;
+using GovUk.Frontend.Umbraco.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -34,6 +35,7 @@ namespace GovUk.Frontend.Umbraco
             services.AddTransient<IUmbracoPublishedContentAccessor, UmbracoPublishedContentAccessor>();
             services.AddTransient<IUmbracoPaginationFactory, UmbracoPaginationFactory>();
             services.AddSingleton<IConfigureOptions<MvcOptions>, ModelBindingMvcConfiguration>();
+            services.AddSingleton<IConfigureOptions<MvcOptions>, RemoveSettingsErrorsMvcConfiguration>();
             services.AddTransient<IPropertyValueFormatter, GovUkTypographyPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, NoParagraphPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, NoParagraphInversePropertyValueFormatter>();

--- a/GovUk.Frontend.Umbraco/Validation/RemoveSettingsErrorsActionFilter.cs
+++ b/GovUk.Frontend.Umbraco/Validation/RemoveSettingsErrorsActionFilter.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using System.Linq;
+using System.Net.Http;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace GovUk.Frontend.Umbraco.Validation
+{
+    /// <summary>
+    /// Where a view model has a ModelsBuilder model as a property, and the document type it represents has an Umbraco block grid property with a 'Settings' element type,
+    /// ModelState contains additional errors saying the Settings and SettingsUdi properties are required. This removes those errors from ModelState before they are a problem.
+    /// This used to happen for properties using the block list editor. In Umbraco 10.6.1 that is not reproducible, but it does happen for properties using the block grid editor.
+    /// </summary>
+    public class RemoveSettingsErrorsActionFilter : IActionFilter
+    {
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (context.HttpContext.Request.Method != HttpMethod.Post.Method) { return; }
+
+            foreach (var argument in context.ActionArguments.Values.Where(x => x != null))
+            {
+                foreach (var property in argument!.GetType().GetPublicProperties())
+                {
+                    if (property.PropertyType.IsAssignableTo(typeof(PublishedContentModel)))
+                    {
+                        foreach (var key in context.ModelState.Keys.Where(x => x.StartsWith(property.Name + ".")))
+                        {
+                            context.ModelState.Remove(key);
+                        }
+                    }
+                }
+
+            }
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco/Validation/RemoveSettingsErrorsMvcConfiguration.cs
+++ b/GovUk.Frontend.Umbraco/Validation/RemoveSettingsErrorsMvcConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Frontend.Umbraco.Validation
+{
+    internal class RemoveSettingsErrorsMvcConfiguration : IConfigureOptions<MvcOptions>
+    {
+        public void Configure(MvcOptions options)
+        {
+            options.Filters.Add<RemoveSettingsErrorsActionFilter>();
+        }
+    }
+}


### PR DESCRIPTION
A form within a block list used to generate additional errors for the settings of a block, so we had a class to remove them. This problem was no longer reproducible in Umbraco 10.4.2, so [our fix for it was removed](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/commit/48715cf5ee027f6f4e5be4b3c42587d4c9f31d4d) in [Release v4.0.0 of ThePensionsRegulator.GovUk.Frontend.Umbraco](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/releases/tag/v4.0.0-ThePensionsRegulator.GovUk.Frontend.Umbraco).

However, even in Umbraco 10.6.1 the block grid is still affected by this same error, so this PR restores the same code with a slightly amended name.