### PR TITLE
_tpr-image.scss was being published in the NuGet package by mistake

### DIFF
--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -520,10 +520,6 @@
 
 	<ItemGroup>
 	  <UpToDateCheckInput Remove="Styles\govuk-frontend.scss" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="Styles\_govuk-list.scss" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -44,10 +44,6 @@
 			<PackagePath>contentFiles\any\net6.0\Content\css</PackagePath>
 			<Pack>true</Pack>
 		</Content>
-		<Content Include="Styles\_tpr-image.scss">
-			<PackagePath>contentFiles\any\net6.0\Content\tpr</PackagePath>
-			<Pack>true</Pack>
-		</Content>
 	</ItemGroup>
 
 	<ItemGroup>
@@ -133,6 +129,9 @@
 	  </None>
 	  <None Update="Styles\govuk-umbraco-backoffice.scss">
 	    <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+	  </None>
+	  <None Update="Styles\_tpr-image.scss">
+		<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 	  </None>
 	</ItemGroup>
 


### PR DESCRIPTION
`_tpr-image.scss` is compiled into tpr.css which is included in ThePensionsRegulator.Frontend.Umbraco as a static file. `_tpr-image.scss` itself doesn't need to be included, and is getting copied to consuming projects where it's not wanted.

There's no version bump because that's already in the `develop` branch.

The other change in this PR is removing one instance of a duplicate setting in `GovUk.Frontend.Umbraco.csproj` that I noticed while comparing the two projects.