### PR TITLE
Upgrade to govuk-frontend 4.8.0 and govuk-frontend-aspnetcore 1.5.0

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.58.1" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.4.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.5.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
 	</ItemGroup>

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/govuk-frontend-4.7.0.min.js"></script>
+﻿<script src="~/govuk-frontend-4.8.0.min.js"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js"></script>

--- a/GovUk.Frontend.Umbraco/ApplicationBuilderExtensions.cs
+++ b/GovUk.Frontend.Umbraco/ApplicationBuilderExtensions.cs
@@ -42,7 +42,7 @@ namespace GovUk.Frontend.Umbraco
                 bundles.CreateCss("govuk-frontend-css",
                     "/_content/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk/govuk-frontend.css");
 
-                bundles.CreateJs("govuk-frontend-js", "~/govuk-frontend-4.7.0.min.js",
+                bundles.CreateJs("govuk-frontend-js", "~/govuk-frontend-4.8.0.min.js",
                   "/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js");
 
                 bundles.CreateJs("govuk-frontend-validation", "/_content/ThePensionsRegulator.GovUk.Frontend/lib/jquery/dist/jquery.min.js",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We add support for:
 - The Pensions Regulator (TPR) styling for all of the above components, and:
   - [Back link](https://github.com/gunndabad/govuk-frontend-aspnetcore/blob/main/docs/components/back-link.md)
 
-We target [GDS Frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) in line with James Gunn's base project. We also include 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
+We target [GDS Frontend v4.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0) in line with James Gunn's base project. We also include 'Task list' based on [govuk-frontend pre-release code](https://github.com/alphagov/govuk-design-system/pull/1994).
 
 ## ASP.NET projects without Umbraco
 

--- a/ThePensionsRegulator.Frontend.Umbraco/ApplicationBuilderExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             {
                 bundles.CreateCss("tpr-frontend-css", "/_content/ThePensionsRegulator.Frontend.Umbraco/tpr/tpr.css");
 
-                bundles.CreateJs("tpr-frontend-js", "~/govuk-frontend-4.7.0.min.js",
+                bundles.CreateJs("tpr-frontend-js", "~/govuk-frontend-4.8.0.min.js",
                     "/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js",
                     "/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.js");
             });

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -34,7 +34,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.58.1" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.4.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.5.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
 	</ItemGroup>

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
@@ -1,3 +1,3 @@
-﻿<script src="~/govuk-frontend-4.7.0.min.js"></script>
+﻿<script src="~/govuk-frontend-4.8.0.min.js"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js"></script>
 <script src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.js"></script>


### PR DESCRIPTION
- Update govuk-frontend-aspnetcore to v1.5.0, which targets govuk-frontend v4.8.0.
- Update govuk-frontend references in this repo to v4.8.0.
- No further changes as 4.8 is an update to the crown logo that we are not using.

See also the [release notes for govuk-frontend v4.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0) and also the release notes for [govuk-frontend-aspnetcore v1.5.0](https://github.com/gunndabad/govuk-frontend-aspnetcore/releases/tag/v1.5.0).