### PR TITLE
The related links component had incorrect HTML

### DIFF
--- a/GovUk.Frontend.ExampleApp/Views/RelatedLinks/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/RelatedLinks/Index.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    ViewData["Title"] = "Related Links";
+    ViewData["Title"] = "Related links";
 }
 <span class="govuk-caption-xl">Example application</span>
 <div class="govuk-grid-row govuk-grid-row--tpr-divider">
@@ -8,9 +8,29 @@
     </div>
 </div>
 
-<tpr-related-links>
-    <tpr-related-links-heading>Related links example heading</tpr-related-links-heading>
-    <tpr-related-link href="">Example link 1</tpr-related-link>
-    <tpr-related-link href="">Example link 2</tpr-related-link>
-    <tpr-related-link href="">Example link 3</tpr-related-link>
-</tpr-related-links>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column govuk-grid-column-two-thirds">
+        <div class="govuk-grid-row"> 
+            <div class="govuk-grid-column govuk-grid-column-full"> 
+                <p class="govuk-body">Related links is a TPR component normally found in the right column of desktop layouts.</p>
+                <p class="govuk-body">
+                    The heading defaults to 'Related' if left blank. 
+                    It can be overridden sitewide by creating a dictionary entry called 'TPR Related links heading'. 
+                    This in turn can be overridden by setting the heading on an individual component.
+                </p>
+            </div> 
+        </div> 
+    </div>
+    <div class="govuk-grid-column govuk-grid-column-one-third">
+        <div class="govuk-grid-row"> 
+            <div class="govuk-grid-column govuk-grid-column-full"> 
+                <tpr-related-links>
+                    <tpr-related-links-heading>Related links</tpr-related-links-heading>
+                    <tpr-related-link href="">Example link 1</tpr-related-link>
+                    <tpr-related-link href="">Example link 2</tpr-related-link>
+                    <tpr-related-link href="">Example link 3</tpr-related-link>
+                </tpr-related-links>
+            </div> 
+        </div>
+    </div>
+</div>

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukSectionBreakSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/GovukSectionBreakSettings.generated.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 {
 	/// <summary>Section break settings</summary>
 	[PublishedModel("govukSectionBreakSettings")]
-	public partial class GovukSectionBreakSettings : PublishedElementModel
+	public partial class GovukSectionBreakSettings : PublishedElementModel, IGovukCssClasses, IGovukGrid, IGovukGridColumnClasses
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant
@@ -50,18 +50,58 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		// properties
 
 		///<summary>
-		/// Hidden: Toggle visibility on/off, not hidden by default.
+		/// Hidden
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
 		[ImplementPropertyType("hidden")]
 		public virtual bool Hidden => this.Value<bool>(_publishedValueFallback, "hidden");
 
 		///<summary>
-		/// Size: Defaults to medium
+		/// Size: Defaults to 'Large' if left blank.
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		[ImplementPropertyType("size")]
 		public virtual string Size => this.Value<string>(_publishedValueFallback, "size");
+
+		///<summary>
+		/// CSS classes: Applied to the outermost HTML element of the component.
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("cssClasses")]
+		public virtual string CssClasses => global::Umbraco.Cms.Web.Common.PublishedModels.GovukCssClasses.GetCssClasses(this, _publishedValueFallback);
+
+		///<summary>
+		/// CSS classes for row: Applied to the grid row which contains this component and other adjacent components that have the same setting.
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("cssClassesForRow")]
+		public virtual string CssClassesForRow => global::Umbraco.Cms.Web.Common.PublishedModels.GovukGrid.GetCssClassesForRow(this, _publishedValueFallback);
+
+		///<summary>
+		/// Column size
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("columnSize")]
+		public virtual string ColumnSize => global::Umbraco.Cms.Web.Common.PublishedModels.GovukGridColumnClasses.GetColumnSize(this, _publishedValueFallback);
+
+		///<summary>
+		/// Column size (from desktop): Defaults to 'two-thirds' if both column size properties are left blank.
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("columnSizeFromDesktop")]
+		public virtual string ColumnSizeFromDesktop => global::Umbraco.Cms.Web.Common.PublishedModels.GovukGridColumnClasses.GetColumnSizeFromDesktop(this, _publishedValueFallback);
+
+		///<summary>
+		/// CSS classes for column: Applied to the grid column which contains this component and other adjacent components that have the same setting.
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("cssClassesForColumn")]
+		public virtual string CssClassesForColumn => global::Umbraco.Cms.Web.Common.PublishedModels.GovukGridColumnClasses.GetCssClassesForColumn(this, _publishedValueFallback);
 	}
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/RelatedLinks.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/RelatedLinks.generated.cs
@@ -19,13 +19,13 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Web.Common.PublishedModels
 {
 	/// <summary>TPR related links</summary>
-	[PublishedModel("tprRelatedLinksExamplePage")]
-	public partial class TprRelatedLinksExamplePage : PublishedContentModel
+	[PublishedModel("relatedLinks")]
+	public partial class RelatedLinks : PublishedContentModel
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
-		public new const string ModelTypeAlias = "tprRelatedLinksExamplePage";
+		public new const string ModelTypeAlias = "relatedLinks";
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
 		public new const PublishedItemType ModelItemType = PublishedItemType.Content;
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
@@ -34,14 +34,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 			=> PublishedModelUtility.GetModelContentType(publishedSnapshotAccessor, ModelItemType, ModelTypeAlias);
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.3.2+696a711")]
 		[return: global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		public static IPublishedPropertyType GetModelPropertyType<TValue>(IPublishedSnapshotAccessor publishedSnapshotAccessor, Expression<Func<TprRelatedLinksExamplePage, TValue>> selector)
+		public static IPublishedPropertyType GetModelPropertyType<TValue>(IPublishedSnapshotAccessor publishedSnapshotAccessor, Expression<Func<RelatedLinks, TValue>> selector)
 			=> PublishedModelUtility.GetModelPropertyType(GetModelContentType(publishedSnapshotAccessor), selector);
 #pragma warning restore 0109
 
 		private IPublishedValueFallback _publishedValueFallback;
 
 		// ctor
-		public TprRelatedLinksExamplePage(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
+		public RelatedLinks(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
 			: base(content, publishedValueFallback)
 		{
 			_publishedValueFallback = publishedValueFallback;

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprRelatedLinks.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprRelatedLinks.generated.cs
@@ -18,7 +18,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.PublishedModels
 {
-	/// <summary>TPR related links</summary>
+	/// <summary>Related links</summary>
 	[PublishedModel("tprRelatedLinks")]
 	public partial class TprRelatedLinks : PublishedElementModel
 	{

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprRelatedLinksSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprRelatedLinksSettings.generated.cs
@@ -18,7 +18,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.PublishedModels
 {
-	/// <summary>TPR related links settings</summary>
+	/// <summary>Related links settings</summary>
 	[PublishedModel("tprRelatedLinksSettings")]
 	public partial class TprRelatedLinksSettings : PublishedElementModel, IGovukCssClasses
 	{

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRRelatedLinks.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRRelatedLinks.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<TprRelatedLinksExamplePage>
+﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<RelatedLinks>
 @section head {
 	<title>@Model.PageHeadingOrName()</title>
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/related-links.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/related-links.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Content Key="b32c5acb-3eb5-4a34-8555-579554021ed4" Alias="TPR Related Links" Level="2">
+<Content Key="b32c5acb-3eb5-4a34-8555-579554021ed4" Alias="Related links" Level="2">
   <Info>
     <Parent Key="5e682cbe-b867-491a-955f-3382446d5663">Home</Parent>
-    <Path>/Home/TPRRelatedLinks</Path>
+    <Path>/Home/RelatedLinks</Path>
     <Trashed>false</Trashed>
     <ContentType>tprRelatedLinksExamplePage</ContentType>
     <CreateDate>2025-02-13T16:49:07</CreateDate>
-    <NodeName Default="TPR Related Links" />
+    <NodeName Default="Related links" />
     <SortOrder>28</SortOrder>
     <Published Default="true" />
     <Schedule />
@@ -74,7 +74,7 @@
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
       "udi": "umb://element/b43ec17e590e4211a36f8c826033aad8",
-      "text": "TPR Related Links"
+      "text": ""
     },
     {
       "contentTypeKey": "650d7119-e9cf-4c26-a08c-21cf2ffbbbbc",
@@ -84,7 +84,7 @@
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "udi": "umb://element/6a2f2abdfeaf46bc832cba38acdb9fde",
       "text": {
-        "markup": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>",
+        "markup": "<p>Related links is a TPR component normally found in the right column of desktop layouts.</p>\n<p>The heading defaults to 'Related' if left blank. It can be overridden sitewide by creating a dictionary entry called 'TPR Related links heading'. This in turn can be overridden by setting the heading on an individual component.</p>",
         "blocks": {
           "contentData": [],
           "settingsData": []

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/related-links.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/related-links.config
@@ -4,7 +4,7 @@
     <Parent Key="5e682cbe-b867-491a-955f-3382446d5663">Home</Parent>
     <Path>/Home/RelatedLinks</Path>
     <Trashed>false</Trashed>
-    <ContentType>tprRelatedLinksExamplePage</ContentType>
+    <ContentType>relatedLinks</ContentType>
     <CreateDate>2025-02-13T16:49:07</CreateDate>
     <NodeName Default="Related links" />
     <SortOrder>28</SortOrder>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/relatedlinks.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/relatedlinks.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ContentType Key="257bedac-29c9-488b-adba-9ed5a2742a4a" Alias="tprRelatedLinksExamplePage" Level="1">
+<ContentType Key="257bedac-29c9-488b-adba-9ed5a2742a4a" Alias="relatedLinks" Level="1">
   <Info>
     <Name>TPR related links</Name>
     <Icon>icon-link color-black</Icon>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprrelatedlinks.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprrelatedlinks.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="a2f4c028-e009-402b-a292-8cc898bb5aa9" Alias="tprRelatedLinks" Level="2">
   <Info>
-    <Name>TPR related links</Name>
+    <Name>Related links</Name>
     <Icon>icon-link color-black</Icon>
     <Thumbnail>folder.png</Thumbnail>
-    <Description>A list of relevant related links for a page.</Description>
+    <Description>A list of related links for a page.</Description>
     <AllowAtRoot>False</AllowAtRoot>
     <IsListView>False</IsListView>
     <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprrelatedlinkssettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprrelatedlinkssettings.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="bfe62807-47c4-47b0-bb4b-c4a1d991886b" Alias="tprRelatedLinksSettings" Level="2">
   <Info>
-    <Name>TPR related links settings</Name>
+    <Name>Related links settings</Name>
     <Icon>icon-link color-black</Icon>
     <Thumbnail>folder.png</Thumbnail>
-    <Description>Settings for a list of relevant related links for a page.</Description>
+    <Description>Settings for a list of related links for a page.</Description>
     <AllowAtRoot>False</AllowAtRoot>
     <IsListView>False</IsListView>
     <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKNoFormsBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKNoFormsBlockList.config
@@ -1,2 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Empty Key="a6cd5d54-75a9-407e-a688-842b9f397a44" Alias="GOV.UK No forms block list" Change="Delete" />

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRBlockGrid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRBlockGrid.config
@@ -1292,7 +1292,7 @@
       "view": null
     },
     {
-      "allowAtRoot": true,
+      "allowAtRoot": false,
       "allowInAreas": true,
       "areaGridColumns": null,
       "areas": [],

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRNoFormsBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRNoFormsBlockList.config
@@ -1,2 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Empty Key="6e1529d8-d96a-41a8-a7da-3541996e339c" Alias="TPR No forms block list" Change="Delete" />

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ We add support for:
   - [TPR context bar](/docs/components/tpr-context-bar.md)
   - [TPR footer bar](/docs/components/tpr-footer-bar.md)
   - [TPR youtube video](/docs/components/tpr-youtube-video.md)
-  
   - [TPR related links](/docs/components/tpr-related-links.md)
   - [TPR section cards](/docs/components/tpr-section-cards.md)
 

--- a/ThePensionsRegulator.Frontend.Umbraco/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRRelatedLinks.html
+++ b/ThePensionsRegulator.Frontend.Umbraco/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRRelatedLinks.html
@@ -1,11 +1,10 @@
 ﻿
 <div class="tpr-related-links {{block.settingsData.cssClasses}}">
-    <ul>
-        <li>
-            <h2 ng-bind="block.data.heading"></h2>
-        </li>
+    <h2 class="govuk-heading-m" ng-bind="block.data.heading" ng-if="block.data.heading"></h2>
+    <h2 class="govuk-heading-m" ng-if="!block.data.heading">Related</h2>
+    <ul class="govuk-list">
         <li ng-repeat="link in block.data.links">
-            <a href="{{link.url}}">{{link.name}}</a>
+            <a href="{{link.url}}" class="govuk-link">{{link.name}}</a>
         </li>
     </ul>
 </div>

--- a/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
+++ b/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
@@ -33,24 +33,3 @@ p.tpr-add-link {
 .tpr-youtube-video-previewbox-play-button{
     margin:0px 20%;
 }
-
-div.tpr-related-links {
-    border-top: solid 4px $tpr-colour-royal-blue;
-    padding-top: 20px;
-    margin-bottom: 30px;
-}
-
-.tpr-related-links ul {
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-}
-
-.tpr-related-links li h2 {
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-}
-
-.tpr-related-links li {
-    padding-bottom: 1rem;
-}

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRRelatedLinks.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRRelatedLinks.cshtml
@@ -15,7 +15,7 @@
     }
 }
 
-<tpr-related-links outer-styles="@cssClasses">
+<tpr-related-links class="@cssClasses">
 
     <tpr-related-links-heading>@heading</tpr-related-links-heading>
 

--- a/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/ContentTypes/tprrelatedlinks.config
+++ b/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/ContentTypes/tprrelatedlinks.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="a2f4c028-e009-402b-a292-8cc898bb5aa9" Alias="tprRelatedLinks" Level="2">
   <Info>
-    <Name>TPR related links</Name>
+    <Name>Related links</Name>
     <Icon>icon-link color-black</Icon>
     <Thumbnail>folder.png</Thumbnail>
-    <Description>A list of relevant related links for a page.</Description>
+    <Description>A list of related links for a page.</Description>
     <AllowAtRoot>False</AllowAtRoot>
     <IsListView>False</IsListView>
     <Variations>Nothing</Variations>

--- a/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/ContentTypes/tprrelatedlinkssettings.config
+++ b/ThePensionsRegulator.Frontend.Umbraco/uSync/v9/ContentTypes/tprrelatedlinkssettings.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="bfe62807-47c4-47b0-bb4b-c4a1d991886b" Alias="tprRelatedLinksSettings" Level="2">
   <Info>
-    <Name>TPR related links settings</Name>
+    <Name>Related links settings</Name>
     <Icon>icon-link color-black</Icon>
     <Thumbnail>folder.png</Thumbnail>
-    <Description>Settings for a list of relevant related links for a page.</Description>
+    <Description>Settings for a list of related links for a page.</Description>
     <AllowAtRoot>False</AllowAtRoot>
     <IsListView>False</IsListView>
     <Variations>Nothing</Variations>

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprRelatedLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprRelatedLinks.cs
@@ -1,0 +1,42 @@
+using GovUk.Frontend.AspNetCore;
+using GovUk.Frontend.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace ThePensionsRegulator.Frontend.HtmlGeneration
+{
+    public partial class ComponentGenerator
+    {
+        public virtual TagBuilder GenerateTprRelatedLinks(TprRelatedLinks tprRelatedLinks)
+        {
+            Guard.ArgumentNotNull(nameof(tprRelatedLinks), tprRelatedLinks);
+            Guard.ArgumentValid(nameof(tprRelatedLinks), $"{nameof(tprRelatedLinks.HeadingContent)} cannot be null", tprRelatedLinks.HeadingContent != null);
+
+            var outer = new TagBuilder("div");
+            if (tprRelatedLinks.RelatedLinksAttributes != null) { outer.MergeAttributes(tprRelatedLinks.RelatedLinksAttributes); }
+            outer.MergeCssClass("tpr-related-links");
+
+            var heading = new TagBuilder("h2");
+            if (tprRelatedLinks.HeadingAttributes != null) { heading.MergeAttributes(tprRelatedLinks.HeadingAttributes); }
+            heading.MergeCssClass("govuk-heading-m");
+            heading.InnerHtml.AppendHtml(tprRelatedLinks.HeadingContent!);
+            outer.InnerHtml.AppendHtml(heading);
+
+            var list = new TagBuilder("ul");
+            list.MergeCssClass("govuk-list");
+            outer.InnerHtml.AppendHtml(list);
+
+            foreach (var link in tprRelatedLinks.Links)
+            {
+                var li = new TagBuilder("li");
+                var a = new TagBuilder("a");
+                a.MergeAttributes(link.Attributes);
+                a.MergeCssClass("govuk-link");
+                a.InnerHtml.AppendHtml(link.Content);
+                li.InnerHtml.AppendHtml(a);
+                list.InnerHtml.AppendHtml(li);
+            }
+
+            return outer;
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/TprRelatedLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/TprRelatedLinks.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Collections.Generic;
+
+namespace ThePensionsRegulator.Frontend.HtmlGeneration
+{
+    public record TprRelatedLinks
+    {
+        public required AttributeDictionary RelatedLinksAttributes { get; set; }
+        public required AttributeDictionary HeadingAttributes { get; set; }
+        public required IHtmlContent HeadingContent { get; set; }
+        public required IList<(AttributeDictionary Attributes, IHtmlContent Content)> Links { get; set; }
+    }
+}

--- a/ThePensionsRegulator.Frontend/ITprHtmlGenerator.cs
+++ b/ThePensionsRegulator.Frontend/ITprHtmlGenerator.cs
@@ -12,9 +12,10 @@ namespace ThePensionsRegulator.Frontend
         TagBuilder GenerateTprHeaderBar(TprHeaderBar tprHeaderBar);
         TagBuilder GenerateTprFooterBar(TprFooterBar tprFooterBar);
         TagBuilder GenerateTprContextBar(TprContextBar tprContextBar);
+        TagBuilder GenerateTprRelatedLinks(TprRelatedLinks tprRelatedLinks);
         TagBuilder GenerateTprSectionCards(TprSectionCards tprSectionCards);
-        TagBuilder GenerateTprAblePlayer(string id,string title,string videoId,bool autoplay,bool playsinline,string preload, string transcriptUrl, string transcriptTitle, string transcriptTarget);
-        TagBuilder GenerateTprYoutubeNoCookiesEmbeddedPlayer(string id,string title, string videoId,bool autoplay,bool playsinline,string preload, string transcriptUrl, string transcriptTitle, string transcriptTarget);
+        TagBuilder GenerateTprAblePlayer(string id, string title, string videoId, bool autoplay, bool playsinline, string preload, string transcriptUrl, string transcriptTitle, string transcriptTarget);
+        TagBuilder GenerateTprYoutubeNoCookiesEmbeddedPlayer(string id, string title, string videoId, bool autoplay, bool playsinline, string preload, string transcriptUrl, string transcriptTitle, string transcriptTarget);
 
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-related-links.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-related-links.scss
@@ -1,9 +1,9 @@
 ﻿@import '_tpr-variables.scss';
 
-div.tpr-related-links {
+.tpr-related-links {
     border-top: solid 4px $tpr-colour-royal-blue;
-    padding-top: 20px;
-    margin-bottom: 30px;
+    padding-top: govuk-spacing(4);
+    @include govuk-responsive-margin(6, "bottom");
 }
 
 .tpr-related-links ul {

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinkTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinkTagHelper.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using GovUk.Frontend.AspNetCore;
+using GovUk.Frontend.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Threading.Tasks;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
@@ -12,11 +10,15 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
     {
         internal const string TagName = "tpr-related-link";
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
-            output.PreElement.SetHtmlContent("<li>");
-            output.TagName = "a";
-            output.PostElement.SetHtmlContent("</li>");
+            var relatedLinksContext = context.GetContextItem<TprRelatedLinksContext>();
+
+            var childContent = await output.GetChildContentAsync();
+
+            relatedLinksContext.AddLink(output.Attributes.ToAttributeDictionary(), childContent.Snapshot());
+
+            output.SuppressOutput();
         }
     }
 }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinksContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinksContext.cs
@@ -1,0 +1,33 @@
+﻿using GovUk.Frontend.AspNetCore;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Collections.Generic;
+
+namespace ThePensionsRegulator.Frontend.TagHelpers
+{
+    internal class TprRelatedLinksContext
+    {
+        private (AttributeDictionary Attributes, IHtmlContent Content)? _heading;
+
+        public AttributeDictionary HeadingAttributes => _heading?.Attributes ?? [];
+        public IHtmlContent HeadingContent => _heading?.Content ?? new HtmlString(string.Empty);
+        public IList<(AttributeDictionary Attributes, IHtmlContent Content)> Links = new List<(AttributeDictionary Attributes, IHtmlContent Content)>();
+
+        public void AddLink(AttributeDictionary attributes, IHtmlContent htmlContent)
+        {
+            Links.Add((attributes, htmlContent));
+        }
+
+        public void SetHeading(AttributeDictionary attributes, IHtmlContent htmlContent)
+        {
+            if (_heading != null)
+            {
+                throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                    TprRelatedLinksHeadingTagHelper.TagName,
+                    TprRelatedLinksTagHelper.TagName);
+            }
+
+            _heading = (attributes, htmlContent);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinksHeadingTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinksHeadingTagHelper.cs
@@ -1,9 +1,6 @@
-﻿using GovUk.Frontend.AspNetCore.Extensions.TagHelpers;
+﻿using GovUk.Frontend.AspNetCore;
+using GovUk.Frontend.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
@@ -13,11 +10,15 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
     {
         internal const string TagName = "tpr-related-links-heading";
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
-            output.PreElement.SetHtmlContent("<li>");
-            output.TagName = "h2";
-            output.PostElement.SetHtmlContent("</li>");
+            var relatedLinksContext = context.GetContextItem<TprRelatedLinksContext>();
+
+            var childContent = await output.GetChildContentAsync();
+
+            relatedLinksContext.SetHeading(output.Attributes.ToAttributeDictionary(), childContent.Snapshot());
+
+            output.SuppressOutput();
         }
     }
 }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinksTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprRelatedLinksTagHelper.cs
@@ -1,11 +1,9 @@
-﻿using GovUk.Frontend.AspNetCore.Extensions.HtmlGeneration;
-using GovUk.Frontend.AspNetCore.Extensions.TagHelpers;
+﻿using GovUk.Frontend.AspNetCore;
+using GovUk.Frontend.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using ThePensionsRegulator.Frontend.HtmlGeneration;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
 {
@@ -15,14 +13,44 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
     {
         internal const string TagName = "tpr-related-links";
 
-        [HtmlAttributeName("outer-styles")]
-        public string? OuterStyles { get; set; }
+        private readonly ITprHtmlGenerator _htmlGenerator;
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        /// <summary>
+        /// Creates a new <see cref="TprContextBarTagHelper"/>.
+        /// </summary>
+        public TprRelatedLinksTagHelper()
+            : this(htmlGenerator: null)
         {
-            output.PreElement.SetHtmlContent($"<div class='{TagName} govuk-body {OuterStyles}'>");
-            output.TagName = "ul";
-            output.PostElement.SetHtmlContent("</div>");
+        }
+
+        internal TprRelatedLinksTagHelper(ITprHtmlGenerator? htmlGenerator)
+        {
+            _htmlGenerator = htmlGenerator ?? new ComponentGenerator();
+        }
+
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var relatedLinksContext = new TprRelatedLinksContext();
+
+            using (context.SetScopedContextItem(relatedLinksContext))
+            {
+                await output.GetChildContentAsync();
+            }
+
+            var tagBuilder = _htmlGenerator.GenerateTprRelatedLinks(new TprRelatedLinks
+            {
+                RelatedLinksAttributes = output.Attributes.ToAttributeDictionary(),
+                HeadingAttributes = relatedLinksContext.HeadingAttributes,
+                HeadingContent = relatedLinksContext.HeadingContent,
+                Links = relatedLinksContext.Links
+            });
+
+            output.TagName = tagBuilder.TagName;
+            output.TagMode = TagMode.StartTagAndEndTag;
+
+            output.Attributes.Clear();
+            output.MergeAttributes(tagBuilder);
+            output.Content.SetHtmlContent(tagBuilder.InnerHtml);
         }
     }
 }

--- a/docs/components/tpr-related-links.md
+++ b/docs/components/tpr-related-links.md
@@ -2,7 +2,7 @@
 
 A design component for the related links column which can be re-used on TPR sites. This component is implemented using tag helpers and can be used in both ASP.NET applications and Umbraco.
 
-## ASP.NET example
+## Example
 
 ```razor
 <tpr-related-links>
@@ -16,68 +16,38 @@ A design component for the related links column which can be re-used on TPR site
 In ASP.NET applications the related links component is structured like so, replacing the example heading and example link placeholders with the required content.
 
 If the tag helpers are arranged like the example above, then it should render the following html code:
+
 ```html
-<div class='tpr-related-links govuk-body '>
-    <ul>
-        <li>
-            <h2>Related links example heading</h2>
-        </li>
-        <li>
-            <a href="/">Example link 1</a>
-        </li>
-        <li>
-            <a href="/">Example link 2</a>
-        </li>
-        <li>
-            <a href="/">Example link 3</a>
-        </li>
-    </ul>
+<div class="tpr-related-links">
+  <h2 class="govuk-heading-m">Related links example heading</h2>
+  <ul class="govuk-list">
+    <li>
+      <a href="/" class="govuk-link">Example link 1</a>
+    </li>
+    <li>
+      <a href="/" class="govuk-link">Example link 2</a>
+    </li>
+    <li>
+      <a href="/" class="govuk-link">Example link 3</a>
+    </li>
+  </ul>
 </div>
 ```
 
 ![TPR related links ASP.NET example](../images/tpr-related-links-asp.net-example.png)
 
-## Umbraco example
+## Umbraco
 
 The 'TPR Related Links' block which is supported on the 'TPR Block Grid' component is used to implement this component in Umbraco. The related links component should only be used in the right-side column of the 'Two thirds / One third' column layout.
 
-![TPR related links umbraco example](../images/tpr-related-links-umbraco-example.png)
+![TPR related links Umbraco example](../images/tpr-related-links-umbraco-example.png)
 
 To implement this component you should select the 'TPR related links' block:
 
-![TPR related links umbraco block](../images/tpr-related-links-umbraco-block.png)
+![TPR related links Umbraco block](../images/tpr-related-links-umbraco-block.png)
 
 Then you can add a relevant heading as well as whatever related links are needed for the page:
 
-![TPR related links umbraco block content](../images/tpr-related-links-umbraco-block-content.png)
+![TPR related links Umbraco block content](../images/tpr-related-links-umbraco-block-content.png)
 
 If the heading is left empty then it will search for a dictionary entry under the 'Translation' tab in Umbraco called 'TPR Related links heading', if there is no dictionary entry under that name then the heading will default to 'Related'.
-
-```razor
-@using Umbraco.Cms.Core.Models
-@using Umbraco.Cms.Web.Common
-@using GovUkPropertyAliases = GovUk.Frontend.Umbraco.PropertyAliases
-@using TprPropertyAliases = ThePensionsRegulator.Frontend.Umbraco.PropertyAliases
-@inject UmbracoHelper Umbraco
-@addTagHelper *, ThePensionsRegulator.Frontend
-
-@{
-    var cssClasses = Model.Settings.Value<string>(GovUkPropertyAliases.CssClasses);
-    var heading = Model.Content.Value<string>(TprPropertyAliases.TprRelatedLinksHeading);
-    var links = Model.Content.Value<IEnumerable<Link>>(TprPropertyAliases.TprRelatedLinksLinks);
-
-    if (string.IsNullOrEmpty(heading)) {
-        heading = Umbraco.GetDictionaryValueOrDefault("TPR Related links heading", "Related");
-    }
-}
-
-<tpr-related-links outer-styles="@cssClasses">
-
-    <tpr-related-links-heading>@heading</tpr-related-links-heading>
-
-    @foreach (var link in links) {
-        <tpr-related-link href="@link.Url">@link.Name</tpr-related-link>
-    }
-
-</tpr-related-links>
-```


### PR DESCRIPTION
Incorrect HTML and a number of other issues in #395 are addressed in this PR:

- restructure the tag helper so that it does not require `ul` to be a root element
- remove duplicate styles
- rename the example page doc type so that it's not included in the package
- rename the related links document types for consistency
- fix an issue with the backoffice preview when falling back to the default heading
- update docs