### PR TITLE
Avoid using extension method to access properties

### DIFF
--- a/GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
@@ -342,6 +342,10 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                     .SetupUmbracoBlockListPropertyValue(listItemsPropertyAlias, originalItems)
                     .Object);
 
+            var blocks = UmbracoBlockListFactory.CreateOverridableBlockListModel(
+                UmbracoBlockListFactory.CreateOverridableBlock(content));
+
+
             var replacement = new[]
             {
                 new SummaryListItem("3", new HtmlEncodedString("Item 3")),

--- a/GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
@@ -342,10 +342,6 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                     .SetupUmbracoBlockListPropertyValue(listItemsPropertyAlias, originalItems)
                     .Object);
 
-            var blocks = UmbracoBlockListFactory.CreateOverridableBlockListModel(
-                UmbracoBlockListFactory.CreateOverridableBlock(content));
-
-
             var replacement = new[]
             {
                 new SummaryListItem("3", new HtmlEncodedString("Item 3")),

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
@@ -93,8 +93,11 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             _ = new OverridableBlockListModel(parentBlockList, null, factory);
 
             // Assert
-            Assert.NotNull(convertedChildBlockList);
-            Assert.NotNull(convertedGrandChildBlockList);
+            Assert.Multiple(() =>
+            {
+                Assert.That(convertedChildBlockList, Is.Not.Null);
+                Assert.That(convertedGrandChildBlockList, Is.Not.Null);
+            });
         }
 
         [Test]

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
@@ -93,11 +93,9 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             _ = new OverridableBlockListModel(parentBlockList, null, factory);
 
             // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(convertedChildBlockList, Is.Not.Null);
-                Assert.That(convertedGrandChildBlockList, Is.Not.Null);
-            });
+            Assert.IsNotNull(convertedChildBlockList);
+            Assert.IsNotNull(convertedGrandChildBlockList);
+           
         }
 
         [Test]

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModel.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModel.cs
@@ -19,7 +19,15 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         {
             if (property.PropertyType.EditorAlias == propertyEditorAlias)
             {
-                var overriddenNestedBlockModel = overridableItem.Content.Value<TOverridableModel>(property.Alias);
+                var overridenNestedBlockModelProperty = overridableItem.Content.GetProperty(property.Alias);
+
+                TOverridableModel? overriddenNestedBlockModel = default;
+
+                if (overridenNestedBlockModelProperty is not null)
+                {
+                    overriddenNestedBlockModel = (TOverridableModel?)overridenNestedBlockModelProperty.GetValue();
+                }
+
                 if (overriddenNestedBlockModel == null)
                 {
                     var nestedBlockModel = overridableItem.Content.Value<TBaseModel>(property.Alias);


### PR DESCRIPTION
When creating an `OverrideableBlockListModel` with a mocked `IPublishedElement`, `GetValue(alias)` would throw the exception `The type initializer for 'Umbraco.Extensions.FriendlyPublishedElementExtensions' threw an exception. ----> System.ArgumentNullException : Value cannot be null. (Parameter 'provider')` when converting a block model to an overrideable block model. 

To avoid this the constructor for `OverrideableBlockListModel` now gets the value of block being converted the 'long way' which avoids calling the mocked value.