### PR TITLE
AB#171298 SetInitialVaue should accept a nullable string as a param

### DIFF
--- a/GovUk.Frontend.Umbraco.Tests/Validation/ModelStateExtensionsTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Validation/ModelStateExtensionsTests.cs
@@ -30,5 +30,24 @@ namespace GovUk.Frontend.Umbraco.Tests.Validation
             Assert.AreEqual("value1,value2", modelState["fieldname"]!.AttemptedValue);
             Assert.True(modelState.IsValid);
         }
+
+        [Test]
+        public void Inital_value_is_set_when_initial_value_is_null()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            var key = "myKey";
+
+            // Act
+            modelState.SetInitialValue(key, (string?)null);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.True(modelState.ContainsKey(key));
+                Assert.True(modelState.IsValid);
+                Assert.That(modelState[key]!.AttemptedValue, Is.Null);
+            });
+        }
     }
 }

--- a/GovUk.Frontend.Umbraco/Validation/ModelStateExtensions.cs
+++ b/GovUk.Frontend.Umbraco/Validation/ModelStateExtensions.cs
@@ -31,7 +31,7 @@ namespace GovUk.Frontend.Umbraco.Validation
         /// <param name="key">The name attribute of the field in the HTML</param>
         /// <param name="initialValues">The initial value to select or populate</param>
         /// <exception cref="ArgumentNullException">modelState</exception>
-        public static void SetInitialValue(this ModelStateDictionary modelState, string key, string initialValue)
+        public static void SetInitialValue(this ModelStateDictionary modelState, string key, string? initialValue)
         {
             if (modelState is null)
             {


### PR DESCRIPTION
In consuming applications, there are a lot of warnings that the `initialValue` could be null. The method that `SetInitialValue` passes the `initialValue` value to accepts a nullable string so we should also allow a nullable string to be passed to `SetInitialValue`