### PR TITLE
Fix exception message in MaxFileSizeAttribute

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
-		<Version>6.0.0-alpha8.1</Version>
+		<Version>6.0.0-alpha8.4</Version>
 		<!-- Set PackageValidationBaselineVersion to the current major version, eg if you're publishing 1.1.1 set it to 1.0.0. 
 		     This will help identify breaking changes where the major version should change. -->
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/GovUk.Frontend.AspNetCore.Extensions/Validation/MaxFileSizeAttribute.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Validation/MaxFileSizeAttribute.cs
@@ -2,12 +2,12 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 
-
 namespace GovUk.Frontend.AspNetCore.Extensions.Validation
 {
     public class MaxFileSizeAttribute : ValidationAttribute
     {
         private readonly int _maxFileSize;
+
         public MaxFileSizeAttribute(int maxFileSize)
         {
             _maxFileSize = maxFileSize;
@@ -22,7 +22,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
 
             if (value is not IFormFile file)
             {
-                throw new InvalidOperationException($"Target property for {nameof(AllowedFileExtensionsAttribute)} must be {nameof(IFormFile)}");
+                throw new InvalidOperationException($"Target property for {nameof(MaxFileSizeAttribute)} must be {nameof(IFormFile)}");
             }
 
             if (file.Length > _maxFileSize)


### PR DESCRIPTION
The exception message refers to the `AllowedFileExtensionsAttribute` when it should be `MaxFileSizeAttribute`
This change fixes that.