### PR TITLE
Update govuk-frontend to v4.6.0

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.58.1" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.2.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.3.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
 	</ItemGroup>

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/govuk-frontend-4.5.0.min.js"></script>
+﻿<script src="~/govuk-frontend-4.6.0.min.js"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js"></script>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/text-input.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/text-input.config
@@ -299,7 +299,8 @@
       "columnSizeFromDesktop": "",
       "labelIsPageHeading": "0",
       "cssClassesForRow": "",
-      "textInputWidth": "[\"x-small\"]"
+      "textInputWidth": "[\"x-small\"]",
+      "readOnly": "0"
     },
     {
       "contentTypeKey": "6930e373-0fce-44ad-89b8-267442675807",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/text-input.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/text-input.config
@@ -92,7 +92,8 @@
     {
       "contentTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
       "udi": "umb://element/1a08f650c8e74e2cb1dfc0822c5b9ed5",
-      "label": "Telefonnummer"
+      "label": "Telefonnummer",
+      "hint": ""
     },
     {
       "contentTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
@@ -150,7 +151,10 @@
       "errorMessagePhone": "Dies muss eine Telefonnummer sein",
       "labelIsPageHeading": "0",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "textInputWidth": "",
+      "readOnly": "0",
+      "extraLetterSpacing": "1"
     },
     {
       "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
@@ -317,7 +321,10 @@
       "errorMessagePhone": "This must be a phone number",
       "labelIsPageHeading": "0",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "textInputWidth": "",
+      "readOnly": "0",
+      "extraLetterSpacing": "1"
     },
     {
       "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuktextinputsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuktextinputsettings.config
@@ -33,6 +33,22 @@
   <Structure />
   <GenericProperties>
     <GenericProperty>
+      <Key>1d5965c0-f041-40f9-bd95-9d63cf5981ba</Key>
+      <Name>Extra letter spacing</Name>
+      <Alias>extraLetterSpacing</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[For things like security codes, reference or phone numbers, where users check one character at a time.]]></Description>
+      <SortOrder>15</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>0f5d75ea-9cbb-4f55-afc1-98f8374f7af3</Key>
       <Name>Prefix</Name>
       <Alias>prefix</Alias>
@@ -41,7 +57,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[For example, a £ sign before a currency field.]]></Description>
-      <SortOrder>3</SortOrder>
+      <SortOrder>2</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -57,7 +73,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[For example, a % sign after a percentage field.]]></Description>
-      <SortOrder>4</SortOrder>
+      <SortOrder>3</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -73,7 +89,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>6</SortOrder>
+      <SortOrder>5</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>

--- a/GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -36,7 +36,8 @@ namespace GovUk.Frontend.Umbraco.Tests.ModelBinding
                     converterMock.Object,
                     _testContext.UmbracoContextAccessor.Object,
                     Mock.Of<ICultureDictionary>(),
-                    _testContext.PublishedValueFallback.Object
+                    _testContext.PublishedValueFallback.Object,
+                    false
                 );
 
         [Test]
@@ -298,7 +299,7 @@ namespace GovUk.Frontend.Umbraco.Tests.ModelBinding
             // Arrange
 
             // Act
-            var result = UmbracoDateInputModelBinder.Parse(dayEnabled, day, month, year, out var parsed);
+            var result = UmbracoDateInputModelBinder.Parse(dayEnabled, day, month, year, false ,out var parsed);
 
             // Assert
             Assert.That(result, Is.EqualTo(DateInputParseErrors.None));
@@ -329,7 +330,7 @@ namespace GovUk.Frontend.Umbraco.Tests.ModelBinding
             // Arrange
 
             // Act
-            var result = UmbracoDateInputModelBinder.Parse(true, day, month, year, out var dateComponents);
+            var result = UmbracoDateInputModelBinder.Parse(true, day, month, year, false, out var dateComponents);
 
             // Assert
             Assert.AreEqual(default, dateComponents);

--- a/GovUk.Frontend.Umbraco/ApplicationBuilderExtensions.cs
+++ b/GovUk.Frontend.Umbraco/ApplicationBuilderExtensions.cs
@@ -42,7 +42,7 @@ namespace GovUk.Frontend.Umbraco
                 bundles.CreateCss("govuk-frontend-css",
                     "/_content/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk/govuk-frontend.css");
 
