### PR TITLE
In section cards use GOV.UK / TPR standards for CSS and fix HTML/CSS bugs

### DIFF
--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSectionCards.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSectionCards.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.Rendering;
+﻿using GovUk.Frontend.AspNetCore;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace ThePensionsRegulator.Frontend.HtmlGeneration
 {
@@ -8,31 +9,33 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         {
             var ulTag = new TagBuilder("ul");
             if (tprSectionCards.ContainerAttributes != null) { ulTag.MergeAttributes(tprSectionCards.ContainerAttributes); }
-            ulTag.AddCssClass("tpr-sectioncards-container govuk-list ");
+            ulTag.MergeCssClass("tpr-sectioncards-container");
+            ulTag.MergeCssClass("govuk-list");
 
             foreach (var card in tprSectionCards.Cards)
             {
                 var tprSectionCard = new TagBuilder("li");
                 if (card.CardAttributes != null) { tprSectionCard.MergeAttributes(card.CardAttributes); }
-                tprSectionCard.AddCssClass("tpr-sectioncards");
+                tprSectionCard.MergeCssClass("tpr-sectioncards");
 
                 var tprSectionCardBody = new TagBuilder("div");
-                tprSectionCardBody.AddCssClass("tpr-sectioncards__body");
+                tprSectionCardBody.MergeCssClass("tpr-sectioncards__body");
 
-                if (card.Title != null)
+                if (card.Title is not null && !string.IsNullOrWhiteSpace(card.Title.ToString()))
                 {
                     var tprSectionCardTitle = new TagBuilder("h2");
                     if (card.TitleAttributes != null) { tprSectionCardTitle.MergeAttributes(card.TitleAttributes); }
-                    tprSectionCardTitle.AddCssClass("tpr-sectioncards__title govuk-link");
+                    tprSectionCardTitle.MergeCssClass("tpr-sectioncards__title");
 
                     if (!string.IsNullOrEmpty(card.TitleUrl))
                     {
                         var anchorElement = new TagBuilder("a");
+                        anchorElement.MergeCssClass("govuk-link");
                         anchorElement.Attributes.Add("href", card.TitleUrl);
 
-                        if(!string.IsNullOrWhiteSpace(card.TitleTarget))
+                        if (!string.IsNullOrWhiteSpace(card.TitleTarget))
                         {
-                            anchorElement.Attributes.Add("target",card.TitleTarget);
+                            anchorElement.Attributes.Add("target", card.TitleTarget);
                         }
 
                         if (card.TitleAllowHtml)
@@ -61,9 +64,10 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                     tprSectionCardBody.InnerHtml.AppendHtml(tprSectionCardTitle);
                 }
 
-                if (card.Content != null)
+                if (card.Content is not null && !string.IsNullOrWhiteSpace(card.Content.ToString()))
                 {
-                    var tprSectionCardContent = new TagBuilder("p");
+                    var tprSectionCardContent = new TagBuilder("div");
+                    tprSectionCardContent.MergeCssClass("tpr-sectioncards__content");
                     if (card.ContentAttributes != null) { tprSectionCardContent.MergeAttributes(card.ContentAttributes); }
 
                     if (card.ContentAllowHtml)
@@ -72,7 +76,10 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                     }
                     else
                     {
-                        tprSectionCardContent.InnerHtml.Append(card.Content.ToString()!);
+                        var tprSectionCardPara = new TagBuilder("p");
+                        tprSectionCardPara.MergeCssClass("govuk-body");
+                        tprSectionCardPara.InnerHtml.Append(card.Content.ToString()!);
+                        tprSectionCardContent.InnerHtml.AppendHtml(tprSectionCardPara);
                     }
 
                     tprSectionCardBody.InnerHtml.AppendHtml(tprSectionCardContent);

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-section-cards.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-section-cards.scss
@@ -6,20 +6,22 @@
     flex-wrap: wrap;
     justify-content: left;
     margin-top: 0;
-    margin: 0px -15px;
-    padding: 0px;
+    margin-left: -$govuk-gutter-half;
+    margin-right: -$govuk-gutter-half;
+    @include govuk-responsive-margin(6, "bottom");
+    padding: 0;
     background: $tpr-colour-whisper;
 
     .tpr-box--full-width & {
         background: transparent;
-        margin: 0px -45px;
+        margin-left: $govuk-gutter*-1.5;
+        margin-right: $govuk-gutter*-1.5;
     }
 
     @include govuk-media-query($from:1020px) {
-        margin: 0px -15px;
-
         .tpr-box--full-width & {
-            margin: 0px -15px;
+            margin-left: -$govuk-gutter-half;
+            margin-right: -$govuk-gutter-half;
         }
     }
 }
@@ -38,22 +40,25 @@
     @include govuk-media-query($until:tablet) {
         max-width: 100%;
     }
+}
 
+.tpr-sectioncards__body {
+    background-color: $tpr-colour-white;
+    margin: 0;
+    @include govuk-responsive-padding(6);
+    margin: 0.9rem;
+    flex-grow: 1;
+}
 
-    .tpr-sectioncards__body {
-        background-color: white;
-        margin: 0;
-        @include govuk-responsive-padding(6);
-        margin: 0.9rem;
-        flex-grow: 1;
+.tpr-sectioncards__content {
+    @include govuk-responsive-padding(4, "top");
 
-        p {
-            margin-bottom: 0;
-        }
+    > :last-child {
+        margin-bottom: 0;
     }
 }
 
-h2.tpr-sectioncards__title {
+.tpr-sectioncards__title {
     @include govuk-responsive-padding(6,"right");
     @include govuk-responsive-padding(6,"bottom");
     @include govuk-responsive-padding(6,"left");


### PR DESCRIPTION
- Use `MergeCssClass` instead of `AddCssClass` to check for duplicates
- Check for whitespace titles and content
- `.govuk-link` was applied incorrectly to the `h2` when it should always apply to an `a` element
- when rich text HTML was used the HTML was `<p><p class="govuk-body">...</p></p>`, and without HTML it was `<p>...</p>` instead of `<p class="govuk-body">...</p>`. Introduce an extra `<div class="tpr-sectionboxes__content">...</div>` to fix that.
- use GOV.UK and TPR variables in CSS where possible
- add bottom margin to the section boxes component similar to all other components, to separate it from the next component when present (the example page demonstrated that this spacing was missing)
- remove redundant margin setting to `-15px` in `1020px` media query when it was already set that way
- replace `.tpr-sectioncards__body p` CSS selector with `.tpr-sectioncards__body > :last-child` so that it is not incorrectly applied to multiple paragraphs, and is now applied when ending with a list rather than a paragraph
- reduce hierarchy in CSS selectors to use simple classes, to be consistent with existing GOV.UK and TPR approach and save a few bytes

Addresses issues in #397