### PR TITLE
Adds data-prevent-double-click="true"

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukButtonSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukButtonSettings.generated.cs
@@ -57,6 +57,13 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		public virtual bool Disabled => this.Value<bool>(_publishedValueFallback, "disabled");
 
 		///<summary>
+		/// Prevent double click: Optionally adds data-prevent-double-click="true" attribute to a button.  If a user double clicks a button, this will make the button ignore the second click.
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "10.8.3+e04a41b")]
+		[ImplementPropertyType("preventDoubleClick")]
+		public virtual bool PreventDoubleClick => this.Value<bool>(_publishedValueFallback, "preventDoubleClick");
+
+		///<summary>
 		/// Style of button
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.0.3+a0f3c15")]

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -43,6 +43,22 @@
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
     <GenericProperty>
+      <Key>bc84a6b1-b200-4f67-ab4f-1432093f5dcb</Key>
+      <Name>Prevent double-click</Name>
+      <Alias>preventDoubleClick</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Adds data-prevent-double-click="true". If a user double-clicks the button, the button will ignore the second and subsequent clicks.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>dcd92fb5-669f-4be4-b4c0-efd622117d88</Key>
       <Name>Style of button</Name>
       <Alias>styleOfButton</Alias>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkButton.cshtml
@@ -22,6 +22,7 @@
     if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--inverse"; }
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
     var disabled = Model.Settings.Value<bool>("disabled").ToString().ToLower();
+    var preventDoubleClick = Model.Settings.Value<bool>("preventDoubleClick").ToString().ToLower();
 
-    <govuk-button class="@string.Join(' ', buttonStyle)@cssClasses" type="@buttonType" name="@modelPropertyName" id="@Model.Content.Key" value="@text" aria-disabled="@disabled">@text</govuk-button>
+    <govuk-button class="@string.Join(' ', buttonStyle)@cssClasses" type="@buttonType" name="@modelPropertyName" id="@Model.Content.Key" value="@text" aria-disabled="@disabled" data-prevent-double-click="@preventDoubleClick">@text</govuk-button>
 }

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukbuttonsettings.config
@@ -43,6 +43,22 @@
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
     <GenericProperty>
+      <Key>bc84a6b1-b200-4f67-ab4f-1432093f5dcb</Key>
+      <Name>Prevent double-click</Name>
+      <Alias>preventDoubleClick</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Adds data-prevent-double-click="true". If a user double-clicks the button, the button will ignore the second and subsequent clicks.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
       <Key>dcd92fb5-669f-4be4-b4c0-efd622117d88</Key>
       <Name>Style of button</Name>
       <Alias>styleOfButton</Alias>


### PR DESCRIPTION
If a user double-clicks the button, the button will ignore the second and subsequent clicks. [AB#187292](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/187292)