### PR TITLE
TPR no forms block list had inline editing enabled

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRNoFormsBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRNoFormsBlockList.config
@@ -202,7 +202,7 @@
     }
   ],
   "MaxPropertyWidth": null,
-  "UseInlineEditingAsDefault": true,
+  "UseInlineEditingAsDefault": false,
   "UseLiveEditing": false,
   "UseSingleBlockMode": false,
   "ValidationLimit": {

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>5.0.0</Version>
+		<Version>5.0.1</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRNoFormsBlockList.config
+++ b/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRNoFormsBlockList.config
@@ -202,7 +202,7 @@
     }
   ],
   "MaxPropertyWidth": null,
-  "UseInlineEditingAsDefault": true,
+  "UseInlineEditingAsDefault": false,
   "UseLiveEditing": false,
   "UseSingleBlockMode": false,
   "ValidationLimit": {


### PR DESCRIPTION
This is a problem because we now have block previews in the place where inline editing used to happen. Inline editing needs to be disabled so that editing happens in a pop-up panel instead. This has already been changed for all other block list data types.