### PR TITLE
Added objects SCSS folder to the package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.1.0</Version>
+    <Version>8.1.1</Version>
     </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -121,7 +121,10 @@
 			<Pack>true</Pack>
 			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\govuk\vendor</PackagePath>
 		</Content>
-
+		<Content Include="$(GovUkFrontEndSrcFolder)\govuk\objects\*.scss" Link="$(MsBuildThisFileDirectory)">
+			<Pack>true</Pack>
+			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\govuk\objects</PackagePath>
+		</Content>
 		<None Include="..\tpr-nuget.png">
 		  <Pack>True</Pack>
 		  <PackagePath>\</PackagePath>


### PR DESCRIPTION
In order to create custom width containers using then provided GDS mixins, we need to provide access to the objects folder where the _width-container file lives.