### PR TITLE
Upgrade to govuk-frontend 4.7

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.58.1" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.3.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.4.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
 	</ItemGroup>

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/govuk-frontend-4.6.0.min.js"></script>
+﻿<script src="~/govuk-frontend-4.7.0.min.js"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js"></script>

--- a/GovUk.Frontend.ExampleApp/Views/Button/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Button/Index.cshtml
@@ -29,16 +29,16 @@
 
 <div class="govuk-grid-row govuk-grid-row--dark-background">
     <div class="govuk-grid-column govuk-grid-column-two-thirds">
-        <govuk-button class="govuk-button--reversed" type="button">Reversed button</govuk-button>
+        <govuk-button class="govuk-button--inverse" type="button">Reversed button</govuk-button>
     </div>
 </div>
 
 <govuk-notification-banner>
     <p class="govuk-body">Reversed buttons should be used inside a notification banner.</p>
-    <govuk-button class="govuk-button--reversed" type="button">Reversed button</govuk-button>
+    <govuk-button class="govuk-button--inverse" type="button">Reversed button</govuk-button>
 </govuk-notification-banner>
 
 <govuk-notification-banner type="Success">
     <p class="govuk-body">Reversed buttons should be used inside a notification banner.</p>
-    <govuk-button class="govuk-button--reversed" type="button">Reversed button</govuk-button>
+    <govuk-button class="govuk-button--inverse" type="button">Reversed button</govuk-button>
 </govuk-notification-banner>

--- a/GovUk.Frontend.ExampleApp/Views/NotificationBanner/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/NotificationBanner/Index.cshtml
@@ -8,7 +8,7 @@
         A <a class="govuk-notification-banner__link" href="https://design-system.service.gov.uk/components/notification-banner/">notification banner</a> lets you tell the user about something that's not directly relevant to the thing they’re trying to do on that page of the service.
     </p>
     <p class"govuk-body">A button or a group of buttons can be targeted with Javascript to add additional behaviour.</p>
-    <govuk-button class="govuk-button--reversed" type="button">Reversed button</govuk-button>
+    <govuk-button class="govuk-button--inverse" type="button">Reversed button</govuk-button>
 </govuk-notification-banner>
 
 <govuk-notification-banner type="Success">
@@ -16,7 +16,7 @@
         Use the green version of the notification banner to confirm that something they’re expecting to happen has happened.
     </h3>
     <p class="govuk-body">Do not use a notification banner to tell users that they’ve finished using a linear service. Use a <a class="govuk-notification-banner__link" href="https://design-system.service.gov.uk/patterns/confirmation-pages/">confirmation page</a> instead.</p>
-    <govuk-button class="govuk-button--reversed" type="button">Reversed button</govuk-button>
+    <govuk-button class="govuk-button--inverse" type="button">Reversed button</govuk-button>
 </govuk-notification-banner>
 
 <span class="govuk-caption-xl">Example application</span>

--- a/GovUk.Frontend.Umbraco/ApplicationBuilderExtensions.cs
+++ b/GovUk.Frontend.Umbraco/ApplicationBuilderExtensions.cs
@@ -42,7 +42,7 @@ namespace GovUk.Frontend.Umbraco
                 bundles.CreateCss("govuk-frontend-css",
                     "/_content/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk/govuk-frontend.css");
 
