### PR TITLE
Renames .govuk-grid-row--tpr-box CSS class to .tpr-box 

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/divider-lines-and-boxes.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/divider-lines-and-boxes.config
@@ -58,17 +58,30 @@
   "contentData": [
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
-      "udi": "umb://element/bb9937a5216c4a58a0c31ac46a981914"
+      "udi": "umb://element/bb9937a5216c4a58a0c31ac46a981914",
+      "text": ""
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/fef09d4a5fcb4fceb2356135df68a203",
-      "text": "<p>The Pensions Regulator (TPR) pages include dividing lines which can be applied to a <em>.govuk-grid-row</em> at any level by applying the <em>.govuk-grid-row--tpr-divider</em>.</p>\n<p>They typically appear after the main heading and before the submit button of a form. Wherever possible we only applying spacing using padding and margin on the bottom, not the top of elements, therefore the <em>.govuk-grid-row--tpr-divider</em> class should be applied to the row <strong>before</strong> the point where the divider should appear.</p>"
+      "text": {
+        "markup": "<p>The Pensions Regulator (TPR) pages include dividing lines which can be applied to a <em>.govuk-grid-row</em> at any level by applying the <em>.govuk-grid-row--tpr-divider</em>.</p>\n<p>They typically appear after the main heading and before the submit button of a form. Wherever possible we only applying spacing using padding and margin on the bottom, not the top of elements, therefore the <em>.govuk-grid-row--tpr-divider</em> class should be applied to the row <strong>before</strong> the point where the divider should appear.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/72ca229190654357a88e8dbd6663d681",
-      "text": "<p>Dividers should always span the full width, even when the content they follow does not.</p>\n<p>This is a divider after a 'Text' component.</p>"
+      "text": {
+        "markup": "<p>Dividers should always span the full width, even when the content they follow does not.</p>\n<p>This is a divider after a 'Text' component.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     },
     {
       "contentTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
@@ -79,17 +92,30 @@
     {
       "contentTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
       "udi": "umb://element/e9db258f23cd479e93dce1946fc7d168",
-      "label": "Text input with a divider"
+      "label": "Text input with a divider",
+      "hint": ""
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/41c3348374684b27b333ae0a9ca1a69d",
-      "text": "<p>You can also highlight content in a box by applying <em>.tpr-grid-column--tpr-box</em>.</p>"
+      "text": {
+        "markup": "<p>You can also highlight content in a box by applying <em>.tpr-box</em>.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/07e37dad713f4058972084c21693993b",
-      "text": "<p>This box has a divider applied and the column is set to full width to show the two styles working together.</p>"
+      "text": {
+        "markup": "<p>This box has a divider applied and the column is set to full width to show the two styles working together.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      }
     },
     {
       "contentTypeKey": "b84a633b-1ee7-4a5c-80bd-4267420ed133",
@@ -137,7 +163,14 @@
         ]
       },
       "legend": "Radios where the legend is the heading",
-      "hint": "<p>There is a special case where radio buttons or checkboxes have the legend set as the main page heading.</p>\n<p>Typically two dividers should appear:</p>\n<ul>\n<li>one below the heading, applied using <em>.govuk-grid-row--tpr-divider-for-fieldset</em></li>\n<li>one below the radio buttons, applied using <em>.govuk-grid-row--tpr-divider</em> as normal</li>\n</ul>"
+      "hint": {
+        "markup": "<p>There is a special case where radio buttons or checkboxes have the legend set as the main page heading.</p>\n<p>Typically two dividers should appear:</p>\n<ul>\n<li>one below the heading, applied using <em>.govuk-grid-row--tpr-divider-for-fieldset</em></li>\n<li>one below the radio buttons, applied using <em>.govuk-grid-row--tpr-divider</em> as normal</li>\n</ul>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "fieldsetBlocks": ""
     },
     {
       "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
@@ -151,28 +184,53 @@
       "udi": "umb://element/4a1772053b424d7ba7103b69c6d2183a",
       "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClasses": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "udi": "umb://element/9b254b9997f34d38a7a6b27bff5b715a",
       "cssClassesForRow": "",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "udi": "umb://element/4b60cece286e4e78b68f4685f98c0b2b",
       "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "98070ce9-d528-4bfc-bd90-e411e5110f56",
       "udi": "umb://element/7cf4ce880aca467284002de5523c460e",
       "labelIsPageHeading": "0",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "modelProperty": "",
+      "prefix": "",
+      "suffix": "",
+      "textInputWidth": "",
+      "cssClasses": "",
+      "readOnly": "",
+      "extraLetterSpacing": "",
+      "errorMessageRequired": "",
+      "errorMessageEmail": "",
+      "errorMessagePhone": "",
+      "errorMessageRegex": "",
+      "errorMessageMinLength": "",
+      "errorMessageMaxLength": "",
+      "errorMessageLength": "",
+      "errorMessageRange": "",
+      "errorMessageCompare": "",
+      "customError1": "",
+      "customError2": "",
+      "customError3": "",
+      "cssClassesForRow": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "98070ce9-d528-4bfc-bd90-e411e5110f56",
@@ -180,12 +238,32 @@
       "labelIsPageHeading": "0",
       "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "modelProperty": "",
+      "prefix": "",
+      "suffix": "",
+      "textInputWidth": "",
+      "cssClasses": "",
+      "readOnly": "",
+      "extraLetterSpacing": "",
+      "errorMessageRequired": "",
+      "errorMessageEmail": "",
+      "errorMessagePhone": "",
+      "errorMessageRegex": "",
+      "errorMessageMinLength": "",
+      "errorMessageMaxLength": "",
+      "errorMessageLength": "",
+      "errorMessageRange": "",
+      "errorMessageCompare": "",
+      "customError1": "",
+      "customError2": "",
+      "customError3": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "udi": "umb://element/fa3c38017f3545779383d7874dbe81be",
-      "cssClassesForRow": "govuk-grid-row--tpr-box",
+      "cssClassesForRow": "tpr-box",
       "columnSize": [
         "full"
       ],
@@ -195,7 +273,7 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "udi": "umb://element/a49b698fe7f346b1bd31622c9eb762d4",
-      "cssClassesForRow": "govuk-grid-row--tpr-divider govuk-grid-row--tpr-box",
+      "cssClassesForRow": "govuk-grid-row--tpr-divider tpr-box",
       "columnSize": [
         "full"
       ],
@@ -208,13 +286,24 @@
       "legendIsPageHeading": "1",
       "cssClassesForRow": "govuk-grid-row--tpr-divider-for-fieldset govuk-grid-row--tpr-divider",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "modelProperty": "",
+      "layout": "",
+      "cssClasses": "",
+      "errorMessageRequired": "",
+      "customError1": "",
+      "customError2": "",
+      "customError3": "",
+      "cssClassesForColumn": ""
     },
     {
       "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
       "udi": "umb://element/bf732b3294bc41579295c00ce8a75d97",
       "columnSize": "",
-      "columnSizeFromDesktop": ""
+      "columnSizeFromDesktop": "",
+      "cssClasses": "",
+      "cssClassesForRow": "",
+      "cssClassesForColumn": ""
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/grid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/grid.config
@@ -321,7 +321,7 @@
             "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
             "udi": "umb://element/1c12823faa094653882f51131e16d20f",
             "text": {
-              "markup": "<p>Add the CSS class <em>.govuk-grid-row--tpr-divider</em> to the row to add the dividing line.</p>\n<p>Add the CSS class <em>.govuk-grid-row--tpr-box</em> to the row to add the background box.</p>",
+              "markup": "<p>Add the CSS class <em>.govuk-grid-row--tpr-divider</em> to the row to add the dividing line.</p>\n<p>Add the CSS class <em>.tpr-box</em> to the row to add the background box.</p>",
               "blocks": {
                 "contentData": [],
                 "settingsData": []
@@ -336,7 +336,9 @@
             "columnSize": [
               "two-thirds"
             ],
-            "columnSizeFromDesktop": ""
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": "",
+            "renderRowsAndColumnsForChildBlocks": ""
           },
           {
             "contentTypeKey": "a248d9ad-85e5-446a-9c06-c6a72cd3f34f",
@@ -344,17 +346,25 @@
             "columnSize": [
               "one-third"
             ],
-            "columnSizeFromDesktop": ""
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": "",
+            "renderRowsAndColumnsForChildBlocks": ""
           },
           {
             "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-            "udi": "umb://element/008a97fd0a4d4249a0b426b60fec17d0"
+            "udi": "umb://element/008a97fd0a4d4249a0b426b60fec17d0",
+            "cssClassesForRow": "",
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
+            "cssClassesForColumn": ""
           },
           {
             "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
             "udi": "umb://element/31df6b63fb5443438d2c7963458e46bc",
             "columnSize": "",
-            "columnSizeFromDesktop": ""
+            "columnSizeFromDesktop": "",
+            "cssClassesForRow": "",
+            "cssClassesForColumn": ""
           }
         ]
       }
@@ -551,7 +561,7 @@
     {
       "contentTypeKey": "7f2977e1-5298-4fee-9c8c-5abeeafc1d63",
       "udi": "umb://element/3b1c4912c1a8481abde1a462b9d613f7",
-      "cssClassesForRow": "govuk-grid-row--tpr-divider govuk-grid-row--tpr-box",
+      "cssClassesForRow": "govuk-grid-row--tpr-divider tpr-box",
       "columnSize": [
         "full"
       ],

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
@@ -33,26 +33,26 @@
 }
 
 // Add a background box to highlight a section of content.
-.govuk-grid-row--tpr-box {
+.tpr-box {
     padding-left: $govuk-gutter-half;
     padding-right: $govuk-gutter-half;
 }
 
-.govuk-grid-row--tpr-box > .govuk-grid-column {
+.tpr-box > .govuk-grid-column {
     padding: $govuk-gutter;
     background: $tpr-colour-whisper;
     @include govuk-responsive-margin(6, "bottom");
 }
 
-// .govuk-grid-row--tpr-box can be combined with .govuk-grid-row--tpr-divider. 
-//  In that case the padding applied for .govuk-grid-row--tpr-box creates space equivalent to the margins 
+// .tpr-box can be combined with .govuk-grid-row--tpr-divider. 
+//  In that case the padding applied for .tpr-box creates space equivalent to the margins 
 //  applied for .govuk-grid-row--tpr-divider, so remove the margins.
-.govuk-grid-row--tpr-divider.govuk-grid-row--tpr-box::after {
+.govuk-grid-row--tpr-divider.tpr-box::after {
     margin-left: 0;
     margin-right: 0;
 }
 
-.govuk-grid-row--tpr-divider.govuk-grid-row--tpr-box > .govuk-grid-column {
+.govuk-grid-row--tpr-divider.tpr-box > .govuk-grid-column {
     margin-bottom: 0;
 }
 
@@ -61,8 +61,8 @@
 //  margin from the last element inside either one so that we get one spacer, not the combination of both.
 .govuk-grid-row--tpr-divider > .govuk-grid-column > :last-child,
 .govuk-grid-row--tpr-divider > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child,
-.govuk-grid-row--tpr-box > .govuk-grid-column > :last-child,
-.govuk-grid-row--tpr-box > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child {
+.tpr-box > .govuk-grid-column > :last-child,
+.tpr-box > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child {
     padding-bottom: 0;
     margin-bottom: 0;
 }


### PR DESCRIPTION
This PR just changes a CSS class name from `.govuk-grid-row--tpr-box` to `.tpr-box` because upcoming story [AB#207252](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/207252) will see it applied to elements other than a grid row. 

It changes it in example content as well as in the SASS stylesheet. Some of the example content hasn't been saved in a while, which is why all the extra properties are appearing in this PR from features which have been added since the last time these pages were saved.

This is a good time to make the change as it can be documented as a breaking change in the upgrade to v6.0.0 of the packages.