### PR TITLE
Fix more vulnerable package warnings

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.ConformanceTests/GovUk.Frontend.AspNetCore.Extensions.ConformanceTests.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions.ConformanceTests/GovUk.Frontend.AspNetCore.Extensions.ConformanceTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GovUk.Frontend.ExampleApp/GovUk.Frontend.ExampleApp.csproj
+++ b/GovUk.Frontend.ExampleApp/GovUk.Frontend.ExampleApp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.2" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -88,10 +88,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.77.8" />
-		<PackageReference Include="MimeKit" Version="4.7.1" />
-		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="13.3.2" />
 	</ItemGroup>

--- a/GovUk.Frontend.sln
+++ b/GovUk.Frontend.sln
@@ -39,7 +39,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThePensionsRegulator.Fronte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThePensionsRegulator.Frontend.Umbraco.Tests", "ThePensionsRegulator.Frontend.Umbraco.Tests\ThePensionsRegulator.Frontend.Umbraco.Tests.csproj", "{73D7EA69-E838-46AF-AC3F-A1897EE63F68}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Frontend.AspNetCore.Extensions.ConformanceTests", "GovUk.Frontend.AspNetCore.Extensions.ConformanceTests\GovUk.Frontend.AspNetCore.Extensions.ConformanceTests.csproj", "{E3E3F660-9477-4218-85B0-EB5DE03EC77C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUk.Frontend.AspNetCore.Extensions.ConformanceTests", "GovUk.Frontend.AspNetCore.Extensions.ConformanceTests\GovUk.Frontend.AspNetCore.Extensions.ConformanceTests.csproj", "{E3E3F660-9477-4218-85B0-EB5DE03EC77C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -34,6 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MimeKit" Version="4.7.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="13.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Moves vulnerable package upgrades from GovUk.Frontend.Umbraco to ThePensionsRegulator.Umbraco so that there are no more vulnerable package warnings. You can verify this by looking at the pipeline run in the checks of this PR.

The changed project type GUID in GovUk.Frontend.sln was not intended, but it does appear to be a good thing as it sets the project type to be in line with all the others, and there's no reason it should be different. [The meaning of the GUIDs is on StackOverflow](https://stackoverflow.com/questions/10802198/visual-studio-project-type-guids).