### PR TITLE
Add support for lists of links in the TPR header #295

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukHeadingLevel.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukHeadingLevel.generated.cs
@@ -18,9 +18,15 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.PublishedModels
 {
+	// Mixin Content Type with alias "govukHeadingLevel"
+	/// <summary>Heading level</summary>
+	public partial interface IGovukHeadingLevel : IPublishedElement
+	{
+	}
+
 	/// <summary>Heading level</summary>
 	[PublishedModel("govukHeadingLevel")]
-	public partial class GovukHeadingLevel : PublishedElementModel
+	public partial class GovukHeadingLevel : PublishedElementModel, IGovukHeadingLevel
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/HeaderFooterTpr.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/HeaderFooterTpr.generated.cs
@@ -106,6 +106,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		public virtual global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel AboveContextBarWithoutContext3 => this.Value<global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel>(_publishedValueFallback, "aboveContextBarWithoutContext3");
 
 		///<summary>
+		/// Above header with many links
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("aboveHeaderWithManyLinks")]
+		public virtual global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel AboveHeaderWithManyLinks => this.Value<global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel>(_publishedValueFallback, "aboveHeaderWithManyLinks");
+
+		///<summary>
 		/// Above header with no label
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
@@ -152,5 +160,13 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		[ImplementPropertyType("govukBlocks")]
 		public virtual global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel GovukBlocks => this.Value<global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel>(_publishedValueFallback, "govukBlocks");
