### PR TITLE
Block grid two column layouts were missing settings 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha3</Version>
+		<Version>6.0.0-alpha4</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
@@ -1,97 +1,97 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="d10b177e-98b9-42c3-a7f6-632c885c6bcf" Alias="govukFileUploadSettings" Level="2">
-  <Info>
-    <Name>File upload settings</Name>
-    <Icon>icon-cloud-upload color-black</Icon>
-    <Thumbnail>folder.png</Thumbnail>
-    <Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
-    <AllowAtRoot>False</AllowAtRoot>
-    <IsListView>False</IsListView>
-    <Variations>Nothing</Variations>
-    <IsElement>true</IsElement>
-    <HistoryCleanup>
-      <PreventCleanup>False</PreventCleanup>
-      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
-      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
-    </HistoryCleanup>
-    <Folder>GOV.UK</Folder>
-    <Compositions>
-      <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
-      <Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
-      <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
-      <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
-      <Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
-      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
-      <Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
-    </Compositions>
-    <DefaultTemplate></DefaultTemplate>
-    <AllowedTemplates />
-  </Info>
-  <Structure />
-  <GenericProperties>
-    <GenericProperty>
-      <Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
-      <Name>Allowed file types</Name>
-      <Alias>errorMessageAllowedFileExtensions</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
-      <SortOrder>1</SortOrder>
-      <Tab Alias="errorMessages">Error messages</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-    <GenericProperty>
-      <Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
-      <Name>Maximum file size</Name>
-      <Alias>errorMessageMaxFileSize</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
-      <SortOrder>0</SortOrder>
-      <Tab Alias="errorMessages">Error messages</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-    <GenericProperty>
-      <Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
-      <Name>File types</Name>
-      <Alias>fileTypes</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
-      <SortOrder>7</SortOrder>
-      <Tab Alias="settings">Settings</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-  </GenericProperties>
-  <Tabs>
-    <Tab>
-      <Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
-      <Caption>Settings</Caption>
-      <Alias>settings</Alias>
-      <Type>Group</Type>
-      <SortOrder>0</SortOrder>
-    </Tab>
-    <Tab>
-      <Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
-      <Caption>Error messages</Caption>
-      <Alias>errorMessages</Alias>
-      <Type>Group</Type>
-      <SortOrder>1</SortOrder>
-    </Tab>
-  </Tabs>
+	<Info>
+		<Name>File upload settings</Name>
+		<Icon>icon-cloud-upload color-black</Icon>
+		<Thumbnail>folder.png</Thumbnail>
+		<Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
+		<AllowAtRoot>False</AllowAtRoot>
+		<IsListView>False</IsListView>
+		<Variations>Nothing</Variations>
+		<IsElement>true</IsElement>
+		<HistoryCleanup>
+			<PreventCleanup>False</PreventCleanup>
+			<KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+			<KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+		</HistoryCleanup>
+		<Folder>GOV.UK</Folder>
+		<Compositions>
+			<Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
+			<Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
+			<Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
+			<Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+			<Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
+			<Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
+			<Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
+		</Compositions>
+		<DefaultTemplate></DefaultTemplate>
+		<AllowedTemplates />
+	</Info>
+	<Structure />
+	<GenericProperties>
+		<GenericProperty>
+			<Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
+			<Name>Allowed file types</Name>
+			<Alias>errorMessageAllowedFileExtensions</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
+			<SortOrder>1</SortOrder>
+			<Tab Alias="errorMessages">Error messages</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+		<GenericProperty>
+			<Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
+			<Name>Maximum file size</Name>
+			<Alias>errorMessageMaxFileSize</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
+			<SortOrder>0</SortOrder>
+			<Tab Alias="errorMessages">Error messages</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+		<GenericProperty>
+			<Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
+			<Name>File types</Name>
+			<Alias>fileTypes</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
+			<SortOrder>7</SortOrder>
+			<Tab Alias="settings">Settings</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+	</GenericProperties>
+	<Tabs>
+		<Tab>
+			<Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
+			<Caption>Settings</Caption>
+			<Alias>settings</Alias>
+			<Type>Group</Type>
+			<SortOrder>0</SortOrder>
+		</Tab>
+		<Tab>
+			<Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
+			<Caption>Error messages</Caption>
+			<Alias>errorMessages</Alias>
+			<Type>Group</Type>
+			<SortOrder>1</SortOrder>
+		</Tab>
+	</Tabs>
 </ContentType>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgridtwocolumnlayoutsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukgridtwocolumnlayoutsettings.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ContentType Key="53edb934-ee79-4ff0-b23a-84b91e9fef7a" Alias="govukTwoColumnLayoutSettings" Level="2">
