### PR TITLE
Prevent unnecessary pipeline runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,8 +22,7 @@ parameters:
     type: boolean
     default: false
 
-trigger:
-  - develop
+trigger: none
 
 pool:
   vmImage: "windows-2022"


### PR DESCRIPTION
Every time we merge a PR it kicks off the build pipeline, but we don't need that build, so remove the trigger that causes it. 