### PR TITLE
AB#222540 - Limit image size in editor to prevent image distortion in the backoffice

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-        <Version>7.3.2</Version>
+        <Version>7.3.3</Version>
     </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRImage.html
+++ b/ThePensionsRegulator.Frontend.Umbraco/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRImage.html
@@ -13,7 +13,7 @@
         align-items: center;
         justify-content: center;
         width: 100%;
-        height: 100%;
+        height: auto;
         cursor: pointer;
         color: black;
         background-color: transparent;
@@ -27,12 +27,6 @@
     }
     button:hover {
         color: #2152A3;
-    }
-    img {
-        object-fit: cover;
-        height: 100%;
-        width: 100%;
-        flex-grow: 0;
     }
 
     .icon {
@@ -73,12 +67,15 @@
     .is-trashed .file-name {
         opacity: 1;
     }
-
+	button img.image{
+		max-width:100%;
+		object-fit: contain;
+	} 
 </style>
 
 <button type="button" ng-click="block.edit()" ng-focus="block.focus" ng-class="{'is-trashed': mediaItem.trashed}">
     {{mediaItem = (block.data.image[0].mediaKey | mediaItemResolver); ""}}
-    <img ng-if="mediaItem !== null && (mediaItem.mediaLink.indexOf('jpg') !== -1 || mediaItem.mediaLink.indexOf('png') !== -1 || mediaItem.mediaLink.indexOf('webp') !== -1 || mediaItem.mediaLink.indexOf('gif') !== -1) && !mediaItem.trashed" ng-src="{{mediaItem.mediaLink}}" alt="{{mediaItem.name}}" />
+    <img ng-if="mediaItem !== null && (mediaItem.mediaLink.indexOf('jpg') !== -1 || mediaItem.mediaLink.indexOf('png') !== -1 || mediaItem.mediaLink.indexOf('webp') !== -1 || mediaItem.mediaLink.indexOf('gif') !== -1) && !mediaItem.trashed" ng-src="{{mediaItem.mediaLink}}" alt="{{mediaItem.name}}" class="image"/>
     <umb-icon ng-if="mediaItem !== null && mediaItem.mediaLink.indexOf('jpg') === -1 && mediaItem.mediaLink.indexOf('png') === -1 && mediaItem.mediaLink.indexOf('webp') === -1 && mediaItem.mediaLink.indexOf('gif') === -1 || mediaItem.trashed" icon="{{mediaItem.contentType.icon}}" class="icon"></umb-icon>
     <span ng-if="mediaItem !== null && mediaItem.name" class="file-name">
         <span ng-if="mediaItem.trashed"><localize key="mediaPicker_trashed">Trashed</localize>:</span>


### PR DESCRIPTION
This PR addresses the image distortion issue present on the TPR image block - as illustrated below:
![image](https://github.com/user-attachments/assets/7f0f76d7-4e5e-4bb5-8127-f3603bc03994)

**Updates**
- Prevent image distortion in Image block components on the backoffice.
- Preserve image aspect ratio and fit image to parent container boundaries.