+<ContentType Key="53edb934-ee79-4ff0-b23a-84b91e9fef7a" Alias="govukGridTwoColumnLayoutSettings" Level="2">
   <Info>
     <Name>Two column layout settings</Name>
     <Icon>icon-grid color-black</Icon>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKBlockGrid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKBlockGrid.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "BlockGroups": [
     {
       "key": "fe4459ab-dada-4c2f-97f2-1b70aee27310",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKFieldHelpBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKFieldHelpBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKFieldsetBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKFieldsetBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKGridRowBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKGridRowBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKNoFormsBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKNoFormsBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/RichtextEditor.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/RichtextEditor.config
@@ -6,12 +6,12 @@
     <DatabaseType>Ntext</DatabaseType>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
   "Editor": null,
-  "HideLabel": false,
-  "IgnoreUserStartNodes": false,
-  "MediaParentId": null,
+  "Blocks": null,
+  "UseLiveEditing": false,
   "OverlaySize": null,
-  "UseLiveEditing": false
+  "HideLabel": false,
+  "MediaParentId": null,
+  "IgnoreUserStartNodes": false
 }]]></Config>
 </DataType>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRBlockGrid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRBlockGrid.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>TPR</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "BlockGroups": [
     {
       "key": "fe4459ab-dada-4c2f-97f2-1b70aee27310",
@@ -651,9 +650,30 @@
     },
     {
       "allowAtRoot": true,
-      "allowInAreas": true,
+      "allowInAreas": false,
       "areaGridColumns": null,
-      "areas": [],
+      "areas": [
+        {
+          "alias": "one",
+          "columnSpan": 6,
+          "createLabel": null,
+          "key": "8a7ba895-ae96-4928-8a2e-4fae19cf400e",
+          "maxAllowed": null,
+          "minAllowed": 0,
+          "rowSpan": 1,
+          "specifiedAllowance": []
+        },
+        {
+          "alias": "two",
+          "columnSpan": 6,
+          "createLabel": null,
+          "key": "603e3c96-3014-41ee-9680-820158967fcc",
+          "maxAllowed": null,
+          "minAllowed": 0,
+          "rowSpan": 1,
+          "specifiedAllowance": []
+        }
+      ],
       "backgroundColor": null,
       "columnSpanOptions": [],
       "contentElementTypeKey": "3fa201d9-0d89-458f-b6dc-f5fb6fc8e10a",
@@ -719,7 +739,7 @@
       "areas": [
         {
           "alias": "one",
-          "columnSpan": 6,
+          "columnSpan": 9,
           "createLabel": null,
           "key": "febd0048-c17c-4ca8-aa5e-2d1b27a043a9",
           "maxAllowed": null,
@@ -729,7 +749,7 @@
         },
         {
           "alias": "two",
-          "columnSpan": 6,
+          "columnSpan": 3,
           "createLabel": null,
           "key": "a74d0e11-1a86-4daa-853c-ecd195acd3eb",
           "maxAllowed": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>TPR</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRNoFormsBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRNoFormsBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>TPR</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Domains/https-localhost-44350-de_de.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Domains/https-localhost-44350-de_de.config
@@ -4,6 +4,6 @@
     <IsWildcard>false</IsWildcard>
     <Language>de</Language>
     <Root Key="5e682cbe-b867-491a-955f-3382446d5663">/Home</Root>
-    <SortOrder>2</SortOrder>
+    <SortOrder>0</SortOrder>
   </Info>
 </Domain>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/usync.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/usync.config
@@ -1,2 +1,2 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<uSync version="13.0.1.0" format="10.7.0" />
+<uSync version="13.1.2.0" format="10.7.0" />

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -126,6 +126,9 @@
 		<Content Update="uSync\v9\ContentTypes\govukgridthreequartersonequarter.config">
 		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</Content>
+		<Content Update="uSync\v9\ContentTypes\govukgridtwocolumnlayoutsettings.config">
+		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</Content>
 		<Content Update="uSync\v9\ContentTypes\govukgridtwoequalcolumns.config">
 		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</Content>

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-		<Version>6.0.0-alpha3</Version>
+		<Version>6.0.0-alpha4</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridtwocolumnlayoutsettings.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/ContentTypes/govukgridtwocolumnlayoutsettings.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="53edb934-ee79-4ff0-b23a-84b91e9fef7a" Alias="govukGridTwoColumnLayoutSettings" Level="2">
+  <Info>
+    <Name>Two column layout settings</Name>
+    <Icon>icon-grid color-black</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Settings for a two column layout using the GOV.UK grid.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <IsListView>False</IsListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>GOV.UK</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>dd8d7d52-04c7-48df-89f0-de4693b2b14a</Key>
+      <Name>Stack columns</Name>
+      <Alias>stackColumns</Alias>
+      <Definition>e5ba1961-c541-453b-82bc-35c792b05710</Definition>
+      <Type>Umbraco.RadioButtonList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="grid">Grid</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>d481ade7-0dea-4de1-83a4-de92d2a6b204</Key>
+      <Caption>Grid</Caption>
+      <Alias>grid</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKBlockGrid.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKBlockGrid.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "BlockGroups": [
     {
       "key": "fe4459ab-dada-4c2f-97f2-1b70aee27310",

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKBlockList.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKFieldHelpBlockList.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKFieldHelpBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKFieldsetBlockList.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKFieldsetBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKGridColumnBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKGridRowBlockList.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKGridRowBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKNoFormsBlockList.config
+++ b/GovUk.Frontend.Umbraco/uSync/v9/DataTypes/GOVUKNoFormsBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>GOV.UK</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>6.0.0-alpha3</Version>
+		<Version>6.0.0-alpha4</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRBlockGrid.config
+++ b/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRBlockGrid.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>TPR</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "BlockGroups": [
     {
       "key": "fe4459ab-dada-4c2f-97f2-1b70aee27310",
@@ -651,9 +650,30 @@
     },
     {
       "allowAtRoot": true,
-      "allowInAreas": true,
+      "allowInAreas": false,
       "areaGridColumns": null,
-      "areas": [],
+      "areas": [
+        {
+          "alias": "one",
+          "columnSpan": 6,
+          "createLabel": null,
+          "key": "8a7ba895-ae96-4928-8a2e-4fae19cf400e",
+          "maxAllowed": null,
+          "minAllowed": 0,
+          "rowSpan": 1,
+          "specifiedAllowance": []
+        },
+        {
+          "alias": "two",
+          "columnSpan": 6,
+          "createLabel": null,
+          "key": "603e3c96-3014-41ee-9680-820158967fcc",
+          "maxAllowed": null,
+          "minAllowed": 0,
+          "rowSpan": 1,
+          "specifiedAllowance": []
+        }
+      ],
       "backgroundColor": null,
       "columnSpanOptions": [],
       "contentElementTypeKey": "3fa201d9-0d89-458f-b6dc-f5fb6fc8e10a",
@@ -719,7 +739,7 @@
       "areas": [
         {
           "alias": "one",
-          "columnSpan": 6,
+          "columnSpan": 9,
           "createLabel": null,
           "key": "febd0048-c17c-4ca8-aa5e-2d1b27a043a9",
           "maxAllowed": null,
@@ -729,7 +749,7 @@
         },
         {
           "alias": "two",
-          "columnSpan": 6,
+          "columnSpan": 3,
           "createLabel": null,
           "key": "a74d0e11-1a86-4daa-853c-ecd195acd3eb",
           "maxAllowed": null,

--- a/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRBlockList.config
+++ b/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>TPR</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRNoFormsBlockList.config
+++ b/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRNoFormsBlockList.config
@@ -6,8 +6,7 @@
     <DatabaseType>Ntext</DatabaseType>
     <Folder>TPR</Folder>
   </Info>
-  <Config>
-		  <![CDATA[{
+  <Config><![CDATA[{
   "Blocks": [
     {
       "backgroundColor": null,

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha3</Version>
+		<Version>6.0.0-alpha4</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Title>$(AssemblyName)</Title>
-	<Version>6.0.0-alpha3</Version>
+	<Version>6.0.0-alpha4</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		    This will help identify breaking changes where the major version should change. -->
     <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,7 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>6.0.0-alpha3</Version>
+    <Version>6.0.0-alpha4</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->
 	<PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
The key changes are that some settings were missing on the 'TPR block grid' data type, and the uSync configuration for 'Two column layout settings' was missing from the NuGet package. Fixes #294.

This PR also contains some auto-formatting of uSync data due to a previous upgrade of uSync, and a version bump so that this change can be released.