### PR TITLE
Section cards fix for opening links in new tab

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-        <Version>7.3.3</Version>
+        <Version>7.3.4</Version>
     </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/section-cards.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/section-cards.config
@@ -281,6 +281,7 @@
             "udi": "umb://element/bf6f2c1932564a57881a4df3dc56a7c1",
             "link": [
               {
+                "target": "_blank",
                 "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
               }
             ],
@@ -329,6 +330,7 @@
             "link": [
               {
                 "name": "Employers",
+                "target": "",
                 "url": "/employers"
               }
             ],
@@ -361,6 +363,7 @@
             "udi": "umb://element/d202d64c601b4369ba957be371b394fc",
             "link": [
               {
+                "target": "",
                 "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
               }
             ],

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSectionCards.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSectionCards.cshtml
@@ -51,9 +51,10 @@
                         continue;
                     var name = link.Name;
                     var url = link.Url;
+                    var target = link.Target;
                     var desc = box.Content.Value<string>(descFieldName);
                     <tpr-section-cards-card>                       
-                            <tpr-section-cards-card-title href="@url">
+                            <tpr-section-cards-card-title href="@url" target="@target">
                                  @name 
                             </tpr-section-cards-card-title>
                             @if (!string.IsNullOrWhiteSpace(desc))

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSectionCards.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSectionCards.cs
@@ -30,6 +30,11 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                         var anchorElement = new TagBuilder("a");
                         anchorElement.Attributes.Add("href", card.TitleUrl);
 
+                        if(!string.IsNullOrWhiteSpace(card.TitleTarget))
+                        {
+                            anchorElement.Attributes.Add("target",card.TitleTarget);
+                        }
+
                         if (card.TitleAllowHtml)
                         {
                             anchorElement.InnerHtml.AppendHtml(card.Title);

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/TprSectionCardsCard.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/TprSectionCardsCard.cs
@@ -9,6 +9,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         public AttributeDictionary? TitleAttributes { get; set; }
         public IHtmlContent? Title { get; set; }
         public string? TitleUrl { get; set; }
+        public string? TitleTarget { get; set; }
         public bool TitleAllowHtml { get; set; }
         public AttributeDictionary? ContentAttributes { get; set; }
         public IHtmlContent? Content { get; set; }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprSectionCardsCardContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprSectionCardsCardContext.cs
@@ -6,19 +6,20 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
 {
     internal class TprSectionCardsCardContext
     {
-        private (AttributeDictionary Attributes, IHtmlContent? Title, bool AllowHtml, string? Url)? _title;
+        private (AttributeDictionary Attributes, IHtmlContent? Title, bool AllowHtml, string? Url, string? Target)? _title;
         private (AttributeDictionary Attributes, IHtmlContent? Content, bool AllowHtml)? _content;
 
         public AttributeDictionary? CardAttributes { get; set; }
         public AttributeDictionary? TitleAttributes => _title?.Attributes;
         public IHtmlContent? Title => _title?.Title;
         public string? TitleUrl => _title?.Url;
+        public string? TitleTarget => _title?.Target;
         public bool TitleAllowHtml => _title?.AllowHtml ?? false;
         public AttributeDictionary? ContentAttributes => _content?.Attributes;
         public IHtmlContent? Content => _content?.Content;
         public bool ContentAllowHtml => _content?.AllowHtml ?? false;
 
-        public void SetTitle(AttributeDictionary attributes, IHtmlContent? title, bool allowHtml, string url)
+        public void SetTitle(AttributeDictionary attributes, IHtmlContent? title, bool allowHtml, string url, string target)
         {
             if (_title != null)
             {
@@ -26,7 +27,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                     TprSectionCardsCardTitleTagHelper.TagName,
                     TprSectionCardsCardTagHelper.TagName);
             }
-            _title = (attributes, title, allowHtml, url);
+            _title = (attributes, title, allowHtml, url, target);
         }
 
         public void SetContent(AttributeDictionary contentAttributes, IHtmlContent? content, bool allowHtml)

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprSectionCardsCardTitleTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprSectionCardsCardTitleTagHelper.cs
@@ -13,6 +13,10 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         [HtmlAttributeName("href")]
         public string? Url { get; set; }
 
+        [HtmlAttributeName("target")]
+        public string? Target { get; set; }
+
+
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             var cardContext = context.GetContextItem<TprSectionCardsCardContext>();
@@ -21,7 +25,8 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             cardContext.SetTitle(output.Attributes.ToAttributeDictionary(),
                 content,
                 !content.IsEmptyOrWhiteSpace,
-                Url!);
+                Url!,
+                Target!);
 
             output.SuppressOutput();
         }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprSectionCardsContainerTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprSectionCardsContainerTagHelper.cs
@@ -45,6 +45,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                     TitleAttributes = c.TitleAttributes,
                     Title = c.Title,
                     TitleUrl = c.TitleUrl,
+                    TitleTarget = c.TitleTarget,
                     TitleAllowHtml = c.TitleAllowHtml,
                     ContentAttributes = c.ContentAttributes,
                     Content = c.Content,


### PR DESCRIPTION
Now allows for the links to respect the 'Opens  the linked document in a new window or tab'