### PR TITLE
Allow Github Issues references as well as Azure DevOps. 

### DIFF
--- a/.githooks/Confirm-WorkItemReference.Tests.ps1
+++ b/.githooks/Confirm-WorkItemReference.Tests.ps1
@@ -1,0 +1,36 @@
+Describe 'Confirm-WorkItemReference' {
+    BeforeAll {
+        Push-Location $PSScriptRoot
+        $file = "./test-commit.txt"
+        Mock Write-Warning {}
+    }
+
+    It 'Should allow a commit with an Azure DevOps work item reference' {
+        Set-Content -Path $file -Value "Test commit AB#123456"
+        ./Confirm-WorkItemReference.ps1 $file
+        $LASTEXITCODE | Should -Be 0
+    }
+    
+    It 'Should allow a commit with a Github Issues work item reference' {
+        Set-Content -Path $file -Value "Test commit #123"
+        ./Confirm-WorkItemReference $file 
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'Should allow a merge commit without a work item reference' {
+        Set-Content -Path $file -Value "Merge branch 'example' into 'develop'"
+        ./Confirm-WorkItemReference $file 
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'Should block a non-merge commit without a work item reference' {
+        Set-Content -Path $file -Value "Forgotten work item"
+        ./Confirm-WorkItemReference $file 
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    AfterAll {
+        Remove-Item $file
+        Pop-Location
+    }
+}

--- a/.githooks/Confirm-WorkItemReference.ps1
+++ b/.githooks/Confirm-WorkItemReference.ps1
@@ -3,9 +3,9 @@ param(
     [string]$CommitMessageFile
 )
 
-# Check for a work item reference
+# Check for a work item reference, either Azure DevOps or Github
 $commitMessage = (Get-Content $CommitMessageFile);
-If (!($commitMessage -Match "AB#\d") -And !($commitMessage -Match "^Merge branch '")) { 
+If (!($commitMessage -Match "AB#\d{6}" -Or $commitMessage -Match "#\d{3,4}") -And !($commitMessage -Match "^Merge branch '")) { 
     Write-Warning "Commit aborted. Your commit message must include a Azure DevOps work item reference, eg AB#12345"; Exit 1 
 }
 else { Exit 0 }

--- a/.githooks/Invoke-CommitMessageHook.ps1
+++ b/.githooks/Invoke-CommitMessageHook.ps1
@@ -4,5 +4,5 @@ param(
 )
 
 # Add custom commands for this repo here
-Invoke-Expression -Command "./.githooks/Confirm-AzureDevOpsWorkItem.ps1 $CommitMessageFile"
+Invoke-Expression -Command "./.githooks/Confirm-WorkItemReference.ps1 $CommitMessageFile"
 If ($LASTEXITCODE -gt 0) { Exit $LASTEXITCODE }

--- a/docs/contributing/run-tests.md
+++ b/docs/contributing/run-tests.md
@@ -14,3 +14,11 @@ To run unit tests on the .NET code:
 ```cmd
 dotnet test
 ```
+
+Install [Pester](https://pester.dev/docs/quick-start) before running the following command.
+
+To run unit tests on the PowerShell scripts:
+
+```pwsh
+Invoke-Pester
+```


### PR DESCRIPTION
Updates our pre-commit hook to check for a Github Issues reference OR an Azure DevOps one, instead of just Azure DevOps. Adds tests for that script.

Fixes #348.