### PR TITLE
Allow SetInitialValue to be used in a SurfaceController 

### DIFF
--- a/GovUk.Frontend.Umbraco.Tests/Validation/ModelStateExtensionsTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Validation/ModelStateExtensionsTests.cs
@@ -49,5 +49,27 @@ namespace GovUk.Frontend.Umbraco.Tests.Validation
                 Assert.That(modelState[key]!.AttemptedValue, Is.Null);
             });
         }
+
+        [Test]
+        public void Initial_state_is_set_when_it_was_previously_invalid()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            var key = "myKey";
+            var value = "value";
+
+            // Act
+            modelState.AddModelError(key, "Any error");
+            modelState.SetInitialValue(key, value);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.True(modelState.ContainsKey(key));
+                Assert.True(modelState.IsValid);
+                Assert.That(modelState[key]!.ValidationState, Is.EqualTo(ModelValidationState.Skipped));
+                Assert.That(modelState[key]!.AttemptedValue, Is.EqualTo(value));
+            });
+        }
     }
 }

--- a/GovUk.Frontend.Umbraco/Validation/ModelStateExtensions.cs
+++ b/GovUk.Frontend.Umbraco/Validation/ModelStateExtensions.cs
@@ -39,7 +39,9 @@ namespace GovUk.Frontend.Umbraco.Validation
             }
 
             modelState.SetModelValue(key, null, initialValue);
-            modelState.MarkFieldSkipped(key);
+
+            // Avoid using MarkFieldSkipped because it prevents this method being used in a SurfaceController where the field was previously invalid.
+            modelState[key]!.ValidationState = ModelValidationState.Skipped;
         }
     }
 }


### PR DESCRIPTION
Currently `SetInitialValue()` can throw an exception if used in a surface controller, if the field was previously marked as invalid. 

Looking at the .NET source, everything else `MarkFieldSkipped` does is also done by `SetModelValue`, so this should also be a fraction faster.

[AB#178662](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/178662)