-                bundles.CreateJs("govuk-frontend-js", "~/govuk-frontend-4.5.0.min.js",
+                bundles.CreateJs("govuk-frontend-js", "~/govuk-frontend-4.6.0.min.js",
                   "/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js");
 
                 bundles.CreateJs("govuk-frontend-validation", "/_content/ThePensionsRegulator.GovUk.Frontend/lib/jquery/dist/jquery.min.js",

--- a/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinderProvider.cs
+++ b/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinderProvider.cs
@@ -15,6 +15,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
     public class UmbracoDateInputModelBinderProvider : IModelBinderProvider
     {
         private readonly DateInputModelConverter[] _dateInputModelConverters;
+        private readonly bool _acceptMonthNamesInDateInputs;
         private readonly IUmbracoContextAccessor _umbracoContextAccessor;
         private readonly ICultureDictionary _cultureDictionary;
         private readonly IPublishedValueFallback? _publishedValueFallback;
@@ -28,6 +29,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
             Guard.ArgumentNotNull(nameof(options), options);
 
             _dateInputModelConverters = options.DateInputModelConverters.ToArray();
+            _acceptMonthNamesInDateInputs = options.AcceptMonthNamesInDateInputs;
             _umbracoContextAccessor = umbracoContextAccessor ?? throw new ArgumentNullException(nameof(umbracoContextAccessor));
             _cultureDictionary = cultureDictionary ?? throw new ArgumentNullException(nameof(cultureDictionary));
             _publishedValueFallback = publishedValueFallback;
@@ -43,7 +45,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
             {
                 if (converter.CanConvertModelType(modelType))
                 {
-                    return new UmbracoDateInputModelBinder(converter, _umbracoContextAccessor, _cultureDictionary, _publishedValueFallback);
+                    return new UmbracoDateInputModelBinder(converter, _umbracoContextAccessor, _cultureDictionary, _publishedValueFallback, _acceptMonthNamesInDateInputs);
                 }
             }
 

--- a/GovUk.Frontend.Umbraco/PropertyAliases.cs
+++ b/GovUk.Frontend.Umbraco/PropertyAliases.cs
@@ -27,6 +27,7 @@
         public const string ErrorMessageRange = "errorMessageRange";
         public const string ErrorMessageCompare = "errorMessageCompare";
         public const string ErrorMessage = "error";
+        public const string ExtraLetterSpacing = "extraLetterSpacing";
         public const string FieldsetBlocks = "blocks";
         public const string FieldsetLegendIsPageHeading = "legendIsPageHeading";
         public const string FieldsetErrorsEnabled = "fieldsetErrors";

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
@@ -82,7 +82,7 @@
                                 <govuk-date-input-error-message>@errorMessage</govuk-date-input-error-message>
                             }
                             <govuk-date-input-day maxlength="2" aria-invalid="@ariaInvalid" readonly="readonly" />
-                            <govuk-date-input-month maxlength="2" aria-invalid="@ariaInvalid" readonly="readonly" />
+                            <govuk-date-input-month aria-invalid="@ariaInvalid" readonly="readonly" />
                             <govuk-date-input-year maxlength="4" aria-invalid="@ariaInvalid" readonly="readonly" />
                         </govuk-date-input>
                     </govuk-date-input-options>
@@ -100,7 +100,7 @@
                                 <govuk-date-input-error-message>@errorMessage</govuk-date-input-error-message>
                             }
                             <govuk-date-input-day maxlength="2" aria-invalid="@ariaInvalid" />
-                            <govuk-date-input-month maxlength="2" aria-invalid="@ariaInvalid" />
+                            <govuk-date-input-month aria-invalid="@ariaInvalid" />
                             <govuk-date-input-year maxlength="4" aria-invalid="@ariaInvalid" />
                         </govuk-date-input>
                     </govuk-date-input-options>
@@ -121,7 +121,7 @@
                                 <govuk-date-input-error-message>@errorMessage</govuk-date-input-error-message>
                             }
                             <govuk-date-input-day maxlength="2" aria-invalid="@ariaInvalid" value="@attemptedDay" readonly="readonly" />
-                            <govuk-date-input-month maxlength="2" aria-invalid="@ariaInvalid" value="@attemptedMonth" readonly="readonly" />
+                            <govuk-date-input-month aria-invalid="@ariaInvalid" value="@attemptedMonth" readonly="readonly" />
                             <govuk-date-input-year maxlength="4" aria-invalid="@ariaInvalid" value="@attemptedYear" readonly="readonly" />
                         </govuk-date-input>
                     </govuk-date-input-options>
@@ -139,7 +139,7 @@
                                 <govuk-date-input-error-message>@errorMessage</govuk-date-input-error-message>
                             }
                             <govuk-date-input-day maxlength="2" aria-invalid="@ariaInvalid" value="@attemptedDay" />
-                            <govuk-date-input-month maxlength="2" aria-invalid="@ariaInvalid" value="@attemptedMonth" />
+                            <govuk-date-input-month aria-invalid="@ariaInvalid" value="@attemptedMonth" />
                             <govuk-date-input-year maxlength="4" aria-invalid="@ariaInvalid" value="@attemptedYear" />
                         </govuk-date-input>
                     </govuk-date-input-options>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTextInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTextInput.cshtml
@@ -53,6 +53,11 @@
         }
     }
 
+    var extraLetterSpacing = Model.Settings.Value<bool>(PropertyAliases.ExtraLetterSpacing);
+    if (extraLetterSpacing)
+    {
+        inputClass = (inputClass + " govuk-input--extra-letter-spacing").TrimStart();
+    }
     var hint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
     var hasHint = !string.IsNullOrWhiteSpace(hint?.ToHtmlString());
     var invalid = (modelStateEntry is not null && modelStateEntry.ValidationState == ModelValidationState.Invalid && modelStateEntry.Errors.Any()).ToString().ToLowerInvariant();

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuktextinputsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govuktextinputsettings.config
@@ -33,6 +33,22 @@
   <Structure />
   <GenericProperties>
     <GenericProperty>