+
+		///<summary>
+		/// Many links for header
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("manyLinksForHeader")]
+		public virtual global::Umbraco.Cms.Core.Strings.IHtmlEncodedString ManyLinksForHeader => this.Value<global::Umbraco.Cms.Core.Strings.IHtmlEncodedString>(_publishedValueFallback, "manyLinksForHeader");
 	}
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
@@ -7,8 +7,8 @@
 @inject UmbracoHelper Umbraco
 @inject IConfiguration Configuration 
 @{
-    var home = Umbraco.ContentSingleAtXPath("//home");
-    var settings = Umbraco.ContentSingleAtXPath("//settings");
+    var home = Umbraco.ContentAtRoot().Single(x => x.ContentType.Alias == "home");
+    var settings = Umbraco.ContentAtRoot().Single(x => x.ContentType.Alias == "settings");
     var useTPRstyles = Configuration.GetValue<bool>("TPRStyles");
     var headerLockup = new UmbracoTprHeaderLockupModel(settings!) { ShowHeader = useTPRstyles };
     var footerLockup = new UmbracoTprFooterLockupModel(settings!);

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRHeader.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRHeader.cshtml
@@ -9,8 +9,8 @@
 @inject IConfiguration Configuration
 @{
 	Layout = null;
-    var home = Umbraco.ContentSingleAtXPath("//home");
-    var settings = Umbraco.ContentSingleAtXPath("//settings");
+    var home = Umbraco.ContentAtRoot().Single(x => x.ContentType.Alias == "home");
+    var settings = Umbraco.ContentAtRoot().Single(x => x.ContentType.Alias == "settings");
     var useTPRstyles = Configuration.GetValue<bool>("TPRStyles");
     var skipLink = string.IsNullOrEmpty(settings?.Value<string>("govukSkipLinkText")) ? "Skip to main content" : settings?.Value<string>("govukSkipLinkText");
     var headerLogoAlt = string.IsNullOrEmpty(settings?.Value<string>("tprHeaderLogoAlt")) ? "The Pensions Regulator home page" : settings?.Value<string>("tprHeaderLogoAlt");
@@ -66,6 +66,17 @@
             </div>
             <tpr-header-bar>
                 <tpr-header-bar-logo alt="@headerLogoAlt" href="@(settings?.Value<Link>("tprHeaderLogoHref")?.Url)" />
+            </tpr-header-bar>
+
+            <div class="govuk-width-container govuk-!-margin-top-5">
+                <partial name="GOVUK/BlockList" model="Model.AboveHeaderWithManyLinks" />
+            </div>
+            <tpr-header-bar>
+                <tpr-header-bar-logo alt="@headerLogoAlt" href="@(settings?.Value<Link>("tprHeaderLogoHref")?.Url)" />
+                <tpr-header-bar-label></tpr-header-bar-label>
+                <tpr-header-bar-content allow-html="true">
+                    @Model.ManyLinksForHeader
+                </tpr-header-bar-content>
             </tpr-header-bar>
 
             <div class="govuk-width-container govuk-!-margin-top-5">

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/settings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/settings.config
@@ -17,7 +17,13 @@
       <Value><![CDATA[Alpha]]></Value>
     </govukPhase>
     <govukPhaseBannerText>
-      <Value><![CDATA[<p>This is a new service - your <a href="#" data-anchor="#">feedback</a> will help us to improve it.</p>]]></Value>
+      <Value><![CDATA[{
+  "markup": "<p>This is a new service - your <a href=\"#\" data-anchor=\"#\">feedback</a> will help us to improve it.</p>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
     </govukPhaseBannerText>
     <govukSkipLinkText>
       <Value><![CDATA[Skip to main content]]></Value>
@@ -26,17 +32,40 @@
       <Value><![CDATA[]]></Value>
     </tprBackToTopText>
     <tprContext1>
-      <Value><![CDATA[<p>Example app</p>]]></Value>
+      <Value><![CDATA[{
+  "markup": "<p>Example app</p>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
     </tprContext1>
     <tprContext2>
-      <Value><![CDATA[<p>The thing being displayed or edited in the app</p>]]></Value>
+      <Value><![CDATA[{
+  "markup": "<p>The thing being displayed or edited in the app</p>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
     </tprContext2>
     <tprContext3>
-      <Value><![CDATA[<p>ID: 12345678</p>]]></Value>
+      <Value><![CDATA[{
+  "markup": "<p>ID: 12345678</p>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
     </tprContext3>
     <tprFooterContent>
-      <Value><![CDATA[<p><a href="https://www.example.org">Custom link</a></p>
-<p><a href="https://example.org">Custom link</a></p>]]></Value>
+      <Value><![CDATA[{
+  "markup": "<p><a href=\"https://www.example.org\">Custom link</a></p>\n<p><a href=\"https://example.org\">Custom link</a></p>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
     </tprFooterContent>
     <tprFooterCopyright>
       <Value><![CDATA[{{year}} The Pensions Regulator]]></Value>
@@ -53,8 +82,13 @@
 ]]]></Value>
     </tprFooterLogoHref>
     <tprHeaderContent>
-      <Value><![CDATA[<p><a href="https://www.example.org">Custom link</a></p>
-<p><a href="https://example.org">Custom link</a></p>]]></Value>
+      <Value><![CDATA[{
+  "markup": "<p><a href=\"https://www.example.org\">Custom link</a></p>\n<p><a href=\"https://example.org\">Custom link</a></p>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
     </tprHeaderContent>
     <tprHeaderLabel>
       <Value><![CDATA[Making workplace pensions work]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/the-pensions-regulator-tpr-header-and-footer.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/the-pensions-regulator-tpr-header-and-footer.config
@@ -27,13 +27,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/c9903f3e995b448585d21946800cc8d1",
-      "text": "<h2 class=\"govuk-heading-s\">Context bar with context 2 that wraps</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Context bar with context 2 that wraps</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/d8d0dcbee0424641b3388edba9357b49"
+      "udi": "umb://element/d8d0dcbee0424641b3388edba9357b49",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -52,13 +62,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/1d0599c813234612b45ff028f0a34a12",
-      "text": "<h2 class=\"govuk-heading-s\">Context bar without context 1</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Context bar without context 1</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/5a7b4ad8c82c4d309360d23e4a14253f"
+      "udi": "umb://element/5a7b4ad8c82c4d309360d23e4a14253f",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -77,13 +97,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/3e920ddcef0b4370ac2232d22f9be46f",
-      "text": "<h2 class=\"govuk-heading-s\">Context bar without context 1 or 2</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Context bar without context 1 or 2</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/f4c2a9ff5f364774928183fc1725dcf6"
+      "udi": "umb://element/f4c2a9ff5f364774928183fc1725dcf6",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -102,13 +132,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/b69d93d57eb34e348f45e7674dab40b3",
-      "text": "<h2 class=\"govuk-heading-s\">Context bar without context 1 or 3</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Context bar without context 1 or 3</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/b3162a50fccc4ff883c9e914fb651702"
+      "udi": "umb://element/b3162a50fccc4ff883c9e914fb651702",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -127,13 +167,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/1dbaaa78910348b4b0a0c10ebb50e3a3",
-      "text": "<h2 class=\"govuk-heading-s\">Context bar without context 2</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Context bar without context 2</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/207242db461e4eaf950706ec865d881a"
+      "udi": "umb://element/207242db461e4eaf950706ec865d881a",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -152,13 +202,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/52975d60c96f4f7b9bee411434b21ec5",
-      "text": "<h2 class=\"govuk-heading-s\">Context bar without context 2 or 3</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Context bar without context 2 or 3</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/4c1c64630d814b72a961e6a99bd6273c"
+      "udi": "umb://element/4c1c64630d814b72a961e6a99bd6273c",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -177,17 +237,62 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/e3d965a315714a29b1fa98c56be8bfe8",
-      "text": "<h2 class=\"govuk-heading-s\">Context bar without context 3</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Context bar without context 3</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/7ba33cf07d914153a0c536d352581fc4"
+      "udi": "umb://element/7ba33cf07d914153a0c536d352581fc4",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
     </aboveContextBarWithoutContext3>
+    <aboveHeaderWithManyLinks>
+      <Value><![CDATA[{
+  "layout": {
+    "Umbraco.BlockList": [
+      {
+        "contentUdi": "umb://element/bf16b3e13ba740d8a304d522b34c711e",
+        "settingsUdi": "umb://element/5f72f608fc0d4854a79c50cfecf275b1"
+      }
+    ]
+  },
+  "contentData": [
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "udi": "umb://element/bf16b3e13ba740d8a304d522b34c711e",
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-m govuk-heading-s\">Header bar with many links</h2>\n<p>Links should wrap on small and medium screens.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
+    }
+  ],
+  "settingsData": [
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "udi": "umb://element/5f72f608fc0d4854a79c50cfecf275b1",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
+    }
+  ]
+}]]></Value>
+    </aboveHeaderWithManyLinks>
     <aboveHeaderWithNoLabel>
       <Value><![CDATA[{
   "layout": {
@@ -206,24 +311,37 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/2df922dc42324de1974221184a36bbf8",
-      "text": "<p class=\"govuk-heading-s govuk-body\">The TPR header is designed for TPR use, and is <strong>not</strong> based on the <a href=\"https://design-system.service.gov.uk/components/header/\">header</a> component of the GOV.UK Design System. It typically appears as shown above, where all of its content areas are in use.</p>\n<p class=\"govuk-heading-s govuk-body\">The TPR header is made up of two components, the header bar and the context bar. The header bar has three areas:</p>\n<ul>\n<li>the TPR logo, which is always present</li>\n<li>a label (optional), which is set to the strapline 'Making workplace pensions work' or the name of a bigger service of which the current service is one part </li>\n<li>a space for service-wide links like 'Logout' (optional)</li>\n</ul>\n<p>The context bar also has three areas:</p>\n<ul>\n<li>context 1 has the service name, if the strapline is used. If the header label names a bigger service, context 1 might name the current part of that service or the mode that the service is in. It does not support names that need to wrap.</li>\n<li>context 2 has the name of the thing being displayed or edited</li>\n<li>context 3 has the identifier of the thing being displayed or edited</li>\n</ul>\n<p>The context bar is for context that spans multiple pages. The context for the current page, such as the page heading, does not belong in the context bar.</p>\n<h2 class=\"govuk-heading-s\">Header bar with no label</h2>"
+      "text": {
+        "markup": "<p class=\"govuk-heading-s govuk-body\">The TPR header is designed for TPR use, and is <strong>not</strong> based on the <a href=\"https://design-system.service.gov.uk/components/header/\">header</a> component of the GOV.UK Design System. It typically appears as shown above, where all of its content areas are in use.</p>\n<p class=\"govuk-heading-s govuk-body\">The TPR header is made up of two components, the header bar and the context bar. The header bar has three areas:</p>\n<ul>\n<li>the TPR logo, which is always present</li>\n<li>a label (optional), which is set to the strapline 'Making workplace pensions work' or the name of a bigger service of which the current service is one part </li>\n<li>a space for service-wide links like 'Logout' (optional)</li>\n</ul>\n<p>The context bar also has three areas:</p>\n<ul>\n<li>context 1 has the service name, if the strapline is used. If the header label names a bigger service, context 1 might name the current part of that service or the mode that the service is in. It does not support names that need to wrap.</li>\n<li>context 2 has the name of the thing being displayed or edited</li>\n<li>context 3 has the identifier of the thing being displayed or edited</li>\n</ul>\n<p>The context bar is for context that spans multiple pages. The context for the current page, such as the page heading, does not belong in the context bar.</p>\n<h2 class=\"govuk-heading-s\">Header bar with no label</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     },
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
-      "udi": "umb://element/0dec9ba000604e7bbd2ed6c33b81a345"
+      "udi": "umb://element/0dec9ba000604e7bbd2ed6c33b81a345",
+      "text": ""
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/163ea423870441c2894caf8190dff072"
+      "udi": "umb://element/163ea423870441c2894caf8190dff072",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "6ca199b3-814c-4aa9-b466-fc0533f2b543",
       "udi": "umb://element/5fc4da24ecee40c184989d5d515ea12b",
       "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClasses": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -242,13 +360,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/88ba44f4b6e54412aba3564703f780dc",
-      "text": "<h2 class=\"govuk-heading-s\">Header bar with no label or links</h2>\n<p>It is possible for the logo not to be linked, as demonstrated in the next example.</p>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Header bar with no label or links</h2>\n<p>It is possible for the logo not to be linked, as demonstrated in the next example.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/0e4b6adbe62a4483af5563f0ac81e8bf"
+      "udi": "umb://element/0e4b6adbe62a4483af5563f0ac81e8bf",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -267,13 +395,23 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/5a7e17bcdd614c83a54ff0b270441b9f",
-      "text": "<h2 class=\"govuk-heading-s\">Header bar with no links</h2>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Header bar with no links</h2>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/9c170a0706c5412fb7dc04ba159057d6"
+      "udi": "umb://element/9c170a0706c5412fb7dc04ba159057d6",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -310,7 +448,13 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/8378bb1f22574da297c3876adae466b4",
-      "text": "<h2 class=\"govuk-heading-s\">Footer bar</h2>\n<p>The TPR footer bar is one component with three areas:</p>\n<ul>\n<li>the TPR logo</li>\n<li>links (optional)</li>\n<li>a copyright statement</li>\n</ul>\n<p>It is possible for the logo not to be linked, as demonstrated in the second example.</p>"
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-s\">Footer bar</h2>\n<p>The TPR footer bar is one component with three areas:</p>\n<ul>\n<li>the TPR logo</li>\n<li>links (optional)</li>\n<li>a copyright statement</li>\n</ul>\n<p>It is possible for the logo not to be linked, as demonstrated in the second example.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     }
   ],
   "settingsData": [
@@ -320,11 +464,18 @@
       "columnSize": [
         "full"
       ],
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClasses": "",
+      "cssClassesForRow": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/f9b7081a8844465bba9dfb6ae4e7d607"
+      "udi": "umb://element/f9b7081a8844465bba9dfb6ae4e7d607",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
@@ -351,11 +502,18 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/016494c8a2674f5ca8e1df469b9eb52e",
-      "text": "<p>You have switched off TPR styles in appsettings.json to return to GOV.UK styling, so there is nothing to see on this page.</p>"
+      "text": {
+        "markup": "<p>You have switched off TPR styles in appsettings.json to return to GOV.UK styling, so there is nothing to see on this page.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     },
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
-      "udi": "umb://element/bc7e4f2827ee479184723d99efe0d192"
+      "udi": "umb://element/bc7e4f2827ee479184723d99efe0d192",
+      "text": ""
     },
     {
       "contentTypeKey": "8a1b3437-cdfc-4e4c-8a78-0ebb93d2d772",
@@ -372,14 +530,20 @@
   "settingsData": [
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/6f3684c3ef064b0b98d631ed689b4271"
+      "udi": "umb://element/6f3684c3ef064b0b98d631ed689b4271",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "6ca199b3-814c-4aa9-b466-fc0533f2b543",
       "udi": "umb://element/cd8061c120434ae293db8d27265d5d9e",
       "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClasses": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "fc97d18c-85ca-4ebe-8f22-57268fa7a287",
@@ -387,10 +551,22 @@
       "columnSize": [
         "full"
       ],
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClasses": "",
+      "cssClassesForRow": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>
     </govukBlocks>
+    <manyLinksForHeader>
+      <Value><![CDATA[{
+  "markup": "<ul>\n<li><a href=\"#\">About Us</a></li>\n<li><a href=\"#\">Purpose, Vision, Values &amp; Strategy</a></li>\n<li><a href=\"#\">Strategy and Corporate Performance</a></li>\n<li><a href=\"#\">Catalyst for Change</a></li>\n<li class=\"active\"><a href=\"#\">How to Apply</a></li>\n<li><a href=\"#\">Opportunities</a></li>\n<li><a href=\"#\">Diversity</a></li>\n</ul>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
+    </manyLinksForHeader>
   </Properties>
 </Content>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
@@ -1,97 +1,97 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="d10b177e-98b9-42c3-a7f6-632c885c6bcf" Alias="govukFileUploadSettings" Level="2">
-  <Info>
-    <Name>File upload settings</Name>
-    <Icon>icon-cloud-upload color-black</Icon>
-    <Thumbnail>folder.png</Thumbnail>
-    <Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
-    <AllowAtRoot>False</AllowAtRoot>
-    <IsListView>False</IsListView>
-    <Variations>Nothing</Variations>
-    <IsElement>true</IsElement>
-    <HistoryCleanup>
-      <PreventCleanup>False</PreventCleanup>
-      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
-      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
-    </HistoryCleanup>
-    <Folder>GOV.UK</Folder>
-    <Compositions>
-      <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
-      <Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
-      <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
-      <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
-      <Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
-      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
-      <Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
-    </Compositions>
-    <DefaultTemplate></DefaultTemplate>
-    <AllowedTemplates />
-  </Info>
-  <Structure />
-  <GenericProperties>
-    <GenericProperty>
-      <Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
-      <Name>Allowed file types</Name>
-      <Alias>errorMessageAllowedFileExtensions</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
-      <SortOrder>1</SortOrder>
-      <Tab Alias="errorMessages">Error messages</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-    <GenericProperty>
-      <Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
-      <Name>Maximum file size</Name>
-      <Alias>errorMessageMaxFileSize</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
-      <SortOrder>0</SortOrder>
-      <Tab Alias="errorMessages">Error messages</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-    <GenericProperty>
-      <Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
-      <Name>File types</Name>
-      <Alias>fileTypes</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
-      <SortOrder>7</SortOrder>
-      <Tab Alias="settings">Settings</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-  </GenericProperties>
-  <Tabs>
-    <Tab>
-      <Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
-      <Caption>Settings</Caption>
-      <Alias>settings</Alias>
-      <Type>Group</Type>
-      <SortOrder>0</SortOrder>
-    </Tab>
-    <Tab>
-      <Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
-      <Caption>Error messages</Caption>
-      <Alias>errorMessages</Alias>
-      <Type>Group</Type>
-      <SortOrder>1</SortOrder>
-    </Tab>
-  </Tabs>
+	<Info>
+		<Name>File upload settings</Name>
+		<Icon>icon-cloud-upload color-black</Icon>
+		<Thumbnail>folder.png</Thumbnail>
+		<Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
+		<AllowAtRoot>False</AllowAtRoot>
+		<IsListView>False</IsListView>
+		<Variations>Nothing</Variations>
+		<IsElement>true</IsElement>
+		<HistoryCleanup>
+			<PreventCleanup>False</PreventCleanup>
+			<KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+			<KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+		</HistoryCleanup>
+		<Folder>GOV.UK</Folder>
+		<Compositions>
+			<Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
+			<Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
+			<Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
+			<Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+			<Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
+			<Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
+			<Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
+		</Compositions>
+		<DefaultTemplate></DefaultTemplate>
+		<AllowedTemplates />
+	</Info>
+	<Structure />
+	<GenericProperties>
+		<GenericProperty>
+			<Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
+			<Name>Allowed file types</Name>
+			<Alias>errorMessageAllowedFileExtensions</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
+			<SortOrder>1</SortOrder>
+			<Tab Alias="errorMessages">Error messages</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+		<GenericProperty>
+			<Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
+			<Name>Maximum file size</Name>
+			<Alias>errorMessageMaxFileSize</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
+			<SortOrder>0</SortOrder>
+			<Tab Alias="errorMessages">Error messages</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+		<GenericProperty>
+			<Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
+			<Name>File types</Name>
+			<Alias>fileTypes</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
+			<SortOrder>7</SortOrder>
+			<Tab Alias="settings">Settings</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+	</GenericProperties>
+	<Tabs>
+		<Tab>
+			<Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
+			<Caption>Settings</Caption>
+			<Alias>settings</Alias>
+			<Type>Group</Type>
+			<SortOrder>0</SortOrder>
+		</Tab>
+		<Tab>
+			<Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
+			<Caption>Error messages</Caption>
+			<Alias>errorMessages</Alias>
+			<Type>Group</Type>
+			<SortOrder>1</SortOrder>
+		</Tab>
+	</Tabs>
 </ContentType>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/headerfootertpr.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/headerfootertpr.config
@@ -31,7 +31,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>3</SortOrder>
+      <SortOrder>5</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -47,7 +47,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>5</SortOrder>
+      <SortOrder>7</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -63,7 +63,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>8</SortOrder>
+      <SortOrder>10</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -79,7 +79,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>9</SortOrder>
+      <SortOrder>11</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -95,7 +95,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>6</SortOrder>
+      <SortOrder>8</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -111,7 +111,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>10</SortOrder>
+      <SortOrder>12</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -127,7 +127,23 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>7</SortOrder>
+      <SortOrder>9</SortOrder>
+      <Tab Alias="content">Content</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3ac97213-cba3-4b9e-bc50-408bf81b193e</Key>
+      <Name>Above header with many links</Name>
+      <Alias>aboveHeaderWithManyLinks</Alias>
+      <Definition>6e1529d8-d96a-41a8-a7da-3541996e339c</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -159,7 +175,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>2</SortOrder>
+      <SortOrder>4</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -191,7 +207,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>4</SortOrder>
+      <SortOrder>6</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -207,7 +223,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>11</SortOrder>
+      <SortOrder>13</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -223,7 +239,23 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>12</SortOrder>
+      <SortOrder>14</SortOrder>
+      <Tab Alias="content">Content</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9d65c182-1909-47bc-80af-d659d72d25f1</Key>
+      <Name>Many links for header</Name>
+      <Alias>manyLinksForHeader</Alias>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Tpr.HeaderFooterRichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
@@ -103,8 +103,20 @@ $tpr-header-left-width-xl: 200px;
     margin: 0;
 }
 
+.tpr-header__content > .govuk-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.tpr-header__content > .govuk-list > li {
+    display: inline-block;
+}
+
 @include tpr-header-media-query-m {
-    .tpr-header__content {
+    .tpr-header__content, 
+    .tpr-header__content > .govuk-list {
+        display: flex;
         flex-direction: column;
         text-align: center;
     }
@@ -116,42 +128,46 @@ $tpr-header-left-width-xl: 200px;
     }
 }
 
-.tpr-header__content > a {
+.tpr-header__content a {
     font-weight: $tpr-font-weight-regular;
     line-height: $tpr-header-line-height;
     white-space: nowrap;
 }
 
-.tpr-header__content > a:link,
-.tpr-header__content > a:visited {
+.tpr-header__content a:link,
+.tpr-header__content a:visited {
     color: $tpr-colour-white;
 }
 
-.tpr-header__content > a:focus {
+.tpr-header__content a:focus {
     color: $govuk-focus-text-colour;
 }
 
-.tpr-header__content > a:active {
+.tpr-header__content a:active {
     @include govuk-focused-text;
 }
 
-.tpr-header__content > a {
+.tpr-header__content a {
     margin-right: $govuk-gutter;
 }
-.tpr-header__content > a:last-child {
+.tpr-header__content > a:last-child,
+.tpr-header__content > .govuk-list > li:last-child > a {
     margin-right: 0;
 }
 
 // Links are now stacked to save space, so remove the margin that would knock them off-centre.
 @include tpr-header-media-query-m {
-    .tpr-header__content > a {
+    .tpr-header__content a {
         margin-right: 0;
     }
 }
 
 // Now the links have room to spread out.
 @include tpr-header-media-query-l {
-    .tpr-header__content > a {
+    .tpr-header__content > .govuk-list {
+        display: block;
+    }
+    .tpr-header__content a {
         margin-right: $govuk-gutter;
     }
 }


### PR DESCRIPTION
Allows the use of a list of links in the header, addressing #295, and adds an example in the example app for testing. Appearance is now:

# Small screen

![Small screen](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/21306539-03b2-4f05-97cc-a0ed7bc9b181)

# Medium screen

![Medium screen](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/15d511e4-12d6-49ba-9cfb-9f64d519a22f)

# Large screen

![Large screen](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/assets/1260550/30b02b97-f038-4de3-8dba-38ca739a62ec)


This PR also removes use of `ContentSingleAtXPath` in the example app, which will be obsolete in the next version of Umbraco.