### PR TITLE
Backoffice views were not being included in the NuGet packages / Fix build error

### DIFF
--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -31,6 +31,34 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Content Include="App_Plugins\GOVUK\blocks\controllers\govukPageHeading.controller.js" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkButton.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkButtonGroup.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkCaption.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkCheckbox.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkCheckboxes.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkDateInput.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkDetails.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkErrorMessage.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkErrorSummary.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkFieldset.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkGridColumns.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkInsetText.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkLinkAsButton.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkNotificationBanner.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkPageHeading.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkPagination.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkPanel.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkRadios.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkSelect.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkSummaryCard.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkSummaryList.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkTaskList.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkTaskListSummary.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkTextArea.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkTextInput.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkTypography.html" />
+		<Content Include="App_Plugins\GOVUK\blocks\views\GovUkWarningText.html" />
 		<Content Include="App_Plugins\GOVUK\govuk.controller.js" />
 		<Content Include="App_Plugins\GOVUK\govuk.css" />
 		<Content Include="App_Plugins\GOVUK\model-property.html" />

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -31,6 +31,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Content Include="App_Plugins\ThePensionsRegulator.Frontend.Umbraco\blocks\views\TPRImage.html" />
 		<Content Include="ThePensionsRegulator.Frontend.Umbraco.targets">
 		  <PackagePath>build;buildTransitive</PackagePath>
 		  <Pack>true</Pack>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
@@ -3,13 +3,23 @@
 	<Target Name="ThePensionsRegulatorFrontendUmbraco" AfterTargets="ThePensionsRegulatorFrontend;ThePensionsRegulatorGovUkFrontendUmbraco">
 		<!-- Look for the PackageReference to this package to get the current version.
 			 Use that version to find the NuGet package folder, and copy files to the consuming project.
+			 There will be no PackageReference in the project if it has a project reference to another project that has the PackageReference. 
+			 This would be typical for a unit test project. Detect that and no nothing.
 		-->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
+			<Output TaskParameter="Result" ItemName="TprFrontendUmbracoVersion" />
+		</XmlPeek>
+		<Message Text="No PackageReference to ThePensionsRegulator.Frontend.Umbraco found. Nothing to do." Condition="@(TprFrontendUmbracoVersion->Count() )==0" />
+		<CallTarget Targets="ThePensionsRegulatorFrontendUmbraco_PackageFound" Condition="@(TprFrontendUmbracoVersion->Count() )>0" />
+	</Target>
+	
+	<Target Name="ThePensionsRegulatorFrontendUmbraco_PackageFound">
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
 			<Output TaskParameter="Result" ItemName="TprFrontendUmbracoVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<TprFrontendUmbracoVersion>@(TprFrontendUmbracoVersion)</TprFrontendUmbracoVersion>
-			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\contentFiles\any\net6.0\</ContentFilesPath>		
+			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\contentFiles\any\net6.0\</ContentFilesPath>
 		</PropertyGroup>
 		<ItemGroup>
 			<uSyncFilesFromTprFrontendUmbraco Include="$(ContentFilesPath)uSync\**" />
@@ -144,7 +154,7 @@
 		</ItemGroup>
 		<Message Text="Generating $(ProjectDir)App_Plugins\ThePensionsRegulator.Frontend.Umbraco\.gitignore" Importance="high" />
 		<WriteLinesToFile File="$(ProjectDir)App_Plugins\ThePensionsRegulator.Frontend.Umbraco\.gitignore" Lines="@(TprFrontendUmbracoGitIgnore)" Overwrite="True"/>
-		
+
 		<ItemGroup>
 			<TprFrontendUmbracoUSyncGitIgnoreText Include="TprFrontendUmbracoUSyncGitIgnoreText">
 				<Text>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -7,7 +7,7 @@
 		<Version>5.0.0</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
-		<PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
 		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.Frontend</Title>


### PR DESCRIPTION
## Backoffice views were not being included in the NuGet packages. 

The result was a backoffice that looked like this:

![Error messages](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/966dcbda-d584-4e56-8c1a-1bc6abe99e25)

## Fix build error in test projects

If you install `ThePensionsRegulator.Umbraco.Testing` into a test project it will follow the project reference to the project you're testing and run the targets file for `ThePensionsRegulator.Frontend.Umbraco`. That led to a build error because that project assumed you had a direct reference to it, couldn't find the version number, and started getting paths wrong. This PR avoids running that code if there is no direct PackageReference.

## Versioning error
This PR also fixes a minor versioning error.