### PR TITLE
Overriding summary lists and other bugs

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryListController.cs
@@ -1,0 +1,52 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.Umbraco.Blocks;
+using GovUk.Frontend.Umbraco.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Cms.Web.Common.PublishedModels;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
+{
+    public class SummaryListController : RenderController
+    {
+        private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
+
+        public SummaryListController(ILogger<RenderController> logger,
+            ICompositeViewEngine compositeViewEngine,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor)
+            : base(logger, compositeViewEngine, umbracoContextAccessor)
+        {
+            _publishedSnapshotAccessor = publishedSnapshotAccessor ?? throw new System.ArgumentNullException(nameof(publishedSnapshotAccessor));
+        }
+
+        [ModelType(typeof(SummaryList))]
+        public override IActionResult Index()
+        {
+            var viewModel = new SummaryList(CurrentPage, null);
+
+            // Override content in a summary list
+            var summaryListToOverride = viewModel.Blocks!.FindBlockByClass("override-this");
+            if (summaryListToOverride is not null)
+            {
+                var summaryListItems = new List<SummaryListItem>();
+                for (var i = 1; i <= 5; i++)
+                {
+                    var summaryListItem = new SummaryListItem($"Data source item {i}", new HtmlEncodedString($"Data source item value {i}"));
+                    summaryListItem.Actions.Add(new SummaryListAction(new Link { Url = "https://www.example.org" }, $"Action {i}"));
+                    summaryListItems.Add(summaryListItem);
+                }
+                summaryListToOverride.Content.OverrideSummaryListItems(summaryListItems, _publishedSnapshotAccessor);
+            }
+
+            return CurrentTemplate(viewModel);
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/summary-list.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/summary-list.config
@@ -28,6 +28,14 @@
       {
         "contentUdi": "umb://element/75a9d1349e5b440293a8787bfd4f81cb",
         "settingsUdi": "umb://element/d3c06801aa72459ebe7b9bbfa6bdcf1c"
+      },
+      {
+        "contentUdi": "umb://element/32cc84cf104d42a38b3bd98e36b1f3e4",
+        "settingsUdi": "umb://element/c1a6ce3fe616489db0b10c3e88da9931"
+      },
+      {
+        "contentUdi": "umb://element/6521a3c0b3b24c9baf17a60df7b4aa2a",
+        "settingsUdi": "umb://element/4748141931ef46d2a6bf1ee724e3f40e"
       }
     ]
   },
@@ -45,13 +53,23 @@
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
       "udi": "umb://element/54d6ee29d8eb4f598a3bb648d791a7d1"
+    },
+    {
+      "contentTypeKey": "bd6069cc-a8c1-456b-8a00-1d180c45c36c",
+      "udi": "umb://element/6521a3c0b3b24c9baf17a60df7b4aa2a",
+      "items": null
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "udi": "umb://element/32cc84cf104d42a38b3bd98e36b1f3e4",
+      "text": "<p>You can configure a fixed set of summary list items in the Umbraco backoffice, or you can supply summary list items at runtime from a database or other data source.</p>"
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "d43b72b5-edac-42e0-aa09-1b080d7bd6eb",
       "udi": "umb://element/d3c06801aa72459ebe7b9bbfa6bdcf1c",
-      "columnSize": "[\"full\"]",
+      "columnSize": "",
       "columnSizeFromDesktop": "",
       "cssClasses": ""
     },
@@ -65,6 +83,17 @@
       "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "columnSize": "",
       "columnSizeFromDesktop": ""
+    },
+    {
+      "contentTypeKey": "d43b72b5-edac-42e0-aa09-1b080d7bd6eb",
+      "udi": "umb://element/4748141931ef46d2a6bf1ee724e3f40e",
+      "cssClasses": "override-this",
+      "columnSize": "",
+      "columnSizeFromDesktop": ""
+    },
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "udi": "umb://element/c1a6ce3fe616489db0b10c3e88da9931"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco/Blocks/TaskListTaskStatusProvider.cs
+++ b/GovUk.Frontend.Umbraco/Blocks/TaskListTaskStatusProvider.cs
@@ -20,28 +20,21 @@ namespace GovUk.Frontend.Umbraco.Blocks
             }
 
             var blocks = new List<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>();
