### PR TITLE
When overriding a property value within a child block list, property value formatters weren't being applied

### DIFF
--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockGridModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockGridModelTests.cs
@@ -361,6 +361,49 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             Assert.That(((OverridablePublishedElement)blockWithinArea.Settings).PropertyValueFormatters?.Count(), Is.EqualTo(1));
         }
 
+
+
+        [Test]
+        public void PropertyValueFormatters_are_applied_when_an_OverridableBlockListModel_property_is_overridden()
+        {
+            // Arrange - original block grid with PropertyValueFormatters, has a block with a child block list
+            var formatter = new Mock<IPropertyValueFormatter>();
+            formatter.Setup(x => x.IsFormatter(It.IsAny<IPublishedPropertyType>())).Returns(true);
+
+            var parentBlockGrid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(
+                UmbracoBlockGridFactory.CreateOverridableBlock(
+                    new OverridablePublishedElement(UmbracoBlockGridFactory.CreateContentOrSettings()
+                        .SetupUmbracoBlockListPropertyValue(PROPERTY_ALIAS_CHILD_BLOCKS, new OverridableBlockListModel(Array.Empty<OverridableBlockListItem>()))
+                    .Object),
+                    new OverridablePublishedElement(UmbracoBlockGridFactory.CreateContentOrSettings().Object)
+                ));
+            parentBlockGrid.PropertyValueFormatters = new List<IPropertyValueFormatter> { formatter.Object };
+
+            // Act - a property within the child block list is overridden
+            const string CONTENT_PROPERTY_ALIAS_TO_OVERRIDE = "contentProperty";
+            const string SETTINGS_PROPERTY_ALIAS_TO_OVERRIDE = "settingsProperty";
+            const string CONTENT_PROPERTY_VALUE = "new content";
+            const string SETTINGS_PROPERTY_VALUE = "new setting";
+
+            var replacementChildBlock = UmbracoBlockListFactory.CreateOverridableBlock(
+                    new OverridablePublishedElement(UmbracoBlockListFactory.CreateContentOrSettings()
+                        .SetupUmbracoTextboxPropertyValue(CONTENT_PROPERTY_ALIAS_TO_OVERRIDE, string.Empty)
+                    .Object),
+                    new OverridablePublishedElement(UmbracoBlockListFactory.CreateContentOrSettings()
+                        .SetupUmbracoTextboxPropertyValue(SETTINGS_PROPERTY_ALIAS_TO_OVERRIDE, string.Empty)
+                    .Object)
+                );
+            replacementChildBlock.Content.OverrideValue(CONTENT_PROPERTY_ALIAS_TO_OVERRIDE, CONTENT_PROPERTY_VALUE);
+            replacementChildBlock.Settings.OverrideValue(SETTINGS_PROPERTY_ALIAS_TO_OVERRIDE, SETTINGS_PROPERTY_VALUE);
+
+            var replacementChildBlockList = new OverridableBlockListModel(new[] { replacementChildBlock });
+            parentBlockGrid[0].Content.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, replacementChildBlockList);
+
+            // Assert
+            formatter.Verify(x => x.FormatValue(CONTENT_PROPERTY_VALUE), Times.Once);
+            formatter.Verify(x => x.FormatValue(SETTINGS_PROPERTY_VALUE), Times.Once);
+        }
+
         [Test]
         public void Can_cast_to_BlockGridModel()
         {

--- a/ThePensionsRegulator.Umbraco/PropertyEditors/PropertyValueFormatterExtensions.cs
+++ b/ThePensionsRegulator.Umbraco/PropertyEditors/PropertyValueFormatterExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.Models.PublishedContent;
+﻿using ThePensionsRegulator.Umbraco.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace ThePensionsRegulator.Umbraco.PropertyEditors
 {
@@ -27,6 +28,16 @@ namespace ThePensionsRegulator.Umbraco.PropertyEditors
             if (value is null)
             {
                 throw new ArgumentNullException(nameof(value));
+            }
+
+            if (value is OverridableBlockListModel blockList && blockList.PropertyValueFormatters is null)
+            {
+                blockList.PropertyValueFormatters = formatters;
+            }
+
+            if (value is OverridableBlockGridModel blockGrid && blockGrid.PropertyValueFormatters is null)
+            {
+                blockGrid.PropertyValueFormatters = formatters;
             }
 
             foreach (var formatter in formatters)

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,7 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->
 	<PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
The `IPropertyValueFormatter` collection is registered with dependency injection. It's injected into property value converters which create the `OverridableBlockListModel` and `OverridableBlockGridModel` instances for ModelsBuilder models with the formatters.

When you override an entire child block list, you create a new `OverridableBlockListModel` that doesn't have the formatters. The `PropertyValueFormatters` property is internal, so you couldn't assign them even if you had them.

This means, for example, that if you populate summary list items from a controller using the `.OverrideSummaryListItems()` extension method, the formatters would be missing and properties within that block list would not be formatted.

This PR fixes that by checking and fixing missing formatters before applying them. When missing formatters are spotted and set, it applies the formatters to any values that have already been overridden.

[AB#169598](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/169598)