### PR TITLE
net6.0 was hard-coded in MSBuild files

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha1</Version>
+		<Version>6.0.0-alpha2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
@@ -106,23 +106,23 @@
 	<ItemGroup>
 		<Content Include="$(GovUkFrontEndSrcFolder)\govuk\_base.scss" Link="$(MsBuildThisFileDirectory)">
 			<Pack>true</Pack>
-			<PackagePath>contentFiles\any\net6.0\Styles\govuk</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\govuk</PackagePath>
 		</Content>
 		<Content Include="$(GovUkFrontEndSrcFolder)\govuk\helpers\*.scss" Link="$(MsBuildThisFileDirectory)">
 			<Pack>true</Pack>
-			<PackagePath>contentFiles\any\net6.0\Styles\govuk\helpers</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\govuk\helpers</PackagePath>
 		</Content>
 		<Content Include="$(GovUkFrontEndSrcFolder)\govuk\tools\*.scss" Link="$(MsBuildThisFileDirectory)">
 			<Pack>true</Pack>
-			<PackagePath>contentFiles\any\net6.0\Styles\govuk\tools</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\govuk\tools</PackagePath>
 		</Content>
 		<Content Include="$(GovUkFrontEndSrcFolder)\govuk\settings\*.scss" Link="$(MsBuildThisFileDirectory)">
 			<Pack>true</Pack>
-			<PackagePath>contentFiles\any\net6.0\Styles\govuk\settings</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\govuk\settings</PackagePath>
 		</Content>
 		<Content Include="$(GovUkFrontEndSrcFolder)\govuk\vendor\*.scss" Link="$(MsBuildThisFileDirectory)">
 			<Pack>true</Pack>
-			<PackagePath>contentFiles\any\net6.0\Styles\govuk\vendor</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\govuk\vendor</PackagePath>
 		</Content>
 
 		<None Include="..\tpr-nuget.png">

--- a/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
@@ -14,7 +14,7 @@
 		</XmlPeek>
 		<PropertyGroup>
 			<ThePensionsRegulatorGovUkFrontendVersion>@(ThePensionsRegulatorGovUkFrontendVersion)</ThePensionsRegulatorGovUkFrontendVersion>
-			<ThePensionsRegulatorGovUkFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\net6.0\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
+			<ThePensionsRegulatorGovUkFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(ThePensionsRegulatorGovUkFrontendSassFolder)**\*.scss" />

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-		<Version>6.0.0-alpha1</Version>
+		<Version>6.0.0-alpha2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
@@ -74,11 +74,11 @@
 		  <Pack>true</Pack>
 		</Content>
 		<Content Include="Styles\govuk-umbraco-backoffice.css">
-			<PackagePath>contentFiles\any\net6.0\Content\css</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Content\css</PackagePath>
 			<Pack>true</Pack>
 		</Content>
 		<Content Include="Styles\govuk-umbraco-backoffice.css.map">
-			<PackagePath>contentFiles\any\net6.0\Content\css</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Content\css</PackagePath>
 			<Pack>true</Pack>
 		</Content>
 	</ItemGroup>

--- a/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
+++ b/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
@@ -15,7 +15,7 @@
 		<PropertyGroup>
 			<GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbracoVersion)</GovUkFrontendUmbracoVersion>
 			<HasPackageReferenceForGovUkFrontendUmbraco Condition="@(GovUkFrontendUmbracoVersion->Count() )==0">false</HasPackageReferenceForGovUkFrontendUmbraco>
-			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\net6.0\</ContentFilesPath>
+			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</ContentFilesPath>
 		</PropertyGroup>
 		<ItemGroup>
 			<uSyncFilesFromGovUkFrontendUmbraco Include="$(ContentFilesPath)uSync\**" />
@@ -56,14 +56,14 @@
 			<HasPackageReferenceForThePensionsRegulatorGovUkFrontend Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false and @(ThePensionsRegulatorGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForThePensionsRegulatorGovUkFrontend>
 		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\thepensionsregulator.govuk.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = 'net6.0']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
+			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
 			 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false and $(HasPackageReferenceForThePensionsRegulatorGovUkFrontend) == false">
 			<Output TaskParameter="Result" ItemName="ThePensionsRegulatorGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<ThePensionsRegulatorGovUkFrontendVersion Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false">@(ThePensionsRegulatorGovUkFrontendVersion)</ThePensionsRegulatorGovUkFrontendVersion>
-			<ThePensionsRegulatorGovUkFrontendSassFolder Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false">$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\net6.0\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
+			<ThePensionsRegulatorGovUkFrontendSassFolder Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false">$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(ThePensionsRegulatorGovUkFrontendSassFolder)**\*.scss" Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false" />

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>6.0.0-alpha1</Version>
+		<Version>6.0.0-alpha2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
@@ -37,11 +37,11 @@
 		  <Pack>true</Pack>
 		</Content>
 		<Content Include="Styles\govuk-umbraco-backoffice.css">
-			<PackagePath>contentFiles\any\net6.0\Content\css</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Content\css</PackagePath>
 			<Pack>true</Pack>
 		</Content>
 		<Content Include="Styles\govuk-umbraco-backoffice.css.map">
-			<PackagePath>contentFiles\any\net6.0\Content\css</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Content\css</PackagePath>
 			<Pack>true</Pack>
 		</Content>
 	</ItemGroup>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
@@ -42,14 +42,14 @@
 			<HasPackageReferenceForTprGovUkFrontend Condition="@(BaseTprGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForTprGovUkFrontend>
 		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = 'net6.0']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