-                bundles.CreateJs("govuk-frontend-js", "~/govuk-frontend-4.6.0.min.js",
+                bundles.CreateJs("govuk-frontend-js", "~/govuk-frontend-4.7.0.min.js",
                   "/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js");
 
                 bundles.CreateJs("govuk-frontend-validation", "/_content/ThePensionsRegulator.GovUk.Frontend/lib/jquery/dist/jquery.min.js",

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkButton.cshtml
@@ -19,7 +19,7 @@
     var buttonStyle = Model.Settings.Value<string[]>("styleOfButton") ?? Array.Empty<string>();
     if (buttonStyle.Contains("Secondary")) { buttonStyle[buttonStyle.IndexOf("Secondary")] = "govuk-button--secondary"; }
     if (buttonStyle.Contains("Warning")) { buttonStyle[buttonStyle.IndexOf("Warning")] = "govuk-button--warning"; }
-    if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--reversed"; }
+    if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--inverse"; }
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
     var disabled = Model.Settings.Value<bool>("disabled").ToString().ToLower();
 

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
@@ -14,7 +14,7 @@
     var buttonStyle = Model.Settings.Value<string[]>("styleOfButton") ?? Array.Empty<string>();
     if (buttonStyle.Contains("Secondary")) { buttonStyle[buttonStyle.IndexOf("Secondary")] = "govuk-button--secondary"; }
     if (buttonStyle.Contains("Warning")) { buttonStyle[buttonStyle.IndexOf("Warning")] = "govuk-button--warning"; }
-    if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--reversed"; }
+    if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--inverse"; }
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
 }
 <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses">@text</govuk-button-link>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We add support for:
 - The Pensions Regulator (TPR) styling for all of the above components, and:
   - [Back link](https://github.com/gunndabad/govuk-frontend-aspnetcore/blob/main/docs/components/back-link.md)
 
-We target [GDS Frontend v4.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0) in line with James Gunn's base project. We also include 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
+We target [GDS Frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) in line with James Gunn's base project. We also include 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
 
 ## ASP.NET projects without Umbraco
 

--- a/ThePensionsRegulator.Frontend.Umbraco/ApplicationBuilderExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             {
                 bundles.CreateCss("tpr-frontend-css", "/_content/ThePensionsRegulator.Frontend.Umbraco/tpr/tpr.css");
 
-                bundles.CreateJs("tpr-frontend-js", "~/govuk-frontend-4.6.0.min.js",
+                bundles.CreateJs("tpr-frontend-js", "~/govuk-frontend-4.7.0.min.js",
                     "/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js",
                     "/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.js");
             });

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-button.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-button.scss
@@ -67,7 +67,7 @@ input[type="file"]::file-selector-button {
 }
 .govuk-button--start:focus:not(:active):not(:hover),
 .govuk-button--secondary:focus:not(:active):not(:hover),
-.govuk-button--reversed:focus:not(:active):not(:hover) {
+.govuk-button--inverse:focus:not(:active):not(:hover) {
     background-image: none;
 }
 
@@ -103,7 +103,7 @@ a.govuk-button--warning.govuk-button--secondary:active {
     border-color: $tpr-colour-petite-orchid;
 }
 
-.govuk-button--reversed {
+.govuk-button--inverse {
     background-color: transparent;
     background-image: none;
     padding-right: govuk-spacing(4);

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-notification-banner.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-notification-banner.scss
@@ -18,7 +18,7 @@
         .govuk-notification-banner__content {
             background-color: $tpr-colour-camarone;
 
-            .govuk-button--reversed:not(:active):not(:focus):not(:hover) {
+            .govuk-button--inverse:not(:active):not(:focus):not(:hover) {
                 color: $tpr-colour-camarone;
             }
         }
@@ -37,13 +37,13 @@
             max-width: none;
         }
 
-        .govuk-button--reversed {
+        .govuk-button--inverse {
             background-color: $tpr-colour-white;
             color: $tpr-colour-eastern-blue;
 
-            &:hover, 
-            &:active, 
-            &:hover:focus, 
+            &:hover,
+            &:active,
+            &:hover:focus,
             &:active:focus {
                 background-color: transparent;
                 color: $tpr-colour-white;

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -34,7 +34,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.58.1" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.3.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.4.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
 	</ItemGroup>

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
@@ -1,3 +1,3 @@
-﻿<script src="~/govuk-frontend-4.6.0.min.js"></script>
+﻿<script src="~/govuk-frontend-4.7.0.min.js"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js"></script>
 <script src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.js"></script>


### PR DESCRIPTION
- Update govuk-frontend-aspnetcore to v1.4.0, which targets govuk-frontend v4.7.0.
- Update govuk-frontend references in this repo to v4.7.0.
- Rename our class `govuk-input--reversed` to `govuk-input--inverse`. The new name is introduced by govuk-frontend v4.7.0 so it means we build on their styles, although no changes are needed to our styles at present.
- We do not remove our version of `TitleTagHelper` even though `govuk-frontend-aspnetcore v1.4.0` includes an updated version, because ours also handles client-side support.

See also the [release notes for govuk-frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) and also the release notes for [govuk-frontend-aspnetcore v1.4.0](https://github.com/gunndabad/govuk-frontend-aspnetcore/releases/tag/v1.4.0).