### PR TITLE
Page history was not loading in the backoffice

### DIFF
--- a/GovUk.Frontend.Umbraco/ModelBinding/ModelBindingMvcConfiguration.cs
+++ b/GovUk.Frontend.Umbraco/ModelBinding/ModelBindingMvcConfiguration.cs
@@ -5,18 +5,28 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
+using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
 
 namespace GovUk.Frontend.Umbraco.ModelBinding
 {
     internal class ModelBindingMvcConfiguration : IConfigureOptions<MvcOptions>
     {
+        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly ICultureDictionary _cultureDictionary;
         private readonly IPublishedValueFallback? _publishedValueFallback;
         private readonly GovUkFrontendAspNetCoreOptions _options;
 
-        public ModelBindingMvcConfiguration(GovUkFrontendAspNetCoreOptionsProvider optionsProvider, IPublishedValueFallback? publishedValueFallback)
+        public ModelBindingMvcConfiguration(
+            GovUkFrontendAspNetCoreOptionsProvider optionsProvider,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            ICultureDictionary cultureDictionary,
+            IPublishedValueFallback? publishedValueFallback)
         {
             _options = optionsProvider?.Options ?? throw new ArgumentNullException(nameof(optionsProvider));
+            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _cultureDictionary = cultureDictionary ?? throw new ArgumentNullException(nameof(cultureDictionary));
             _publishedValueFallback = publishedValueFallback;
         }
 
@@ -27,7 +37,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
             var govukDateBinder = options.ModelBinderProviders.FirstOrDefault(x => x.GetType().FullName == typeof(DateInputModelBinderProvider).FullName);
             if (govukDateBinder != null) { options.ModelBinderProviders.Remove(govukDateBinder); }
 
-            options.ModelBinderProviders.Insert(0, new UmbracoDateInputModelBinderProvider(_options, _publishedValueFallback));
+            options.ModelBinderProviders.Insert(0, new UmbracoDateInputModelBinderProvider(_options, _umbracoContextAccessor, _cultureDictionary, _publishedValueFallback));
         }
     }
 }

--- a/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinderProvider.cs
+++ b/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinderProvider.cs
@@ -2,7 +2,10 @@
 using GovUk.Frontend.AspNetCore.Extensions;
 using GovUk.Frontend.AspNetCore.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
 
 namespace GovUk.Frontend.Umbraco.ModelBinding
 {
@@ -12,13 +15,21 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
     public class UmbracoDateInputModelBinderProvider : IModelBinderProvider
     {
         private readonly DateInputModelConverter[] _dateInputModelConverters;
+        private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+        private readonly ICultureDictionary _cultureDictionary;
         private readonly IPublishedValueFallback? _publishedValueFallback;
 
-        public UmbracoDateInputModelBinderProvider(GovUkFrontendAspNetCoreOptions options, IPublishedValueFallback? publishedValueFallback)
+        public UmbracoDateInputModelBinderProvider(
+            GovUkFrontendAspNetCoreOptions options,
+            IUmbracoContextAccessor umbracoContextAccessor,
+            ICultureDictionary cultureDictionary,
+            IPublishedValueFallback? publishedValueFallback)
         {
             Guard.ArgumentNotNull(nameof(options), options);
 
             _dateInputModelConverters = options.DateInputModelConverters.ToArray();
+            _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
+            _cultureDictionary = cultureDictionary ?? throw new ArgumentNullException(nameof(cultureDictionary));
             _publishedValueFallback = publishedValueFallback;
         }
 
@@ -32,7 +43,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
             {
                 if (converter.CanConvertModelType(modelType))
                 {
-                    return new UmbracoDateInputModelBinder(converter, _publishedValueFallback);
+                    return new UmbracoDateInputModelBinder(converter, _umbracoContextAccessor, _cultureDictionary, _publishedValueFallback);
                 }
             }
 

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
@@ -203,6 +203,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
         private void SetupServices()
         {
             di.StaticServiceProvider.Instance = ServiceProvider.Object;
+            HttpContext.Setup(x => x.RequestServices).Returns(ServiceProvider.Object);
             SetupService(CompositeViewEngine.Object);
             SetupService(UmbracoContextAccessor.Object);
             SetupService(PublishedSnapshotAccessor.Object);


### PR DESCRIPTION
In the Umbraco backoffice for every page the history section was failing to load with an error, as shown below (or after #268 it displays a full stack trace).

<img width="747" alt="History section not loading" src="https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/920a4e0c-e85f-4228-a493-6b403ef25431">

This is because `UmbracoDateInputModelBinder` looks for the current published request and throws an exception if it doesn't find it, but in the backoffice there is no published request. Since `UmbracoDateInputModelBinder` is not intended for the backoffice, this PR returns immediately from `UmbracoDateInputModelBinder` when a backoffice request is detected. 

This requires replacing the use of `IUmbracoPublishedContentAccessor`, which throws the exception, with `UmbracoContextAccessor`. This PR also takes the opportunity to replace the service location pattern with dependency injection, for that service and `ICultureDictionary`.

Noting that `HttpContext.RequestServices` is used for service location, it also adds support for that to `UmbracoTestContext`.

There is no version bump because other open PRs have suitable version bumps.