-            Func<OverridableBlockListItem, bool> blockListFilter = x => true;
-            Func<OverridableBlockGridItem, bool> blockGridFilter = x => true;
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool> blockFilter = x => true;
             foreach (var blockModel in content.FindOverridableBlockModels())
             {
                 if (blockModel is OverridableBlockListModel blockList)
                 {
-                    blockListFilter = blockList.Filter;
+                    blockFilter = blockList.Filter;
                     blocks.AddRange(blockList);
                 }
                 else if (blockModel is OverridableBlockGridModel blockGrid)
                 {
-                    blockGridFilter = blockGrid.Filter;
+                    blockFilter = blockGrid.Filter;
                     blocks.AddRange(blockGrid);
                 }
             }
 
-            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool> combinedFilter = block =>
-            {
-                if (block is OverridableBlockListItem listItem) { return blockListFilter(listItem); }
-                if (block is OverridableBlockGridItem gridItem) { return blockGridFilter(gridItem); }
-                return true;
-            };
             Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>?> blockSelector = block =>
             {
                 if (block is OverridableBlockListItem listItem) { return listItem; }
@@ -49,7 +42,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
                 return null;
             };
             var tasks = blocks.FindBlocksByContentTypeAlias(ElementTypeAliases.Task)
-                .Where(combinedFilter).Select(blockSelector).OfType<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>();
+                .Where(blockFilter).Select(blockSelector).OfType<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>();
             var taskStatuses = tasks
                 .Select(x => x.Settings.Value<string>(PropertyAliases.TaskListTaskStatus))
                 .Where(x => !string.IsNullOrEmpty(x))

