### PR TITLE
Reduce the list of dlls to load when getting model properties

### DIFF
--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ThePensionsRegulator.$(AssemblyName)</Title>
-		<Version>6.0.0-alpha4</Version>
+		<Version>6.0.0-alpha5</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.Umbraco/Validation/ModelPropertyController.cs
+++ b/GovUk.Frontend.Umbraco/Validation/ModelPropertyController.cs
@@ -1,5 +1,6 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,20 +11,34 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Extensions;
 
 namespace GovUk.Frontend.Umbraco.Validation
 {
     [PluginController("GOVUK")]
     public class ModelPropertyController : UmbracoAuthorizedApiController
     {
+        private readonly ILogger<ModelPropertyController> _logger;
+
+        public ModelPropertyController(ILogger<ModelPropertyController> logger)
+        {
+            _logger = logger;
+        }
+
+
         [HttpGet]
         public IEnumerable<string> ForDocumentType(string alias)
         {
             var filepath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+           
             List<Type> controllers = new();
-            foreach (string assemblyFile in Directory.GetFiles(filepath, "*.dll"))
-            {
-                Assembly assembly = Assembly.LoadFrom(assemblyFile);
+
+            var files = Directory.GetFiles(filepath, "*.dll").ToList();
+            files.RemoveAll(x => x.Contains("System") || x.Contains("Microsoft")); // Don't load dlls where there won't be any custom code. This list is not exhaustive
+
+            foreach(var file in files) 
+            { 
+                Assembly assembly = Assembly.LoadFrom(file);
                 List<Type> controllersToAdd = assembly.GetTypes().Where(x => x.IsSubclassOf(typeof(RenderController))).ToList();
                 controllers.AddRange(controllersToAdd);
             }

--- a/GovUk.Frontend.Umbraco/Validation/ModelPropertyController.cs
+++ b/GovUk.Frontend.Umbraco/Validation/ModelPropertyController.cs
@@ -18,14 +18,6 @@ namespace GovUk.Frontend.Umbraco.Validation
     [PluginController("GOVUK")]
     public class ModelPropertyController : UmbracoAuthorizedApiController
     {
-        private readonly ILogger<ModelPropertyController> _logger;
-
-        public ModelPropertyController(ILogger<ModelPropertyController> logger)
-        {
-            _logger = logger;
-        }
-
-
         [HttpGet]
         public IEnumerable<string> ForDocumentType(string alias)
         {

--- a/GovUk.Frontend.Umbraco/Validation/ModelPropertyController.cs
+++ b/GovUk.Frontend.Umbraco/Validation/ModelPropertyController.cs
@@ -34,7 +34,7 @@ namespace GovUk.Frontend.Umbraco.Validation
             List<Type> controllers = new();
 
             var files = Directory.GetFiles(filepath, "*.dll").ToList();
-            files.RemoveAll(x => x.Contains("System") || x.Contains("Microsoft")); // Don't load dlls where there won't be any custom code. This list is not exhaustive
+            files.RemoveAll(x => x.StartsWith("System") || x.StartsWith("Microsoft")); // Don't load dlls where there won't be any custom code. This list is not exhaustive
 
             foreach(var file in files) 
             { 

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>$(AssemblyName)</Title>
-		<Version>6.0.0-alpha5</Version>
+		<Version>6.0.0-alpha6</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,7 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>6.0.0-alpha4</Version>
+    <Version>6.0.0-alpha5</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->
 	<PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
This method was throwing an exception and meaning model properties where not shown in the picker in the back office in the scheme return project. Reducing the number of DLLs to load seems to have fixed this.

DLLs starting with "System" or "Microsoft" have been picked to begin with but I'm sure there are others we would not want to scan. The main thing is we scan DLLs containing the projects or a consuming projects code.