### PR TITLE
Add a TPR consent cookie reader

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Security/IConsentCookieReader.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Security/IConsentCookieReader.cs
@@ -1,0 +1,17 @@
+﻿namespace GovUk.Frontend.AspNetCore.Extensions.Security
+{
+    public interface IConsentCookieReader
+    {
+        /// <summary>
+        /// Checks whether the user has granted their consent to all cookies.
+        /// </summary>
+        /// <returns><c>true</c> if consent granted. <c>false</c> if consent refused, or no response recorded.</returns>
+        bool HasConsent();
+
+        /// <summary>
+        /// Checks whether the user has granted their consent to a specific category of cookies.
+        /// </summary>
+        /// <returns><c>true</c> if consent granted. <c>false</c> if consent refused, or no response recorded.</returns>
+        bool HasConsent(string category);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ We target [GOV.UK Frontend v5.2.0](https://github.com/alphagov/govuk-frontend/re
 - [Configure a new ASP.NET project (TPR)](docs/aspnet/new-aspnet-project-tpr.md)
 - [Localisation and validation in ASP.NET projects](docs/aspnet/localisation-and-validation.md)
 - [Use SASS for CSS](docs/aspnet/sass.md)
+- [Read the TPR consent cookie](docs/aspnet/consent-cookie.md)
 
 ASP.NET support for GOV.UK Design System components is published on NuGet as [ThePensionsRegulator.GovUk.Frontend](https://www.nuget.org/packages/ThePensionsRegulator.GovUk.Frontend)
 

--- a/ThePensionsRegulator.Frontend.Tests/Security/TprConsentCookieReaderTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Security/TprConsentCookieReaderTests.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+using Moq;
+using ThePensionsRegulator.Frontend.Security;
+
+namespace ThePensionsRegulator.Frontend.Tests.Security
+{
+    public class TprConsentCookieReaderTests
+    {
+        private readonly HttpContext _context = new DefaultHttpContext();
+        private readonly Mock<IHttpContextAccessor> _contextAccessor = new();
+
+        public TprConsentCookieReaderTests()
+        {
+            _contextAccessor.Setup(x => x.HttpContext).Returns(_context);
+        }
+
+        private static IRequestCookieCollection MockRequestCookieCollection(string key, string value)
+        {
+            var requestFeature = new HttpRequestFeature();
+            var featureCollection = new FeatureCollection();
+
+            requestFeature.Headers = new HeaderDictionary();
+            requestFeature.Headers.Append(HeaderNames.Cookie, new StringValues(key + "=" + value));
+
+            featureCollection.Set<IHttpRequestFeature>(requestFeature);
+
+            var cookiesFeature = new RequestCookiesFeature(featureCollection);
+
+            return cookiesFeature.Cookies;
+        }
+
+        [Fact]
+        public void No_cookie_returns_false()
+        {
+            // Arrange
+            var reader = new TprConsentCookieReader(_contextAccessor.Object);
+
+            // Act
+            var result1 = reader.HasConsent();
+            var result2 = reader.HasConsent(TprConsentCookieReader.TPR_CONSENT_CATEGORY_PERFORMANCE);
+
+            // Assert
+            Assert.False(result1);
+            Assert.False(result2);
+        }
+
+        [Fact]
+        public void Reject_all_returns_false()
+        {
+            // Arrange
+            _context.Request.Cookies = MockRequestCookieCollection(TprConsentCookieReader.TPR_CONSENT_COOKIE_NAME, "Reject|");
+            var reader = new TprConsentCookieReader(_contextAccessor.Object);
+
+            // Act
+            var result1 = reader.HasConsent();
+            var result2 = reader.HasConsent(TprConsentCookieReader.TPR_CONSENT_CATEGORY_PERFORMANCE);
+
+            // Assert
+            Assert.False(result1);
+            Assert.False(result2);
+        }
+
+        [Fact]
+        public void Accept_all_returns_true()
+        {
+            // Arrange
+            _context.Request.Cookies = MockRequestCookieCollection(TprConsentCookieReader.TPR_CONSENT_COOKIE_NAME, "All|");
+            var reader = new TprConsentCookieReader(_contextAccessor.Object);
+
+            // Act
+            var result1 = reader.HasConsent();
+            var result2 = reader.HasConsent(TprConsentCookieReader.TPR_CONSENT_CATEGORY_PERFORMANCE);
+
+            // Assert
+            Assert.True(result1);
+            Assert.True(result2);
+        }
+
+        [Theory]
+        [InlineData(TprConsentCookieReader.TPR_CONSENT_CATEGORY_PERFORMANCE, true)]
+        [InlineData(TprConsentCookieReader.TPR_CONSENT_CATEGORY_FUNCTIONALITY, true)]
+        [InlineData(TprConsentCookieReader.TPR_CONSENT_CATEGORY_TARGETING, false)]
+        public void Partial_consent_returns_correct_response(string category, bool expectedResponse)
+        {
+            // Arrange
+            _context.Request.Cookies = MockRequestCookieCollection(TprConsentCookieReader.TPR_CONSENT_COOKIE_NAME, "performance=On|functionality=On|targeting=Off|");
+            var reader = new TprConsentCookieReader(_contextAccessor.Object);
+
+            // Act
+            var result = reader.HasConsent(category);
+
+            // Assert
+            Assert.Equal(expectedResponse, result);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprContextBarTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprContextBarTagHelperTests.cs
@@ -8,12 +8,11 @@ using System.Text.Encodings.Web;
 using ThePensionsRegulator.Frontend.HtmlGeneration;
 using ThePensionsRegulator.Frontend.TagHelpers;
 
-namespace ThePensionsRegulator.Frontend.Tests
+namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
 {
-    [TestFixture]
     public class TprContextBarTagHelperTests
     {
-        [Test]
+        [Fact]
         public async Task All_3_contexts_empty_does_not_render_bar()
         {
             // Arrange
@@ -34,7 +33,7 @@ namespace ThePensionsRegulator.Frontend.Tests
             Assert.True(string.IsNullOrEmpty(result.ToString()));
         }
 
-        [Test]
+        [Fact]
         public async Task Context_1_content_is_rendered()
         {
             // Arrange
@@ -60,7 +59,7 @@ namespace ThePensionsRegulator.Frontend.Tests
             htmlGenerator.Verify(x => x.GenerateTprContextBar(It.Is<TprContextBar>(bar => bar.Context1Content != null && bar.Context1Content.ToHtmlString() == CONTEXT_1_CONTENT)), Times.Once);
         }
 
-        [Test]
+        [Fact]
         public async Task Context_2_content_is_rendered()
         {
             // Arrange
@@ -86,7 +85,7 @@ namespace ThePensionsRegulator.Frontend.Tests
             htmlGenerator.Verify(x => x.GenerateTprContextBar(It.Is<TprContextBar>(bar => bar.Context2Content != null && bar.Context2Content.ToHtmlString() == CONTEXT_2_CONTENT)), Times.Once);
         }
 
-        [Test]
+        [Fact]
         public async Task Context_3_content_is_rendered()
         {
             // Arrange

--- a/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
@@ -12,16 +12,15 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.Frontend.Tests/Usings.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Usings.cs
@@ -1,1 +1,1 @@
-global using NUnit.Framework;
+global using Xunit;

--- a/ThePensionsRegulator.Frontend.Tests/xunit.runner.json
+++ b/ThePensionsRegulator.Frontend.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "ReplaceUnderscoreWithSpace"
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
 using GovUk.Frontend.AspNetCore;
+using GovUk.Frontend.AspNetCore.Extensions.Security;
 using GovUk.Frontend.Umbraco;
 using GovUk.Frontend.Umbraco.Blocks;
 using GovUk.Frontend.Umbraco.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using ThePensionsRegulator.Frontend.Security;
 using ThePensionsRegulator.Frontend.Services;
 using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors;
 using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
@@ -43,6 +45,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
 
             services.AddGovUkFrontendUmbraco(configureGovUkOptions, configureGovUkUmbracoOptions);
 
+            services.AddTransient<IConsentCookieReader, TprConsentCookieReader>();
             services.AddTransient<IContextAwareHostUpdater, TprHostUpdater>();
             services.AddTransient<IPropertyValueFormatter, HostNameInRichTextEditorPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, HostNameInMultiUrlPickerPropertyValueFormatter>();

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRYouTubeVideo.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRYouTubeVideo.cshtml
@@ -1,8 +1,11 @@
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>;
 @addTagHelper *, ThePensionsRegulator.Frontend
 @inject IYouTubeVideoIdParser videoIdParser
+@inject IConsentCookieReader consentCookie
+@using GovUk.Frontend.AspNetCore.Extensions.Security
 @using GovUk.Frontend.Umbraco.Models
 @using GovUk.Frontend.Umbraco;
+@using ThePensionsRegulator.Frontend.Security
 @using ThePensionsRegulator.Frontend.Umbraco
 @using ThePensionsRegulator.Frontend.Umbraco.Services
 @using ThePensionsRegulator.Umbraco.Blocks;
@@ -14,10 +17,12 @@
 @{
     @* TODO: Since AblePlayer support is incomplete (see https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/issues/381)
        the following condition is set to false and therefore the default YouTube embed iFrame is always used. 
-       
-       If AblePlayer is enabled it will set cookies, so check for consent first.
        *@
     var useAblePlayer = false;
+    if (useAblePlayer)
+    {
+        if (!consentCookie.HasConsent(TprConsentCookieReader.TPR_CONSENT_CATEGORY_FUNCTIONALITY)){ useAblePlayer = false; }
+    }
     var videoUrl = Model.Content.Value<string>(TprPropertyAliases.VideoUrl);
     if(string.IsNullOrWhiteSpace(videoUrl))
     {

--- a/ThePensionsRegulator.Frontend/Security/TprConsentCookieReader.cs
+++ b/ThePensionsRegulator.Frontend/Security/TprConsentCookieReader.cs
@@ -1,0 +1,46 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Security;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Linq;
+
+namespace ThePensionsRegulator.Frontend.Security
+{
+    public class TprConsentCookieReader : IConsentCookieReader
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        public const string TPR_CONSENT_COOKIE_NAME = "TPR_Cookie_CONSENT";
+        public const string TPR_CONSENT_CATEGORY_PERFORMANCE = "performance";
+        public const string TPR_CONSENT_CATEGORY_FUNCTIONALITY = "functionality";
+        public const string TPR_CONSENT_CATEGORY_TARGETING = "targeting";
+
+        public TprConsentCookieReader(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        }
+
+        /// <inheritdoc/>
+        public bool HasConsent()
+        {
+            var context = _httpContextAccessor.HttpContext ?? throw new InvalidOperationException("HttpContext cannot be null");
+            return (context.Request.Cookies.TryGetValue(TPR_CONSENT_COOKIE_NAME, out var cookieValue) && cookieValue == "All|");
+        }
+
+        /// <inheritdoc/>
+        public bool HasConsent(string category)
+        {
+            var context = _httpContextAccessor.HttpContext ?? throw new InvalidOperationException("HttpContext cannot be null");
+            if (context.Request.Cookies.TryGetValue(TPR_CONSENT_COOKIE_NAME, out var cookieValue))
+            {
+                if (cookieValue == "All|") { return true; }
+                if (cookieValue == "Reject|") { return false; }
+                var categories = cookieValue.Split('|').Select(x => x.Split('='));
+                foreach (var consentCategory in categories)
+                {
+                    if (consentCategory.Count() != 2) { throw new InvalidOperationException($"Invalid TPR consent cookie value {cookieValue}"); }
+                    if (consentCategory[0].Equals(category, StringComparison.OrdinalIgnoreCase)) { return consentCategory[1] == "On"; }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
 using GovUk.Frontend.AspNetCore;
 using GovUk.Frontend.AspNetCore.Extensions;
+using GovUk.Frontend.AspNetCore.Extensions.Security;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using ThePensionsRegulator.Frontend.Security;
+using ThePensionsRegulator.Frontend.Services;
 
 namespace ThePensionsRegulator.Frontend
 {
@@ -20,6 +23,9 @@ namespace ThePensionsRegulator.Frontend
             {
                 throw new ArgumentNullException(nameof(services));
             }
+
+            services.AddTransient<IContextAwareHostUpdater, TprHostUpdater>();
+            services.AddTransient<IConsentCookieReader, TprConsentCookieReader>();
 
             services.AddGovUkFrontendExtensions(options);
             return services;

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/AblePlayer.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/AblePlayer.cshtml
@@ -1,17 +1,16 @@
+@using GovUk.Frontend.AspNetCore.Extensions.Security
 @using Microsoft.CSharp.RuntimeBinder
+@using ThePensionsRegulator.Frontend.Security
+@inject IConsentCookieReader consentCookie
 @{
-    // TODO: If AblePlayer is enabled it will set cookies, so check for consent first.
-    // if(cookieConsent == false)
-    // {
-    //     return;
-    // }
-    // 
+    // If AblePlayer is enabled it will set cookies, so check for consent first.
+    if (!consentCookie.HasConsent(TprConsentCookieReader.TPR_CONSENT_CATEGORY_FUNCTIONALITY)){ return; }
+    
     // TODO: jQuery is also a dependency for ASP.NET validation and is included in this repo (see Validation.cshtml).
     //       so we need to ensure it's not included in different ways or with multiple copies per page.
     //       Review and consoldidate approach to client-side third-party dependencies before releasing Able Player support.
     //       See https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/issues/381
 }
-
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js" integrity="sha384-ETDm/j6COkRSUfVFsGNM5WYE4WjyRgfDhy4Pf4Fsc8eNw/eYEMqYZWuxTzMX6FBa" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/_content/ThePensionsRegulator.Frontend/lib/ableplayer/build/ableplayer.min.css" type="text/css" />

--- a/docs/aspnet/consent-cookie.md
+++ b/docs/aspnet/consent-cookie.md
@@ -1,0 +1,18 @@
+# Read the TPR consent cookie
+
+Applications can implement `IConsentCookieReader` to read their consent cookie, and any use of cookies in these packages will respect that consent.
+
+TPR has a single consent cookie that is valid across the public `*.thepensionsregulator.gov.uk` domain. This is read by `TprConsentCookieReader` which implements `IConsentCookieReader` in the `ThePensionsRegulator.Frontend` package.
+
+```razor
+@using GovUk.Frontend.AspNetCore.Extensions.Security
+@using ThePensionsRegulator.Frontend.Security
+@inject IConsentCookieReader consentCookie
+
+@if (consentCookie.HasConsent(TprConsentCookieReader.TPR_CONSENT_CATEGORY_FUNCTIONALITY))
+{
+    // do protected activity
+}
+```
+
+The `TprConsentCookieReader` class contains constants representing each category of consent which can be granted for the `*.thepensionsregulator.gov.uk` domain.


### PR DESCRIPTION
This PR:
- creates an `IConsentCookieReader` interface that could be implemented for any consent cookie
- implements and documents `TprConsentCookieReader` to read the TPR consent cookie
- adds consent cookie checks to the code for Able Player
- converts the affected test project from NUnit to Xunit to reflect the current TPR standard

Completes a task on  #381