### PR TITLE
Set all packages to the same alpha version 

### DIFF
--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Title>$(AssemblyName)</Title>
-	<Version>6.0.0</Version>
+	<Version>6.0.0--alpha1</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		    This will help identify breaking changes where the major version should change. -->
     <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,7 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>6.0.0</Version>
+    <Version>6.0.0--alpha1</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->
 	<PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
v6.0.0 of all packages will update to Umbraco v13 and GOV.UK Frontend v5. This is dependent upon GOV.UK Frontend v5 support in govuk-frontend-aspnetcore, which is currently in alpha.

This PR sets all projects in this repo to alpha, even those not directly dependent on govuk-frontend-aspnetcore, so that v6.0.0 of all packages can be released together when it's ready.