### PR TITLE
TinyMCE was upgraded with Umbraco. styleselect has changed to styles

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditor.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditor.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInlineAndInverse.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInlineAndInverse.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditor.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditor.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditorInlineAndInverse.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditorInlineAndInverse.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
@@ -10,7 +10,7 @@
   "Blocks": null,
   "Editor": {
     "toolbar": [
-      "styleselect",
+      "styles",
       "bold",
       "italic",
       "bullist",


### PR DESCRIPTION
Without this change the dropdown in rich text editors which allows you to select heading styles is not available.