### PR TITLE
Enable sourcelink

### DIFF
--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -22,6 +22,7 @@
 		<PackageTags>gds govuk gov.uk umbraco blocklist blockgrid umbraco-marketplace</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<IncludeSymbols>True</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageId>ThePensionsRegulator.$(AssemblyName)</PackageId>
 		<Product>ThePensionsRegulator.$(AssemblyName)</Product>
 	</PropertyGroup>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -22,6 +22,7 @@
 		<PackageTags>gds govuk gov.uk umbraco blocklist blockgrid</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<IncludeSymbols>True</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageId>$(AssemblyName)</PackageId>
 		<Product>$(AssemblyName)</Product>
 	</PropertyGroup>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha5</Version>
+		<Version>6.0.0-alpha8</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -22,6 +22,7 @@
 	<PackageTags>gds govuk gov.uk umbraco blocklist testing unittest umbraco-marketplace</PackageTags>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<IncludeSymbols>True</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<PackageId>$(AssemblyName)</PackageId>
 	<Product>$(AssemblyName)</Product>
   </PropertyGroup>

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -18,6 +18,7 @@
     <PackageTags>umbraco blocklist</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>True</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Version>6.0.0-alpha5</Version>
 	<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 	     This will help identify breaking changes where the major version should change. -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ steps:
           SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\GovUk.Frontend.AspNetCore.Extensions\bin\$(buildConfiguration)
           Contents: |
             ThePensionsRegulator.GovUk.Frontend*.nupkg
-            !ThePensionsRegulator.GovUk.Frontend*.symbols.nupkg
+            ThePensionsRegulator.GovUk.Frontend*.snupkg
           TargetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
 
@@ -162,7 +162,7 @@ steps:
           SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Umbraco\bin\$(buildConfiguration)
           Contents: |
             ThePensionsRegulator.Umbraco*.nupkg
-            !ThePensionsRegulator.Umbraco*.symbols.nupkg
+            ThePensionsRegulator.Umbraco*.snupkg
           TargetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
 
@@ -173,7 +173,7 @@ steps:
           SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Frontend\bin\$(buildConfiguration)
           Contents: |
             ThePensionsRegulator.Frontend*.nupkg
-            !ThePensionsRegulator.Frontend*.symbols.nupkg
+            ThePensionsRegulator.Frontend*.snupkg
           TargetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
 
@@ -184,7 +184,7 @@ steps:
           SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\GovUk.Frontend.Umbraco\bin\$(buildConfiguration)
           Contents: |
             ThePensionsRegulator.GovUk.Frontend*.nupkg
-            !ThePensionsRegulator.GovUk.Frontend*.symbols.nupkg
+            ThePensionsRegulator.GovUk.Frontend*.snupkg
           TargetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
 
@@ -195,7 +195,7 @@ steps:
           SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Frontend.Umbraco\bin\$(buildConfiguration)
           Contents: |
             ThePensionsRegulator.Frontend*.nupkg
-            !ThePensionsRegulator.Frontend*.symbols.nupkg
+            ThePensionsRegulator.Frontend*.snupkg
           TargetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
 
@@ -206,7 +206,7 @@ steps:
           SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Umbraco.Testing\bin\$(buildConfiguration)
           Contents: |
             ThePensionsRegulator.Umbraco.Testing*.nupkg
-            !ThePensionsRegulator.Umbraco.Testing*.symbols.nupkg
+            ThePensionsRegulator.Umbraco.Testing*.snupkg
           TargetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
 


### PR DESCRIPTION
This is an attempt to enable [Source Link](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink) so that we can debug the sources with ease.

Nuget uses the new `snupkg` format so we use that over the old `symbols.nupkg`.

I'm not sure how to debug a pipeline so I guess it has to be trial and error.