### PR TITLE
Update checkboxes example so that required field validation is applied

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/CheckboxesViewModel.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/CheckboxesViewModel.cs
@@ -15,7 +15,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Models
         public string? Field2 { get; set; }
 
         [Required(ErrorMessage = nameof(Field3))]
-        public List<string> Field3 { get; set; } = new();
+        public List<string>? Field3 { get; set; }
 
         [Required(ErrorMessage = nameof(Field4))]
         public string? Field4 { get; set; }


### PR DESCRIPTION
This example of required field validation was not working because the list was always instantiated, and the required field check works by checking whether the list is null.