### PR TITLE
Don't write .gitignore and site.css files to test projects

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
@@ -31,8 +31,9 @@
 			  DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
 			  Condition="@(ThePensionsRegulatorGovUkFrontendVersion->Count() )==1"/>
 
-		<!-- Generate a .gitignore so that govuk-frontend SASS files copied from this package are not committed to the consuming project's source control. -->
-		<Message Text="Generating $(ProjectDir)Styles\govuk\.gitignore" Importance="high" />
+		<!-- Generate a .gitignore so that govuk-frontend SASS files copied from this package are not committed to the consuming project's source control.
+			 Only do that if the folder exists, otherwise they'll also get created in a test project with a project reference to the target project. -->
+		<Message Text="Generating $(ProjectDir)Styles\govuk\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)Styles')" />
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendGitIgnoreText Include="ThePensionsRegulatorGovUkFrontendGitIgnoreText">
 				<Text>
@@ -42,7 +43,7 @@
 			</ThePensionsRegulatorGovUkFrontendGitIgnoreText>
 			<ThePensionsRegulatorGovUkFrontendGitIgnore Include="%(ThePensionsRegulatorGovUkFrontendGitIgnoreText.Text)" />
 		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)Styles\govuk\.gitignore" Lines="@(ThePensionsRegulatorGovUkFrontendGitIgnore)" Overwrite="True"/>
+		<WriteLinesToFile File="$(ProjectDir)Styles\govuk\.gitignore" Lines="@(ThePensionsRegulatorGovUkFrontendGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)Styles')" />
 	</Target>
 
 	<!-- In pipeline builds if a CSS file exists AspNetCore.SassCompiler won't overwrite it with the generated version, 

--- a/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
+++ b/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
@@ -74,7 +74,8 @@
 		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
 			  Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false and $(HasPackageReferenceForThePensionsRegulatorGovUkFrontend) == false" />
 
-		<!-- Generate .gitignore files so that files copied from this package are not committed to the consuming project's source control. -->
+		<!-- Generate .gitignore files so that files copied from this package are not committed to the consuming project's source control.	 
+			 Only do that if the folder exists, otherwise they'll also get created in a test project with a project reference to the target project. -->
 		<ItemGroup>
 			<GovUkFrontendUmbracoGitIgnoreText Include="GovUkFrontendUmbracoGitIgnoreText">
 				<Text>
@@ -84,8 +85,8 @@
 			</GovUkFrontendUmbracoGitIgnoreText>
 			<GovUkFrontendUmbracoGitIgnore Include="%(GovUkFrontendUmbracoGitIgnoreText.Text)" />
 		</ItemGroup>
-		<Message Text="Generating $(ProjectDir)App_Plugins\GOVUK\.gitignore" Importance="high" />
-		<WriteLinesToFile File="$(ProjectDir)App_Plugins\GOVUK\.gitignore" Lines="@(GovUkFrontendUmbracoGitIgnore)" Overwrite="True"/>
+		<Message Text="Generating $(ProjectDir)App_Plugins\GOVUK\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)App_Plugins')" />
+		<WriteLinesToFile File="$(ProjectDir)App_Plugins\GOVUK\.gitignore" Lines="@(GovUkFrontendUmbracoGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)App_Plugins')"/>
 
 		<ItemGroup>
 			<GovUkFrontendUmbracoCssGitIgnoreText Include="GovUkFrontendUmbracoCssGitIgnoreText">
@@ -96,8 +97,8 @@ govuk-umbraco-backoffice.css.map
 			</GovUkFrontendUmbracoCssGitIgnoreText>
 			<GovUkFrontendUmbracoCssGitIgnore Include="%(GovUkFrontendUmbracoCssGitIgnoreText.Text)" />
 		</ItemGroup>
-		<Message Text="Generating $(ProjectDir)wwwroot\css\.gitignore" Importance="high" />
-		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\.gitignore" Lines="@(GovUkFrontendUmbracoCssGitIgnore)" Overwrite="True"/>
+		<Message Text="Generating $(ProjectDir)wwwroot\css\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)wwwroot')" />
+		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\.gitignore" Lines="@(GovUkFrontendUmbracoCssGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)wwwroot')"/>
 
 		<ItemGroup>
 			<GovUkFrontendUmbracoUSyncGitIgnoreText Include="GovUkFrontendUmbracoUSyncGitIgnoreText">
@@ -108,15 +109,15 @@ govuk-umbraco-backoffice.css.map
 			</GovUkFrontendUmbracoUSyncGitIgnoreText>
 			<GovUkFrontendUmbracoUSyncGitIgnore Include="%(GovUkFrontendUmbracoUSyncGitIgnoreText.Text)" />
 		</ItemGroup>
