### PR TITLE
Add z-index attribute back to radio and checkbox inputs

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha2</Version>
+		<Version>6.0.0-alpha3</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-checkboxes.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-checkboxes.scss
@@ -6,3 +6,11 @@
     text-align: left;
     padding-left: 12px;
 }
+
+/* Before upgrading to govuk-frontend-aspnetcore v2.0.0-alpha1 and GOV.UK Frontend v5.1.0 checkbox inputs
+   had a z-index of one, placing them infront of their sibling <input/> tag. This broke automated tests
+   as they could not click on checkbox anymore. Adding this attribute back resolves this.
+*/
+.govuk-checkboxes__input {
+    z-index: 1;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-radios.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-radios.scss
@@ -6,3 +6,11 @@
     text-align: left;
     padding-left: 12px;
 }
+
+/* Before upgrading to govuk-frontend-aspnetcore v2.0.0-alpha1 and GOV.UK Frontend v5.1.0 radio button inputs
+   had a z-index of one, placing them infront of their sibling <input/> tag. This broke automated tests as 
+   they could not click on checkbox anymore. Adding this attribute back resolves this.
+*/
+.govuk-radios__input {
+    z-index: 1;
+}

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-		<Version>6.0.0-alpha2</Version>
+		<Version>6.0.0-alpha3</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>6.0.0-alpha2</Version>
+		<Version>6.0.0-alpha3</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha2</Version>
+		<Version>6.0.0-alpha3</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
Before upgrading to govuk-frontend-aspnetcore v2.0.0-alpha1 and GOV.UK Frontend v5.1.0 radio and checkbox inputs had a z-index of one, placing them in front of their sibling <input/> tag. This broke automated tests as they could not click on checkbox anymore. Adding this attribute back resolves this.