+			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
 			 Condition="$(HasPackageReferenceForTprGovUkFrontend) == false">
 			<Output TaskParameter="Result" ItemName="BaseTprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<BaseTprGovUkFrontendVersion>@(BaseTprGovUkFrontendVersion)</BaseTprGovUkFrontendVersion>
-			<BaseTprGovUkFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(BaseTprGovUkFrontendVersion)\contentFiles\any\net6.0\Styles\</BaseTprGovUkFrontendSassFolder>
+			<BaseTprGovUkFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(BaseTprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<BaseTprGovUkFrontendSassFiles Include="$(BaseTprGovUkFrontendSassFolder)**\*.scss" />
@@ -74,14 +74,14 @@
 			<HasPackageReferenceForTprFrontend Condition="@(BaseTprFrontendVersion->Count() )==0">false</HasPackageReferenceForTprFrontend>
 		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = 'net6.0']/nu:dependency[@id = 'ThePensionsRegulator.Frontend']/@version"
+			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
 			 Condition="$(HasPackageReferenceForTprFrontend) == false">
 			<Output TaskParameter="Result" ItemName="BaseTprFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<BaseTprFrontendVersion>@(BaseTprFrontendVersion)</BaseTprFrontendVersion>
-			<BaseTprFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(BaseTprFrontendVersion)\contentFiles\any\net6.0\Styles\</BaseTprFrontendSassFolder>
+			<BaseTprFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(BaseTprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprFrontendSassFolder>
 		
 	</PropertyGroup>
 		<ItemGroup>
@@ -107,14 +107,14 @@
 			<HasPackageReferenceForGovUkFrontendUmbraco Condition="@(GovUkFrontendUmbracoVersion->Count() )==0">false</HasPackageReferenceForGovUkFrontendUmbraco>
 		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = 'net6.0']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend.Umbraco']/@version"
+			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend.Umbraco']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
 			 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false">
 			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbracoVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbracoVersion)</GovUkFrontendUmbracoVersion>
-			<GovUkFrontendUmbracoContentFiles>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\net6.0\</GovUkFrontendUmbracoContentFiles>
+			<GovUkFrontendUmbracoContentFiles>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbracoContentFiles>
 		</PropertyGroup>
 		<ItemGroup>
 			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbracoContentFiles)uSync\**" />
@@ -137,7 +137,7 @@
 		     ThePensionsRegulator.GovUk.Frontend.Umbraco so that we can overwrite them with TPR customisations.
 		-->
 		<PropertyGroup>
-			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\contentFiles\any\net6.0\</ContentFilesPath>
+			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</ContentFilesPath>
 		</PropertyGroup>
 		<ItemGroup>
 			<uSyncFilesFromTprFrontendUmbraco Include="$(ContentFilesPath)uSync\**" />

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha1</Version>
+		<Version>6.0.0-alpha2</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
@@ -94,7 +94,7 @@
 		</Content>
 		<Content Include="Styles\_tpr-variables.scss">
 			<Pack>true</Pack>
-			<PackagePath>contentFiles\any\net6.0\Styles\tpr</PackagePath>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\tpr</PackagePath>
 		</Content>
 	</ItemGroup>
 

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
@@ -15,7 +15,7 @@
 		<PropertyGroup>
 			<TprFrontendVersion>@(TprFrontendVersion)</TprFrontendVersion>
 			<HasPackageReferenceForTprFrontend Condition="@(TprFrontendVersion->Count() )==0">false</HasPackageReferenceForTprFrontend>
-			<TprFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontendVersion)\contentFiles\any\net6.0\Styles\</TprFrontendSassFolder>
+			<TprFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<TprFrontendSassFiles Include="$(TprFrontendSassFolder)**\*.scss" />
@@ -48,14 +48,14 @@
 			<HasPackageReferenceForTprGovUkFrontend Condition="$(HasPackageReferenceForTprFrontend) != false and @(TprGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForTprGovUkFrontend>
 		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontendVersion)\thepensionsregulator.frontend.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = 'net6.0']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
+			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
 			 Condition="$(HasPackageReferenceForTprFrontend) != false and $(HasPackageReferenceForTprGovUkFrontend) == false">
 			<Output TaskParameter="Result" ItemName="TprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<TprGovUkFrontendVersion Condition="$(HasPackageReferenceForTprFrontend) != false">@(TprGovUkFrontendVersion)</TprGovUkFrontendVersion>
-			<TprGovUkFrontendSassFolder Condition="$(HasPackageReferenceForTprFrontend) != false">$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(TprGovUkFrontendVersion)\contentFiles\any\net6.0\Styles\</TprGovUkFrontendSassFolder>
+			<TprGovUkFrontendSassFolder Condition="$(HasPackageReferenceForTprFrontend) != false">$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(TprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(TprGovUkFrontendSassFolder)**\*.scss" Condition="$(HasPackageReferenceForTprFrontend) != false" />

--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Title>$(AssemblyName)</Title>
-	<Version>6.0.0-alpha1</Version>
+	<Version>6.0.0-alpha2</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		    This will help identify breaking changes where the major version should change. -->
     <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,7 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>6.0.0-alpha1</Version>
+    <Version>6.0.0-alpha2</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->
 	<PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
Required files that are part of the packages are copied into the package and then onto the consuming application using a path that includes the .NET version moniker. These files weren't getting copied to the consuming application because it needed to be updated from `net6.0` to `net8.0`. Rather than hard-coding this and hitting the same problem with the next .NET upgrade, use a variable that's defined in consumer project files by default.