### PR TITLE
Document running the ASP.NET example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ We target [GDS Frontend v4.4.1](https://github.com/alphagov/govuk-frontend/relea
 
 ## ASP.NET projects without Umbraco
 
+- [Run the ASP.NET example application](docs/aspnet/run-example-application.md)
 - [Configure a new ASP.NET project](docs/aspnet/new-aspnet-project.md)
 - [Localisation and validation in ASP.NET projects](docs/aspnet/localisation-and-validation.md)
 - [Use SASS for CSS](docs/aspnet/sass.md)

--- a/docs/aspnet/run-example-application.md
+++ b/docs/aspnet/run-example-application.md
@@ -1,0 +1,8 @@
+# Run the ASP.NET example application
+
+This repository includes an example application which demonstrates the validation working both client-side and server-side, and localisation using resource files.
+
+1. Clone this repo
+2. Open `GovUk.Frontend.sln` in Visual Studio 2022 or better, click on the `GovUk.Frontend.ExampleApp` project, and run it.
+
+By default the example application uses The Pensions Regulator (TPR) branding. To see the GOV.UK branded version set `TPRStyles: false` in `appsettings.json` and re-run the application.

--- a/docs/umbraco/run-example-application.md
+++ b/docs/umbraco/run-example-application.md
@@ -9,6 +9,8 @@ This repository includes an example application which demonstrates the validatio
 5. When you are taken to the Umbraco backoffice go to Settings > uSync > Everything > Import all
 6. View the example application at https://localhost:44350. If you want to see GOV.UK default styling, on the 'Settings' page in the 'Content' section of the Umbraco backoffice you can switch off The Pensions Regulator styles.
 
+By default the example application uses The Pensions Regulator (TPR) branding. To see the GOV.UK branded version set `TPRStyles: false` in `appsettings.json` and re-run the application.
+
 ## Troubleshooting
 
 ### Error during installation: Already initialized


### PR DESCRIPTION
Our README documents how to run the Umbraco example app but not the ASP.NET one, so add a page for that.