+      <Key>1d5965c0-f041-40f9-bd95-9d63cf5981ba</Key>
+      <Name>Extra letter spacing</Name>
+      <Alias>extraLetterSpacing</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[For things like security codes, reference or phone numbers, where users check one character at a time.]]></Description>
+      <SortOrder>15</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>0f5d75ea-9cbb-4f55-afc1-98f8374f7af3</Key>
       <Name>Prefix</Name>
       <Alias>prefix</Alias>
@@ -41,7 +57,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[For example, a £ sign before a currency field.]]></Description>
-      <SortOrder>3</SortOrder>
+      <SortOrder>2</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -57,7 +73,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[For example, a % sign after a percentage field.]]></Description>
-      <SortOrder>4</SortOrder>
+      <SortOrder>3</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -73,7 +89,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>6</SortOrder>
+      <SortOrder>5</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We add support for:
 - The Pensions Regulator (TPR) styling for all of the above components, and:
   - [Back link](https://github.com/gunndabad/govuk-frontend-aspnetcore/blob/main/docs/components/back-link.md)
 
-We target [GDS Frontend v4.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.5.0) in line with James Gunn's base project. We also include 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
+We target [GDS Frontend v4.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0) in line with James Gunn's base project. We also include 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
 
 ## ASP.NET projects without Umbraco
 

--- a/ThePensionsRegulator.Frontend.Umbraco/ApplicationBuilderExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             {
                 bundles.CreateCss("tpr-frontend-css", "/_content/ThePensionsRegulator.Frontend.Umbraco/tpr/tpr.css");
 
-                bundles.CreateJs("tpr-frontend-js", "~/govuk-frontend-4.5.0.min.js",
+                bundles.CreateJs("tpr-frontend-js", "~/govuk-frontend-4.6.0.min.js",
                     "/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js",
                     "/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.js");
             });

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-input.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-input.scss
@@ -26,5 +26,5 @@
 
 .govuk-input__prefix--readonly,
 .govuk-input__suffix--readonly {
-    color: govuk-tint(black, 66);
+    color: govuk-tint(black, 44);
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-select.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-select.scss
@@ -1,0 +1,6 @@
+﻿@import '_tpr-variables.scss';
+@import 'govuk/base';
+
+.govuk-select:disabled {
+    @include tpr-read-only;
+}

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-variables.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-variables.scss
@@ -183,7 +183,8 @@ $govuk-typography-scale: (
 ) !default;
 
 @mixin tpr-read-only {
+    opacity: 1;
     background-color: $tpr-colour-white-smoke;
-    border-color: govuk-tint(black, 66);
-    color: govuk-tint(black, 66);
+    border-color: govuk-tint(black, 44);
+    color: govuk-tint(black, 44);
 }

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -58,6 +58,7 @@
 @import '_tpr-panel.scss';
 @import '_tpr-phase-banner.scss';
 @import '_tpr-radios-checkboxes.scss';
+@import '_tpr-select.scss';
 @import '_tpr-summary-list.scss';
 @import '_tpr-table.scss';
 @import '_tpr-textarea.scss';

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -34,7 +34,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.58.1" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.2.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.3.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
 	</ItemGroup>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -215,4 +215,8 @@
 	<ItemGroup>
 	  <UpToDateCheckInput Remove="Styles\_tpr-select.scss" />
 	</ItemGroup>
+	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Styles\_tpr-select.scss" />
+	</ItemGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
@@ -1,3 +1,3 @@
-﻿<script src="~/govuk-frontend-4.5.0.min.js"></script>
+﻿<script src="~/govuk-frontend-4.6.0.min.js"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js"></script>
 <script src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.js"></script>


### PR DESCRIPTION
- Update govuk-frontend-aspnetcore to v1.3.0, which targets govuk-frontend v4.6.0.
- Update govuk-frontend references in this repo to v4.6.0.
- Replicate the govuk-frontend-aspnetcore update which allows month names to be entered in a 'Date input' component in line with revised GOV.UK guidance, because we have a revised copy of govuk-frontend-aspnetcore code that supports custom error messages in Umbraco.
- Add a setting in Umbraco to optionally apply the extra letter spacing class introduced in govuk-frontend 4.6.0
- Align read-only styling to TPR standard [AB#180895](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/180895), including added support for disabled selects (govuk-frontend 4.6.0 changed the default styling for disabled fields, so this needed to be updated)

See also the [release notes for govuk-frontend v4.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0) (and bear in mind we do not have accordion support beyond that which is out-of-the-box from govuk-frontend) and also the release notes for [govuk-aspnet-core v1.3.0](https://github.com/gunndabad/govuk-frontend-aspnetcore/releases/tag/v1.3.0).