### PR TITLE
Add deprecation warning for grid rows and columns in a block list

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/grid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/grid.config
@@ -43,6 +43,14 @@
         "layout": {
           "Umbraco.BlockList": [
             {
+              "contentUdi": "umb://element/f48033a1a7a14e28a7cd53010475ee9f",
+              "settingsUdi": "umb://element/74ec11230d4e49fe8d5462119f87ed13"
+            },
+            {
+              "contentUdi": "umb://element/1b2f841f284643f48925af90b7f2e7e2",
+              "settingsUdi": "umb://element/f47a4236b29641ea8182419ebe254000"
+            },
+            {
               "contentUdi": "umb://element/be98a387b8d84156b27a1a0244faa80f",
               "settingsUdi": "umb://element/0728391856ce4e85bd58e348291a9683"
             },
@@ -61,7 +69,7 @@
             "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
             "udi": "umb://element/be98a387b8d84156b27a1a0244faa80f",
             "text": {
-              "markup": "<h2 class=\"govuk-heading-m\">Block list support</h2>\n<p>The block grid editor is a better way to work with a multi-column layout, but the block list editor is also supported. This paragraph is inside a grid row in the Umbraco block list, but not inside a column. A default single column is created which spans the default 'two-thirds-from-desktop' width.</p>",
+              "markup": "<p>This paragraph is inside a grid row in the Umbraco block list, but not inside a column. A default single column is created which spans the default 'two-thirds-from-desktop' width.</p>",
               "blocks": {
                 "contentData": [],
                 "settingsData": []
@@ -133,12 +141,39 @@
                 }
               ]
             }
+          },
+          {
+            "contentTypeKey": "83cb35fb-51da-45cd-913f-1b8bdfd6a1d9",
+            "udi": "umb://element/1b2f841f284643f48925af90b7f2e7e2",
+            "text": {
+              "markup": "<p>Creating a multi-column layout using a block list is deprecated and may be removed in a future version. Use the block grid.</p>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "iconFallbackText": ""
+          },
+          {
+            "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+            "udi": "umb://element/f48033a1a7a14e28a7cd53010475ee9f",
+            "text": {
+              "markup": "<h2 class=\"govuk-heading-m\">Block list support</h2>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            }
           }
         ],
         "settingsData": [
           {
             "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-            "udi": "umb://element/0728391856ce4e85bd58e348291a9683"
+            "udi": "umb://element/0728391856ce4e85bd58e348291a9683",
+            "cssClassesForRow": "",
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": ""
           },
           {
             "contentTypeKey": "a248d9ad-85e5-446a-9c06-c6a72cd3f34f",
@@ -146,7 +181,9 @@
             "columnSize": [
               "one-half"
             ],
-            "columnSizeFromDesktop": ""
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": "",
+            "renderRowsAndColumnsForChildBlocks": ""
           },
           {
             "contentTypeKey": "a248d9ad-85e5-446a-9c06-c6a72cd3f34f",
@@ -154,7 +191,26 @@
             "columnSize": [
               "one-half"
             ],
-            "columnSizeFromDesktop": ""
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": "",
+            "renderRowsAndColumnsForChildBlocks": ""
+          },
+          {
+            "contentTypeKey": "0bac8213-4607-4547-902a-6a9d84b92633",
+            "udi": "umb://element/f47a4236b29641ea8182419ebe254000",
+            "cssClasses": "",
+            "cssClassesForRow": "",
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": ""
+          },
+          {
+            "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+            "udi": "umb://element/74ec11230d4e49fe8d5462119f87ed13",
+            "cssClassesForRow": "",
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": ""
           }
         ]
       }


### PR DESCRIPTION
#324 deprecated support for multi-column layouts within block lists, because our block grid support is now a better option. This PR adds a deprecation warning to the example app, as well as the one already added in the backoffice.

Screenshot: 

<img width="518" alt="Deprecation warning" src="https://github.com/user-attachments/assets/befd54a6-0d92-487e-8fd8-ea86cbdd94a7">

[AB#204415](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/204415)