-		<Message Text="Generating $(ProjectDir)uSync\.gitignore" Importance="high" />
-		<WriteLinesToFile File="$(ProjectDir)uSync\.gitignore" Lines="@(GovUkFrontendUmbracoUSyncGitIgnore)" Overwrite="True"/>
+		<Message Text="Generating $(ProjectDir)uSync\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)uSync')" />
+		<WriteLinesToFile File="$(ProjectDir)uSync\.gitignore" Lines="@(GovUkFrontendUmbracoUSyncGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)uSync')"/>
 
 		<!-- If the ModelsBuilder out-of-date flag is present, show a helpful warning. -->
 		<Warning Text="Umbraco Models Builder models are out-of-date. Go to Settings &gt; Models Builder &gt; Generate models in the Umbraco backoffice to update them." Condition="Exists('$(ProjectDir)Models\ModelsBuilder\ood.flag')" />
 
 		<!-- Rich text editor data types import wwwroot\css\site.css so that consuming projects can add their own styles, including styles for the 'Formats' dropdown.
 		     However if there is no site.css the backoffice generates a request with a 404 response, so create a placeholder file to respond to that request. -->
-		<Message Text="Generating $(ProjectDir)wwwroot\css\site.css" Importance="high" Condition="!Exists('$(ProjectDir)wwwroot\css\site.css')" />
+		<Message Text="Generating $(ProjectDir)wwwroot\css\site.css" Importance="high" Condition="Exists('$(ProjectDir)wwwroot') and !Exists('$(ProjectDir)wwwroot\css\site.css')" />
 		<ItemGroup>
 			<GovUkFrontendUmbracoSiteCssText Include="GovUkFrontendUmbracoSiteCssText">
 				<Text>
@@ -126,7 +127,7 @@ govuk-umbraco-backoffice.css.map
 			</GovUkFrontendUmbracoSiteCssText>
 			<GovUkFrontendUmbracoSiteCss Include="%(GovUkFrontendUmbracoSiteCssText.Text)" />
 		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\site.css" Lines="@(GovUkFrontendUmbracoSiteCss)" Overwrite="False" Condition="!Exists('$(ProjectDir)wwwroot\css\site.css')"/>
+		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\site.css" Lines="@(GovUkFrontendUmbracoSiteCss)" Overwrite="False" Condition="Exists('$(ProjectDir)wwwroot') and !Exists('$(ProjectDir)wwwroot\css\site.css')"/>
 	</Target>
 
 </Project>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -7,7 +7,7 @@
 		<Version>5.0.1</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
-		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>5.0.1</PackageValidationBaselineVersion>
 		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.Frontend</Title>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
@@ -66,8 +66,9 @@
 		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
 			  Condition="$(HasPackageReferenceForTprFrontend) != false and $(HasPackageReferenceForTprGovUkFrontend) == false" />
 
-		<!-- Generate a .gitignore so that SASS files from the ThePensionsRegulator.Frontend package are not committed to the consuming project's source control. -->
-		<Message Text="Generating $(ProjectDir)Styles\tpr\.gitignore" Importance="high" />
+		<!-- Generate a .gitignore so that SASS files from the ThePensionsRegulator.Frontend package are not committed to the consuming project's source control.	 
+			 Only do that if the folder exists, otherwise they'll also get created in a test project with a project reference to the target project.  -->
+		<Message Text="Generating $(ProjectDir)Styles\tpr\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)Styles')" />
 		<ItemGroup>
 			<ThePensionsRegulatorFrontendGitIgnoreText Include="ThePensionsRegulatorFrontendGitIgnoreText">
 				<Text>
@@ -77,6 +78,6 @@
 			</ThePensionsRegulatorFrontendGitIgnoreText>
 			<ThePensionsRegulatorFrontendGitIgnore Include="%(ThePensionsRegulatorFrontendGitIgnoreText.Text)" />
 		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)Styles\tpr\.gitignore" Lines="@(ThePensionsRegulatorFrontendGitIgnore)" Overwrite="True"/>
+		<WriteLinesToFile File="$(ProjectDir)Styles\tpr\.gitignore" Lines="@(ThePensionsRegulatorFrontendGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)Styles')" />
 	</Target>
 </Project>


### PR DESCRIPTION
When you build with the current packages it writes helpful `site.css` and `.gitignore` files. However, it also writes these in a test project that references your web project, and that is not helpful. This PR prevents that.

Only `ThePensionsRegulator.Frontend` gets a version bump for this because the other affected projects have version bumps in other open PRs.