--- a/GovUk.Frontend.Umbraco/ElementTypeAliases.cs
+++ b/GovUk.Frontend.Umbraco/ElementTypeAliases.cs
@@ -3,6 +3,7 @@
     public static class ElementTypeAliases
     {
         public const string Caption = "govukCaption";
+        public const string CaptionSettings = "govukCaptionSettings";
         public const string Checkboxes = "govukCheckboxes";
         public const string CheckboxesSettings = "govukCheckboxesSettings";
         public const string Checkbox = "govukCheckbox";
@@ -15,25 +16,32 @@
         public const string Fieldset = "govukFieldset";
         public const string FieldsetSettings = "govukFieldsetSettings";
         public const string FileUpload = "govukFileUpload";
+        public const string FileUploadSettings = "govukFileUploadSettings";
         public const string GridRow = "govukGridRow";
         public const string GridRowSettings = "govukGridRowSettings";
         public const string GridColumn = "govukGridColumn";
         public const string GridColumnSettings = "govukGridColumnSettings";
         public const string PageHeading = "govukPageHeading";
+        public const string PageHeadingSettings = "govukPageHeadingSettings";
         public const string Radios = "govukRadios";
         public const string RadiosSettings = "govukRadiosSettings";
         public const string Radio = "govukRadio";
         public const string RadioSettings = "govukRadioSettings";
         public const string RadiosDivider = "govukRadiosDivider";
         public const string Select = "govukSelect";
+        public const string SelectSettings = "govukSelectSettings";
         public const string SelectOption = "govukSelectOption";
         public const string SummaryCard = "govukSummaryCard";
+        public const string SummaryCardSettings = "govukSummaryCardSettings";
         public const string SummaryList = "govukSummaryList";
+        public const string SummaryListSettings = "govukSummaryListSettings";
         public const string SummaryListItem = "govukSummaryListItem";
         public const string SummaryListItemSettings = "govukSummaryListItemSettings";
         public const string SummaryListAction = "govukSummaryListAction";
         public const string TaskListSummary = "govukTaskListSummary";
+        public const string TaskListSummarySettings = "govukTaskListSummarySettings";
         public const string TaskList = "govukTaskList";
+        public const string TaskListSettings = "govukTaskListSettings";
         public const string Task = "govukTask";
         public const string TaskSettings = "govukTaskSettings";
         public const string TextInput = "govukTextInput";

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-		<Version>5.2.2</Version>
+		<Version>5.2.3</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>5.2.2</Version>
+		<Version>5.2.3</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Title>$(AssemblyName)</Title>
-	<Version>5.0.0</Version>
+	<Version>5.0.1</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		    This will help identify breaking changes where the major version should change. -->
     <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
@@ -19,6 +19,7 @@ using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Routing;
+using di = Umbraco.Cms.Web.Common.DependencyInjection;
 
 namespace ThePensionsRegulator.Umbraco.Testing
 {
@@ -77,9 +78,19 @@ namespace ThePensionsRegulator.Umbraco.Testing
         public Mock<IVariationContextAccessor> VariationContextAccessor { get; private init; } = new();
 
         /// <summary>
+        /// Provides a fallback strategy for getting <see cref="IPublishedElement"/> values.
+        /// </summary>
+        public Mock<IPublishedValueFallback> PublishedValueFallback { get; private init; } = new();
+
+        /// <summary>
         /// Represents the Umbraco service context, which provides access to all services.
         /// </summary>
         public ServiceContext ServiceContext { get; private init; }
+
+        /// <summary>
+        /// The service provider used by Umbraco to look up internal services using dependency injection.
+        /// </summary>
+        public Mock<IServiceProvider> ServiceProvider { get; private init; } = new();
 
         /// <summary>
         /// Gets the current content item.
@@ -185,6 +196,25 @@ namespace ThePensionsRegulator.Umbraco.Testing
 
             CurrentIdentity.SetupGet(x => x.IsAuthenticated).Returns(false);
             CurrentPrincipal = new GenericPrincipal(CurrentIdentity.Object, Array.Empty<string>());
+
+            SetupServices();
+        }
+
+        private void SetupServices()
+        {
+            di.StaticServiceProvider.Instance = ServiceProvider.Object;
+            SetupService(CompositeViewEngine.Object);
+            SetupService(UmbracoContextAccessor.Object);
+            SetupService(PublishedSnapshotAccessor.Object);
+            SetupService(VariationContextAccessor.Object);
+            SetupService(PublishedValueFallback.Object);
+            SetupService(PublishedContentCache);
+            SetupService(LocalizationService);
+        }
+
+        private void SetupService<T>(T implementation)
+        {
+            ServiceProvider.Setup(x => x.GetService(typeof(T))).Returns(implementation);
         }
 
         delegate void TryGetPublishedSnapshotCallback(out IPublishedSnapshot snapshot);

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockGridModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockGridModelTests.cs
@@ -12,6 +12,12 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
     {
         private const string PROPERTY_ALIAS_CHILD_BLOCKS = "childBlocks";
 
+        [SetUp]
+        public void Setup()
+        {
+            _ = new UmbracoTestContext(); // Sets up Umbraco dependency injection
+        }
+
         private static (OverridableBlockGridModel ParentBlockGrid, OverridableBlockGridModel ChildBlockGrid, OverridableBlockGridModel GrandChildBlockGrid) CreateThreeNestedOverridableBlockGrids()
         {
             var grandChildBlockGrid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(Array.Empty<BlockGridItem>());

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
@@ -12,6 +12,12 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
     {
         private const string PROPERTY_ALIAS_CHILD_BLOCKS = "childBlocks";
 
+        [SetUp]
+        public void Setup()
+        {
+            _ = new UmbracoTestContext(); // Sets up Umbraco dependency injection
+        }
+
         private static (OverridableBlockListModel ParentBlockList, OverridableBlockListModel ChildBlockList, OverridableBlockListModel GrandChildBlockList) CreateThreeNestedOverridableBlockLists()
         {
             var grandChildBlockList = UmbracoBlockListFactory.CreateOverridableBlockListModel(Array.Empty<BlockListItem>());

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModel.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModel.cs
@@ -19,19 +19,12 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         {
             if (property.PropertyType.EditorAlias == propertyEditorAlias)
             {
-                var overridenNestedBlockModelProperty = overridableItem.Content.GetProperty(property.Alias);
+                var overriddenNestedBlockModel = overridableItem.Content.Value<TOverridableModel>(property.Alias);
 
-                TOverridableModel? overriddenNestedBlockModel = default;
-
-                if (overridenNestedBlockModelProperty is not null)
-                {
-                    overriddenNestedBlockModel = (TOverridableModel?)overridenNestedBlockModelProperty.GetValue();
-                }
-
-                if (overriddenNestedBlockModel == null)
+                if (overriddenNestedBlockModel is null)
                 {
                     var nestedBlockModel = overridableItem.Content.Value<TBaseModel>(property.Alias);
-                    if (nestedBlockModel != null)
+                    if (nestedBlockModel is not null)
                     {
                         overriddenNestedBlockModel = baseToOverridableFactory(nestedBlockModel);
                     }

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModelExtensions.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModelExtensions.cs
@@ -326,8 +326,9 @@ namespace ThePensionsRegulator.Umbraco.Blocks
                 {
                     if (blockProperty.PropertyType.EditorAlias == Constants.PropertyEditors.Aliases.BlockList && blockProperty.HasValue())
                     {
-                        IEnumerable<T>? childBlocks = (IEnumerable<T>?)((block as OverridableBlockListItem)?.Content.Value<OverridableBlockListModel>(blockProperty.Alias));
-                        if (childBlocks == null) { childBlocks = (IEnumerable<T>?)blockProperty.Value<BlockListModel>(publishedValueFallback ?? new NoopPublishedValueFallback()); }
+                        var overridableBlock = block as IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>;
+                        IEnumerable<T>? childBlocks = (IEnumerable<T>?)(overridableBlock?.Content.Value<OverridableBlockListModel>(blockProperty.Alias));
+                        if (childBlocks is null) { childBlocks = (IEnumerable<T>?)blockProperty.Value<BlockListModel>(publishedValueFallback ?? new NoopPublishedValueFallback()); }
                         var result = RecursivelyFindBlocks(childBlocks!, matcher, returnFirstMatchOnly, publishedValueFallback);
                         if (result.Any())
                         {

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,7 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->
 	<PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>

--- a/docs/umbraco/unit-testing.md
+++ b/docs/umbraco/unit-testing.md
@@ -138,23 +138,6 @@ var blockList = UmbracoBlockListFactory.CreateOverridableBlockListModel(
 _testContext.CurrentPage.SetupUmbracoBlockListPropertyValue("myBlockListPropertyAlias", blockList);
 ```
 
-When writing unit tests with blocks you may see the following error:
-
-> System.TypeInitializationException : The type initializer for 'Umbraco.Extensions.FriendlyPublishedElementExtensions' threw an exception.
-> ----> System.ArgumentNullException : Value cannot be null. (Parameter 'provider')
-
-This is thrown by the built-in `.Value<T>` extension method. To resolve this your code may need to cast a block to `OverridableBlockListItem`, which overrides this extension method with one that works during testing.
-
-```csharp
-// Throws an error
-var fieldset1 = blockList.FindBlockByContentTypeAlias(GovukFieldset.ModelTypeAlias);
-var fieldsetBlocks1 = fieldset1.Content.Value<OverridableBlockListModel>(nameof(GovukFieldset.Blocks));
-
-// Works, because the block is cast to OverridableBlockListItem
-var fieldset2 = ((OverridableBlockListItem)blockList.FindBlockByContentTypeAlias(GovukFieldset.ModelTypeAlias));
-var fieldsetBlocks2 = fieldset2.Content.Value<OverridableBlockListModel>(nameof(GovukFieldset.Blocks));
-```
-
 ## Mock Umbraco Dictionary items
 
 `LocalizationServiceExtensions` provides an easy way to mock an Umbraco dictionary. You can add as many dictionary values as needed using a fluent syntax. You can also provide different translations.
@@ -165,4 +148,37 @@ var dictionary = new Mock<ILocalizationService>();
 dictionary
     .AddDictionaryValue("myKey", "myValue") // languageId defaults to 2 - English GB
     .AddDictionaryValue("myKey", "myValue", 1); // Setting languageId to 1 - English US
+```
+
+## Troubleshooting tests
+
+### Value cannot be null. (Parameter 'contentType')
+
+You may see the following error:
+
+```csharp
+System.ArgumentNullException : Value cannot be null. (Parameter 'contentType')
+```
+
+The solution is to set up the relevant content type on the `UmbracoTestContext` - see [Mock Umbraco content types](#mock-umbraco-content-types).
+
+### TypeInitializationException
+
+When writing unit tests with blocks you may see the following error:
+
+```csharp
+System.TypeInitializationException : The type initializer for 'Umbraco.Extensions.FriendlyPublishedElementExtensions' threw an exception.
+----> System.ArgumentNullException : Value cannot be null. (Parameter 'provider')
+```
+
+This is thrown by the built-in `.Value<T>` extension method. To resolve this make sure you are creating an instance of `UmbracoTestContext`, which sets up the dependency injection to make this work. Alternatively, your code may need to cast a block to `OverridableBlockListItem`, which overrides this extension method with one that works during testing.
+
+```csharp
+// Throws an error
+var fieldset1 = blockList.FindBlockByContentTypeAlias(GovukFieldset.ModelTypeAlias);
+var fieldsetBlocks1 = fieldset1.Content.Value<OverridableBlockListModel>(nameof(GovukFieldset.Blocks));
+
+// Works, because the block is cast to OverridableBlockListItem
+var fieldset2 = ((OverridableBlockListItem)blockList.FindBlockByContentTypeAlias(GovukFieldset.ModelTypeAlias));
+var fieldsetBlocks2 = fieldset2.Content.Value<OverridableBlockListModel>(nameof(GovukFieldset.Blocks));
 ```


### PR DESCRIPTION
When using the `OverrideSummaryListItems` extension method to populate a summary list from a data source, list actions were not being rendered. This was due to a [regression](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/commit/d66d6bed52b01e52569272280f6e4eb62245569c) which caused code to no longer look at overridden values for nested block lists.

The Umbraco example app now has a demonstration of this on its 'Summary list' page:

![Dynamic data in a summary list](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/09ebf13e-606b-468b-8985-932c824b1cb6)

This regression was introduced as a workaround for a unit testing bug which meant that the `.Value<T>` method for getting a property value didn't work when it tried to access the original value of a property. We've encountered and worked around this bug frequently, sometimes with workarounds similar to this regression. An update to `UmbracoTestContext` in this PR fixes the bug by registering the `IPublishedValueFallback` service with dependency injection. It also makes the mock of that service and the service container available to consuming projects, and registers other services that are already part of the `UmbracoTestContext`.

Reverting this regression caused another test to fail, which was due to a bug in `OverridableBlockModelExtensions`. It was not considering that a child block list might exist on an `OverridableBlockGridItem` as well as an `OverridableBlockListItem`.

Fixing this in turn caused another test to fail, because `TaskListTaskStatusProvider` was not taking the filter applied to a block grid and passing it down to a child block list. A test for this existed but was passing only due to the previous bug in `OverridableBlockModelExtensions`.