### PR TITLE
Fields did not get a red border when there was a fieldset error

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -171,4 +171,16 @@
 	  <UpToDateCheckInput Remove="Styles\_govuk-checkboxes.scss" />
 	</ItemGroup>
 	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_govuk-input.scss" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_govuk-textarea.scss" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_govuk-select.scss" />
+	</ItemGroup>
+	
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-input.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-input.scss
@@ -1,0 +1,7 @@
+﻿/* 
+    If there is a fieldset level error we do not want to display an error message for the field, 
+    but without an error message the .govuk-input--error class will not be applied.
+*/
+.govuk-input[aria-invalid=true] {
+    @extend .govuk-input--error;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-select.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-select.scss
@@ -1,0 +1,7 @@
+﻿/* 
+    If there is a fieldset level error we do not want to display an error message for the field, 
+    but without an error message the .govuk-select--error class will not be applied.
+*/
+.govuk-select[aria-invalid=true] {
+    @extend .govuk-select--error;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-textarea.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-textarea.scss
@@ -1,0 +1,7 @@
+﻿/* 
+    If there is a fieldset level error we do not want to display an error message for the field, 
+    but without an error message the .govuk-textarea--error class will not be applied.
+*/
+.govuk-textarea[aria-invalid=true] {
+    @extend .govuk-textarea--error;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
@@ -1,7 +1,10 @@
 ﻿// Import and compile govuk-frontend, adding fixes and styles for the components we've added from later versions
 @import 'govuk/all';
 @import "_govuk-checkboxes.scss";
+@import "_govuk-input.scss";
 @import "_govuk-pagination.scss";
 @import "_govuk-radios.scss";
+@import "_govuk-select.scss";
 @import "_govuk-summary-card.scss";
 @import "_govuk-task-list.scss";
+@import "_govuk-textarea.scss";

--- a/GovUk.Frontend.Umbraco/ElementTypeAliases.cs
+++ b/GovUk.Frontend.Umbraco/ElementTypeAliases.cs
@@ -13,6 +13,7 @@
         public const string ErrorMessageSettings = "govukErrorMessageSettings";
         public const string Fieldset = "govukFieldset";
         public const string FieldsetSettings = "govukFieldsetSettings";
+        public const string FileUpload = "govukFileUpload";
         public const string TextInput = "govukTextInput";
         public const string Textarea = "govukTextarea";
         public const string GridRow = "govukGridRow";

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkFieldset.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkFieldset.cshtml
@@ -27,6 +27,7 @@
         var allDescendentFields = blocks.FindBlocks(x => x.Content.ContentType.Alias == ElementTypeAliases.Checkbox || 
                                                          x.Content.ContentType.Alias == ElementTypeAliases.Checkboxes || 
                                                          x.Content.ContentType.Alias == ElementTypeAliases.DateInput || 
+                                                         x.Content.ContentType.Alias == ElementTypeAliases.FileUpload || 
                                                          x.Content.ContentType.Alias == ElementTypeAliases.Radios || 
                                                          x.Content.ContentType.Alias == ElementTypeAliases.Select ||
                                                          x.Content.ContentType.Alias == ElementTypeAliases.TextInput || 

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -32,10 +32,13 @@
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";
 @import "_govuk-checkboxes.scss";
+@import "_govuk-input.scss";
 @import "_govuk-pagination.scss";
 @import "_govuk-radios.scss";
+@import "_govuk-select.scss";
 @import "_govuk-summary-card.scss";
 @import "_govuk-task-list.scss";
+@import "_govuk-textarea.scss";
 
 // Load our custom font (we are not allowed to use 'GDS Transport' https://design-system.service.gov.uk/styles/typography/)
 @import '_open-sans.scss';


### PR DESCRIPTION
When a 'Text input' is invalid it should look like this:

<img width="506" alt="Invalid text input" src="https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/59bcdb6d-5a13-41ba-89cf-628a5d40886a">

When it's part of a fieldset and the entire fieldset is invalid, it looks like this:

<img width="440" alt="Text input in an invalid fieldset" src="https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/592dcbec-937e-4dc8-a72f-515be19a3bc4">

Note the missing red border around the 'Text input'.

If you try to assign the `.govuk-input--error` class in this scenario, it's stripped out. Instead, this PR applies the same styles based on the value of the `aria-invalid` attribute.

It also does this for other field types that might appear within a fieldset in an error state, and which would require a red border:

<img width="556" alt="Text input and other field types within an invalid fieldset" src="https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/15475236-ba0d-45d2-b279-78be1944b42c">

This PR also adds 'File upload' to the list of components which is notified about a fieldset error.