### PR TITLE
Support many header links in Umbraco

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukGridTwoColumnLayoutSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukGridTwoColumnLayoutSettings.generated.cs
@@ -19,13 +19,13 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Web.Common.PublishedModels
 {
 	/// <summary>Two column layout settings</summary>
-	[PublishedModel("govukTwoColumnLayoutSettings")]
-	public partial class GovukTwoColumnLayoutSettings : PublishedElementModel
+	[PublishedModel("govukGridTwoColumnLayoutSettings")]
+	public partial class GovukGridTwoColumnLayoutSettings : PublishedElementModel
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
-		public new const string ModelTypeAlias = "govukTwoColumnLayoutSettings";
+		public new const string ModelTypeAlias = "govukGridTwoColumnLayoutSettings";
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
 		public new const PublishedItemType ModelItemType = PublishedItemType.Content;
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
@@ -34,14 +34,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 			=> PublishedModelUtility.GetModelContentType(publishedSnapshotAccessor, ModelItemType, ModelTypeAlias);
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
 		[return: global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		public static IPublishedPropertyType GetModelPropertyType<TValue>(IPublishedSnapshotAccessor publishedSnapshotAccessor, Expression<Func<GovukTwoColumnLayoutSettings, TValue>> selector)
+		public static IPublishedPropertyType GetModelPropertyType<TValue>(IPublishedSnapshotAccessor publishedSnapshotAccessor, Expression<Func<GovukGridTwoColumnLayoutSettings, TValue>> selector)
 			=> PublishedModelUtility.GetModelPropertyType(GetModelContentType(publishedSnapshotAccessor), selector);
 #pragma warning restore 0109
 
 		private IPublishedValueFallback _publishedValueFallback;
 
 		// ctor
-		public GovukTwoColumnLayoutSettings(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
+		public GovukGridTwoColumnLayoutSettings(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
 			: base(content, publishedValueFallback)
 		{
 			_publishedValueFallback = publishedValueFallback;

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukHeadingLevel.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukHeadingLevel.generated.cs
@@ -18,15 +18,9 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.PublishedModels
 {
-	// Mixin Content Type with alias "govukHeadingLevel"
-	/// <summary>Heading level</summary>
-	public partial interface IGovukHeadingLevel : IPublishedElement
-	{
-	}
-
 	/// <summary>Heading level</summary>
 	[PublishedModel("govukHeadingLevel")]
-	public partial class GovukHeadingLevel : PublishedElementModel, IGovukHeadingLevel
+	public partial class GovukHeadingLevel : PublishedElementModel
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/HeaderFooterTpr.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/HeaderFooterTpr.generated.cs
@@ -106,6 +106,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		public virtual global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel AboveContextBarWithoutContext3 => this.Value<global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel>(_publishedValueFallback, "aboveContextBarWithoutContext3");
 
 		///<summary>
+		/// Above header with list of links
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("aboveHeaderWithListOfLinks")]
+		public virtual global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel AboveHeaderWithListOfLinks => this.Value<global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel>(_publishedValueFallback, "aboveHeaderWithListOfLinks");
+
+		///<summary>
 		/// Above header with many links
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
@@ -160,6 +168,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		[ImplementPropertyType("govukBlocks")]
 		public virtual global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel GovukBlocks => this.Value<global::ThePensionsRegulator.Umbraco.Blocks.OverridableBlockListModel>(_publishedValueFallback, "govukBlocks");
+
+		///<summary>
+		/// List of links for header
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.2.0+7dff3a3")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("listOfLinksForHeader")]
+		public virtual global::Umbraco.Cms.Core.Strings.IHtmlEncodedString ListOfLinksForHeader => this.Value<global::Umbraco.Cms.Core.Strings.IHtmlEncodedString>(_publishedValueFallback, "listOfLinksForHeader");
 
 		///<summary>
 		/// Many links for header

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRHeader.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRHeader.cshtml
@@ -80,6 +80,17 @@
             </tpr-header-bar>
 
             <div class="govuk-width-container govuk-!-margin-top-5">
+                <partial name="GOVUK/BlockList" model="Model.AboveHeaderWithListOfLinks" />
+            </div>
+            <tpr-header-bar>
+                <tpr-header-bar-logo alt="@headerLogoAlt" href="@(settings?.Value<Link>("tprHeaderLogoHref")?.Url)" />
+                <tpr-header-bar-label></tpr-header-bar-label>
+                <tpr-header-bar-content allow-html="true">
+                    @Model.ListOfLinksForHeader
+                </tpr-header-bar-content>
+            </tpr-header-bar>
+
+            <div class="govuk-width-container govuk-!-margin-top-5">
                 <partial name="GOVUK/BlockList" model="Model.AboveHeaderWithNoLabelOrLinks" />
             </div>
             <tpr-header-bar>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/settings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/settings.config
@@ -83,7 +83,7 @@
     </tprFooterLogoHref>
     <tprHeaderContent>
       <Value><![CDATA[{
-  "markup": "<p><a href=\"https://www.example.org\">Custom link</a></p>\n<p><a href=\"https://example.org\">Custom link</a></p>",
+  "markup": "<p><a href=\"https://www.example.org\">Custom link</a></p>\n<p><a href=\"https://example.org\">Custom link</a><a href=\"#\"></a></p>",
   "blocks": {
     "contentData": [],
     "settingsData": []

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/the-pensions-regulator-tpr-header-and-footer.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/the-pensions-regulator-tpr-header-and-footer.config
@@ -258,6 +258,41 @@
   ]
 }]]></Value>
     </aboveContextBarWithoutContext3>
+    <aboveHeaderWithListOfLinks>
+      <Value><![CDATA[{
+  "layout": {
+    "Umbraco.BlockList": [
+      {
+        "contentUdi": "umb://element/6e3fe7217ac84c46b8241b1745f21d4d",
+        "settingsUdi": "umb://element/0d7871b3d3a74c33a7c14992a947bed9"
+      }
+    ]
+  },
+  "contentData": [
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "udi": "umb://element/6e3fe7217ac84c46b8241b1745f21d4d",
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-m govuk-heading-s\">Header bar with many links (as a list)</h2>\n<p>Links should wrap on small and medium screens.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
+    }
+  ],
+  "settingsData": [
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "udi": "umb://element/0d7871b3d3a74c33a7c14992a947bed9",
+      "cssClassesForRow": "",
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
+    }
+  ]
+}]]></Value>
+    </aboveHeaderWithListOfLinks>
     <aboveHeaderWithManyLinks>
       <Value><![CDATA[{
   "layout": {
@@ -559,9 +594,18 @@
   ]
 }]]></Value>
     </govukBlocks>
-    <manyLinksForHeader>
+    <listOfLinksForHeader>
       <Value><![CDATA[{
   "markup": "<ul>\n<li><a href=\"#\">About Us</a></li>\n<li><a href=\"#\">Purpose, Vision, Values &amp; Strategy</a></li>\n<li><a href=\"#\">Strategy and Corporate Performance</a></li>\n<li><a href=\"#\">Catalyst for Change</a></li>\n<li class=\"active\"><a href=\"#\">How to Apply</a></li>\n<li><a href=\"#\">Opportunities</a></li>\n<li><a href=\"#\">Diversity</a></li>\n</ul>",
+  "blocks": {
+    "contentData": [],
+    "settingsData": []
+  }
+}]]></Value>
+    </listOfLinksForHeader>
+    <manyLinksForHeader>
+      <Value><![CDATA[{
+  "markup": "<p><a href=\"#\">About Us</a></p>\n<p><a href=\"#\">Purpose, Vision, Values &amp; Strategy</a></p>\n<p><a href=\"#\">Strategy and Corporate Performance</a></p>\n<p><a href=\"#\">Catalyst for Change</a></p>\n<p><a href=\"#\">How to Apply</a></p>\n<p><a href=\"#\">Opportunities</a></p>\n<p><a href=\"#\">Diversity</a></p>",
   "blocks": {
     "contentData": [],
     "settingsData": []

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
@@ -1,97 +1,97 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="d10b177e-98b9-42c3-a7f6-632c885c6bcf" Alias="govukFileUploadSettings" Level="2">
-  <Info>
-    <Name>File upload settings</Name>
-    <Icon>icon-cloud-upload color-black</Icon>
-    <Thumbnail>folder.png</Thumbnail>
-    <Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
-    <AllowAtRoot>False</AllowAtRoot>
-    <IsListView>False</IsListView>
-    <Variations>Nothing</Variations>
-    <IsElement>true</IsElement>
-    <HistoryCleanup>
-      <PreventCleanup>False</PreventCleanup>
-      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
-      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
-    </HistoryCleanup>
-    <Folder>GOV.UK</Folder>
-    <Compositions>
-      <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
-      <Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
-      <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
-      <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
-      <Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
-      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
-      <Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
-    </Compositions>
-    <DefaultTemplate></DefaultTemplate>
-    <AllowedTemplates />
-  </Info>
-  <Structure />
-  <GenericProperties>
-    <GenericProperty>
-      <Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
-      <Name>Allowed file types</Name>
-      <Alias>errorMessageAllowedFileExtensions</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
-      <SortOrder>1</SortOrder>
-      <Tab Alias="errorMessages">Error messages</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-    <GenericProperty>
-      <Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
-      <Name>Maximum file size</Name>
-      <Alias>errorMessageMaxFileSize</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
-      <SortOrder>0</SortOrder>
-      <Tab Alias="errorMessages">Error messages</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-    <GenericProperty>
-      <Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
-      <Name>File types</Name>
-      <Alias>fileTypes</Alias>
-      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-      <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
-      <SortOrder>7</SortOrder>
-      <Tab Alias="settings">Settings</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-  </GenericProperties>
-  <Tabs>
-    <Tab>
-      <Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
-      <Caption>Settings</Caption>
-      <Alias>settings</Alias>
-      <Type>Group</Type>
-      <SortOrder>0</SortOrder>
-    </Tab>
-    <Tab>
-      <Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
-      <Caption>Error messages</Caption>
-      <Alias>errorMessages</Alias>
-      <Type>Group</Type>
-      <SortOrder>1</SortOrder>
-    </Tab>
-  </Tabs>
+	<Info>
+		<Name>File upload settings</Name>
+		<Icon>icon-cloud-upload color-black</Icon>
+		<Thumbnail>folder.png</Thumbnail>
+		<Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
+		<AllowAtRoot>False</AllowAtRoot>
+		<IsListView>False</IsListView>
+		<Variations>Nothing</Variations>
+		<IsElement>true</IsElement>
+		<HistoryCleanup>
+			<PreventCleanup>False</PreventCleanup>
+			<KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+			<KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+		</HistoryCleanup>
+		<Folder>GOV.UK</Folder>
+		<Compositions>
+			<Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
+			<Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
+			<Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
+			<Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+			<Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
+			<Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
+			<Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
+		</Compositions>
+		<DefaultTemplate></DefaultTemplate>
+		<AllowedTemplates />
+	</Info>
+	<Structure />
+	<GenericProperties>
+		<GenericProperty>
+			<Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
+			<Name>Allowed file types</Name>
+			<Alias>errorMessageAllowedFileExtensions</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
+			<SortOrder>1</SortOrder>
+			<Tab Alias="errorMessages">Error messages</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+		<GenericProperty>
+			<Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
+			<Name>Maximum file size</Name>
+			<Alias>errorMessageMaxFileSize</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
+			<SortOrder>0</SortOrder>
+			<Tab Alias="errorMessages">Error messages</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+		<GenericProperty>
+			<Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
+			<Name>File types</Name>
+			<Alias>fileTypes</Alias>
+			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+			<Type>Umbraco.TextBox</Type>
+			<Mandatory>false</Mandatory>
+			<Validation></Validation>
+			<Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
+			<SortOrder>7</SortOrder>
+			<Tab Alias="settings">Settings</Tab>
+			<Variations>Nothing</Variations>
+			<MandatoryMessage></MandatoryMessage>
+			<ValidationRegExpMessage></ValidationRegExpMessage>
+			<LabelOnTop>false</LabelOnTop>
+		</GenericProperty>
+	</GenericProperties>
+	<Tabs>
+		<Tab>
+			<Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
+			<Caption>Settings</Caption>
+			<Alias>settings</Alias>
+			<Type>Group</Type>
+			<SortOrder>0</SortOrder>
+		</Tab>
+		<Tab>
+			<Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
+			<Caption>Error messages</Caption>
+			<Alias>errorMessages</Alias>
+			<Type>Group</Type>
+			<SortOrder>1</SortOrder>
+		</Tab>
+	</Tabs>
 </ContentType>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukfileuploadsettings.config
@@ -1,97 +1,97 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="d10b177e-98b9-42c3-a7f6-632c885c6bcf" Alias="govukFileUploadSettings" Level="2">
-	<Info>
-		<Name>File upload settings</Name>
-		<Icon>icon-cloud-upload color-black</Icon>
-		<Thumbnail>folder.png</Thumbnail>
-		<Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
-		<AllowAtRoot>False</AllowAtRoot>
-		<IsListView>False</IsListView>
-		<Variations>Nothing</Variations>
-		<IsElement>true</IsElement>
-		<HistoryCleanup>
-			<PreventCleanup>False</PreventCleanup>
-			<KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
-			<KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
-		</HistoryCleanup>
-		<Folder>GOV.UK</Folder>
-		<Compositions>
-			<Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
-			<Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
-			<Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
-			<Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
-			<Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
-			<Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
-			<Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
-		</Compositions>
-		<DefaultTemplate></DefaultTemplate>
-		<AllowedTemplates />
-	</Info>
-	<Structure />
-	<GenericProperties>
-		<GenericProperty>
-			<Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
-			<Name>Allowed file types</Name>
-			<Alias>errorMessageAllowedFileExtensions</Alias>
-			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-			<Type>Umbraco.TextBox</Type>
-			<Mandatory>false</Mandatory>
-			<Validation></Validation>
-			<Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
-			<SortOrder>1</SortOrder>
-			<Tab Alias="errorMessages">Error messages</Tab>
-			<Variations>Nothing</Variations>
-			<MandatoryMessage></MandatoryMessage>
-			<ValidationRegExpMessage></ValidationRegExpMessage>
-			<LabelOnTop>false</LabelOnTop>
-		</GenericProperty>
-		<GenericProperty>
-			<Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
-			<Name>Maximum file size</Name>
-			<Alias>errorMessageMaxFileSize</Alias>
-			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-			<Type>Umbraco.TextBox</Type>
-			<Mandatory>false</Mandatory>
-			<Validation></Validation>
-			<Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
-			<SortOrder>0</SortOrder>
-			<Tab Alias="errorMessages">Error messages</Tab>
-			<Variations>Nothing</Variations>
-			<MandatoryMessage></MandatoryMessage>
-			<ValidationRegExpMessage></ValidationRegExpMessage>
-			<LabelOnTop>false</LabelOnTop>
-		</GenericProperty>
-		<GenericProperty>
-			<Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
-			<Name>File types</Name>
-			<Alias>fileTypes</Alias>
-			<Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
-			<Type>Umbraco.TextBox</Type>
-			<Mandatory>false</Mandatory>
-			<Validation></Validation>
-			<Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
-			<SortOrder>7</SortOrder>
-			<Tab Alias="settings">Settings</Tab>
-			<Variations>Nothing</Variations>
-			<MandatoryMessage></MandatoryMessage>
-			<ValidationRegExpMessage></ValidationRegExpMessage>
-			<LabelOnTop>false</LabelOnTop>
-		</GenericProperty>
-	</GenericProperties>
-	<Tabs>
-		<Tab>
-			<Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
-			<Caption>Settings</Caption>
-			<Alias>settings</Alias>
-			<Type>Group</Type>
-			<SortOrder>0</SortOrder>
-		</Tab>
-		<Tab>
-			<Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
-			<Caption>Error messages</Caption>
-			<Alias>errorMessages</Alias>
-			<Type>Group</Type>
-			<SortOrder>1</SortOrder>
-		</Tab>
-	</Tabs>
+  <Info>
+    <Name>File upload settings</Name>
+    <Icon>icon-cloud-upload color-black</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Settings for a file upload component. Ask users to upload something only if it’s critical to the delivery of your service.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <IsListView>False</IsListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>GOV.UK</Folder>
+    <Compositions>
+      <Composition Key="bf69e8d6-97a6-4b50-bec7-c5993e120339">govukCssClasses</Composition>
+      <Composition Key="37cc75ea-be5c-4107-b9b8-0ef34f4b7c5e">govukErrorMessagePrefix</Composition>
+      <Composition Key="d508995b-a958-4273-8ab3-50735220a1b2">govukGrid</Composition>
+      <Composition Key="d7016563-0b6f-4c3a-b75d-b0bbe66419fd">govukGridColumnClasses</Composition>
+      <Composition Key="2bc3c434-f3ff-495d-b360-1a005245602e">govukLabelIsPageHeading</Composition>
+      <Composition Key="23e1a03d-dc42-4318-9e17-d458dde2dba6">govukModelProperty</Composition>
+      <Composition Key="f2365c7e-08c3-4ef9-abbc-e337e34de272">govukValidationRequired</Composition>
+    </Compositions>
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>cac445e1-9d87-452e-94de-a70e43ff09ff</Key>
+      <Name>Allowed file types</Name>
+      <Alias>errorMessageAllowedFileExtensions</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Sets the message displayed if the file uploaded is not one of the supported types/extensions]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="errorMessages">Error messages</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b5083899-5c0c-440f-8295-4983bdeaaa5d</Key>
+      <Name>Maximum file size</Name>
+      <Alias>errorMessageMaxFileSize</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Sets the message displayed if the file uploaded exceeds the maximum size]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="errorMessages">Error messages</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>23e97cbd-102b-4526-a2e9-0a3b67ba0985</Key>
+      <Name>File types</Name>
+      <Alias>fileTypes</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[A comma-separated list of accepted file extensions or media types. See [the accept attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>b282eda2-24e8-4a95-8796-73238b272d53</Key>
+      <Caption>Settings</Caption>
+      <Alias>settings</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>d2bbeb2c-8bc0-4bf4-942c-88f5d54208bb</Key>
+      <Caption>Error messages</Caption>
+      <Alias>errorMessages</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
 </ContentType>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/headerfootertpr.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/headerfootertpr.config
@@ -31,7 +31,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>5</SortOrder>
+      <SortOrder>7</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -47,7 +47,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>7</SortOrder>
+      <SortOrder>9</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -63,7 +63,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>10</SortOrder>
+      <SortOrder>12</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -79,7 +79,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>11</SortOrder>
+      <SortOrder>13</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -95,7 +95,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>8</SortOrder>
+      <SortOrder>10</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -111,7 +111,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>12</SortOrder>
+      <SortOrder>14</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -127,7 +127,23 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>9</SortOrder>
+      <SortOrder>11</SortOrder>
+      <Tab Alias="content">Content</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>83677444-5c4d-42f3-9317-7981afe2d2a4</Key>
+      <Name>Above header with list of links</Name>
+      <Alias>aboveHeaderWithListOfLinks</Alias>
+      <Definition>6e1529d8-d96a-41a8-a7da-3541996e339c</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>4</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -175,7 +191,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>4</SortOrder>
+      <SortOrder>6</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -207,7 +223,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>6</SortOrder>
+      <SortOrder>8</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -223,7 +239,7 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>13</SortOrder>
+      <SortOrder>15</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>
@@ -239,7 +255,23 @@
       <Mandatory>false</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
-      <SortOrder>14</SortOrder>
+      <SortOrder>16</SortOrder>
+      <Tab Alias="content">Content</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>01abb7e8-7671-4191-af1f-4c726f619eca</Key>
+      <Name>List of links for header</Name>
+      <Alias>listOfLinksForHeader</Alias>
+      <Definition>48f89b23-2121-4f38-acca-02770993ca35</Definition>
+      <Type>Tpr.HeaderFooterRichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>5</SortOrder>
       <Tab Alias="content">Content</Tab>
       <Variations>Nothing</Variations>
       <MandatoryMessage></MandatoryMessage>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRRichTextEditorHeaderAndFooter.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRRichTextEditorHeaderAndFooter.config
@@ -7,9 +7,10 @@
     <Folder>TPR</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
+      "bullist",
       "link",
       "unlink"
     ],

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>6.0.0-alpha4</Version>
+		<Version>6.0.0-alpha5</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRRichTextEditorHeaderAndFooter.config
+++ b/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/DataTypes/TPRRichTextEditorHeaderAndFooter.config
@@ -7,9 +7,10 @@
     <Folder>TPR</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
+      "bullist",
       "link",
       "unlink"
     ],

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
@@ -96,10 +96,14 @@ $tpr-header-left-width-xl: 200px;
         line-height: $tpr-header-line-height;
     }
 }
+@include tpr-header-media-query-l {
+    .tpr-header__label {
+        min-width: 10em
+    }
+}
 
 .tpr-header__content {
     color: $tpr-colour-white;
-    display: flex;
     margin: 0;
 }
 
@@ -111,10 +115,11 @@ $tpr-header-left-width-xl: 200px;
 
 .tpr-header__content > .govuk-list > li {
     display: inline-block;
+    margin-bottom: 0;
 }
 
 @include tpr-header-media-query-m {
-    .tpr-header__content, 
+    .tpr-header__content,
     .tpr-header__content > .govuk-list {
         display: flex;
         flex-direction: column;
@@ -150,28 +155,28 @@ $tpr-header-left-width-xl: 200px;
 .tpr-header__content a {
     margin-right: $govuk-gutter;
 }
+
 .tpr-header__content > a:last-child,
 .tpr-header__content > .govuk-list > li:last-child > a {
     margin-right: 0;
 }
-
 // Links are now stacked to save space, so remove the margin that would knock them off-centre.
 @include tpr-header-media-query-m {
     .tpr-header__content a {
         margin-right: 0;
     }
 }
-
 // Now the links have room to spread out.
 @include tpr-header-media-query-l {
+    .tpr-header__content,
     .tpr-header__content > .govuk-list {
         display: block;
     }
+
     .tpr-header__content a {
         margin-right: $govuk-gutter;
     }
 }
-
 // For .tpr-context stack everything by default.
 .tpr-context .govuk-body {
     font-weight: $tpr-font-weight-regular;
@@ -182,14 +187,14 @@ $tpr-header-left-width-xl: 200px;
 .tpr-context .govuk-link:link, .tpr-context .govuk-link:visited {
     color: $tpr-colour-white;
 }
+
 .tpr-context .govuk-link:focus {
     color: $govuk-focus-text-colour;
     box-shadow: 0 -2px $govuk-focus-colour, 0 4px $tpr-colour-blue-marguerite;
 }
-
 // Required when the text inside .tpr-context__context-2 is short.
 .tpr-context__container {
-    width: 100%; 
+    width: 100%;
 }
 
 .tpr-context__context-1 {
@@ -201,7 +206,6 @@ $tpr-header-left-width-xl: 200px;
     background: $tpr-colour-violet;
     white-space: nowrap;
 }
-
 // Allow more space for .tpr-context__context-2 as the viewport width grows.
 .tpr-context__context-2 {
     color: $tpr-colour-white;
@@ -210,15 +214,14 @@ $tpr-header-left-width-xl: 200px;
     align-items: center;
     padding: $tpr-header-vertical-space $govuk-gutter-half;
 }
-
 // Hide context 2 on small viewports if empty
 .tpr-context__container--context-2-empty .tpr-context__context-2 {
     padding: 0;
 }
+
 .tpr-context__container--context-2-empty .tpr-context__context-3-inner {
     border-top: none;
 }
-
 // Use another div inside .tpr-context__context-3 so that at larger sizes a left border can come in on the inner element,
 // but not extend to the top and bottom of the outer element.
 // overflow: hidden prevents the border of .tpr-context__context-3-inner extending too far.
@@ -242,15 +245,13 @@ $tpr-header-left-width-xl: 200px;
         margin-right: 0;
     }
 }
-
-// Align spacing changes with those in .tpr-header inherited from .govuk-width-container. 
+// Align spacing changes with those in .tpr-header inherited from .govuk-width-container.
 // Calculations copied from the govuk-width-container mixin: https://github.com/alphagov/govuk-frontend/blob/137b806d7c308f98f75f8c78ecfdb7f760b27d39/package/govuk/objects/_width-container.scss
 @include govuk-media-query($from: tablet) {
     @supports (margin: unquote("max(calc(0px))")) {
         .tpr-context__context-1,
         .tpr-context__context-2,
         .tpr-context__context-3-inner {
-
             // Respect 'display cutout' safe area (avoids notches and rounded corners)
             $gutter-safe-area-right: calc(#{$govuk-gutter-half} + env(safe-area-inset-right));
             $gutter-safe-area-left: calc(#{$govuk-gutter-half} + env(safe-area-inset-left));
@@ -294,7 +295,6 @@ $tpr-header-left-width-xl: 200px;
         z-index: 1;
         align-items: center;
     }
-
     // Ensures the black background of .tpr-context__context-2 expands to cover the violet when .tpr-context__context-2 is empty and .tpr-context__context-3 is not rendered
     .tpr-context__container--context-2-empty.tpr-context__container--context-3-empty {
         display: flex;
@@ -340,7 +340,6 @@ $tpr-header-left-width-xl: 200px;
         align-items: center;
         background: $tpr-colour-black; // Ensures the black background covers the violet when the content of .tpr-context__context-2 is short or empty
     }
-
     // Ensures the height of .tpr-context__context-2 is consistent whether or not .tpr-context__context-3 is rendered
     // Vertical space should be equal to the sum of padding & margin on .tpr-context__context-3-inner
     .tpr-context__context-2::after {
@@ -363,35 +362,44 @@ $tpr-header-left-width-xl: 200px;
 .tpr-header__logo-img--print {
     display: none;
 }
+
 @media print {
     .tpr-header__inner {
         display: block;
     }
+
     .tpr-header__logo {
         float: left;
         margin-top: govuk-px-to-rem(5) * -1;
         margin-right: $govuk-gutter;
         padding-bottom: govuk-px-to-rem(10);
     }
+
     .tpr-header__logo-img--screen {
         display: none;
     }
+
     .tpr-header__logo-img--print {
         display: block;
     }
+
     .tpr-header__label {
         display: block;
     }
+
     .tpr-header__content > a:link,
     .tpr-header__content > a:visited {
         color: $govuk-link-colour;
     }
+
     .tpr-context {
         clear: both;
     }
+
     .tpr-context .govuk-body {
         color: $govuk-text-colour;
     }
+
     .tpr-context__context-1 {
         border-bottom: govuk-px-to-rem(1) solid $tpr-colour-blue-marguerite;
     }

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha4</Version>
+		<Version>6.0.0-alpha5</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
In a recent PR support was added for having many links in the header, but it was only tested with pasted content where the links were in a list. Normally Umbraco is configured to not allow that list.

This PR supports many links in the header with or without list formatting. It allows list formatting to be applied in the header.