### PR TITLE
Fix backoffice preview bugs

### DIFF
--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryCard.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryCard.html
@@ -8,7 +8,7 @@
     </div>
     <div class="govuk-summary-card__content" aria-hidden="true">
         <dl class="govuk-summary-list">
-            <div class="backoffice-additional-blocks" ng-if="!block.data.summaryListItems.contentData">Summary list with no list items.</div>
+            <div class="backoffice-additional-blocks" ng-if="!block.data.summaryListItems.contentData.length">Summary list with no list items.</div>
             <div class="govuk-summary-list__row" ng-repeat="item in block.data.summaryListItems.contentData">
                 <dt class="govuk-summary-list__key" ng-bind-html="item.itemKey"></dt>
                 <dd class="govuk-summary-list__value" ng-bind-html="item.itemValue"></dd>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryList.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryList.html
@@ -1,5 +1,5 @@
 ﻿<dl class="govuk-summary-list backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" aria-label="Edit summary list component">
-    <div class="backoffice-additional-blocks" ng-if="!block.data.items.contentData" aria-hidden="true">Summary list with no list items.</div>
+    <div class="backoffice-additional-blocks" ng-if="!block.data.items.contentData.length" aria-hidden="true">Summary list with no list items.</div>
     <div class="govuk-summary-list__row" ng-repeat="item in block.data.items.contentData" aria-hidden="true">
         <dt class="govuk-summary-list__key" ng-bind-html="item.itemKey"></dt>
         <dd class="govuk-summary-list__value" ng-bind-html="item.itemValue"></dd>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTaskList.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTaskList.html
@@ -1,5 +1,5 @@
 ﻿<ul class="govuk-task-list backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" aria-label="Edit task list component">
-    <li class="backoffice-additional-blocks" ng-if="!block.data.tasks.contentData" aria-hidden="true">Task list with no tasks.</li>
+    <li class="backoffice-additional-blocks" ng-if="!block.data.tasks.contentData.length" aria-hidden="true">Task list with no tasks.</li>
     <li class="govuk-task-list__item--with-link govuk-task-list__item" ng-repeat="task in block.data.tasks.contentData" aria-hidden="true">
         <span class="govuk-task-list__task-name-and-hint">
             <span class="govuk-task-list__link govuk-link" href="#" ng-bind-html="task.taskName"></span>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTaskList.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTaskList.html
@@ -2,7 +2,7 @@
     <li class="backoffice-additional-blocks" ng-if="!block.data.tasks.contentData" aria-hidden="true">Task list with no tasks.</li>
     <li class="govuk-task-list__item--with-link govuk-task-list__item" ng-repeat="task in block.data.tasks.contentData" aria-hidden="true">
         <span class="govuk-task-list__task-name-and-hint">
-            <a class="govuk-task-list__link govuk-link" href="#" ng-bind-html="task.taskName"></a>
+            <span class="govuk-task-list__link govuk-link" href="#" ng-bind-html="task.taskName"></span>
             <span class="govuk-task-list__task_hint" ng-bind-html="task.hint" ng-if="task.hint"></span>
         </span>
         <span class="govuk-task-list__status-container">

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-		<Version>5.2.1</Version>
+		<Version>5.2.2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
+++ b/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
@@ -1,4 +1,6 @@
-﻿/* Add spacing around custom backoffice views of block content. */
+﻿@import 'govuk/base';
+
+/* Add spacing around custom backoffice views of block content. */
 .backoffice-block-view {
     margin: 20px 20px 0;
     border-bottom: 1px dashed #bbbabf;
@@ -67,6 +69,9 @@
 .backoffice-block-view .govuk-summary-card__content {
     padding-bottom: 0;
     margin-bottom: 20px;
+}
+.backoffice-block-view .govuk-task-list__link {
+    color: $govuk-link-colour;
 }
 
 .backoffice-block-view .govuk-textarea {

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>5.2.1</Version>
+		<Version>5.2.2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
The backoffice preview for summary lists and summary cards is supposed to show "Summary list with no list items" if there are no list items. That wasn't working, and so the component collapsed to a thin line that's almost impossible to click on to edit.

The backoffice preview for task lists with tasks has been too easy to click on. The click triggers the link in the task, which reloads the backoffice rather than going to the edit view of the task list. This PR removes that link and styles a span instead.

The backoffice preview for task lists without any tasks was impossible to click on because nothing was displayed.