### PR TITLE
Pipeline build was not including TPR uSync files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ steps:
       command: "build"
       arguments: --configuration $(buildConfiguration)
       projects: |
-        $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\GovUk.Frontend.Umbraco\GovUk.Frontend.Umbraco.csproj
+        $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Frontend.Umbraco\ThePensionsRegulator.Frontend.Umbraco.csproj
         $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Umbraco.Testing\ThePensionsRegulator.Umbraco.Testing.csproj
 
   - task: DotNetCoreCLI@2
@@ -120,7 +120,6 @@ steps:
 
   - task: CopyFiles@2
     displayName: Copy GovUk.Frontend package to staging folder
-    condition: and(succeeded(), eq(variables.pushPackages, true))
     inputs:
       SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\GovUk.Frontend.AspNetCore.Extensions\bin\$(buildConfiguration)
       Contents: |
@@ -131,7 +130,6 @@ steps:
 
   - task: CopyFiles@2
     displayName: Copy ThePensionsRegulator.Umbraco package to staging folder
-    condition: and(succeeded(), eq(variables.pushPackages, true))
     inputs:
       SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Umbraco\bin\$(buildConfiguration)
       Contents: |
@@ -142,7 +140,6 @@ steps:
 
   - task: CopyFiles@2
     displayName: Copy ThePensionsRegulator.Frontend package to staging folder
-    condition: and(succeeded(), eq(variables.pushPackages, true))
     inputs:
       SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Frontend\bin\$(buildConfiguration)
       Contents: |
@@ -153,7 +150,6 @@ steps:
 
   - task: CopyFiles@2
     displayName: Copy GovUk.Frontend.Umbraco package to staging folder
-    condition: and(succeeded(), eq(variables.pushPackages, true))
     inputs:
       SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\GovUk.Frontend.Umbraco\bin\$(buildConfiguration)
       Contents: |
@@ -164,7 +160,6 @@ steps:
 
   - task: CopyFiles@2
     displayName: Copy ThePensionsRegulator.Frontend.Umbraco package to staging folder
-    condition: and(succeeded(), eq(variables.pushPackages, true))
     inputs:
       SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Frontend.Umbraco\bin\$(buildConfiguration)
       Contents: |
@@ -175,7 +170,6 @@ steps:
 
   - task: CopyFiles@2
     displayName: Copy ThePensionsRegulator.Umbraco.Testing package to staging folder
-    condition: and(succeeded(), eq(variables.pushPackages, true))
     inputs:
       SourceFolder: $(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Umbraco.Testing\bin\$(buildConfiguration)
       Contents: |
@@ -192,3 +186,10 @@ steps:
       packagesToPush: "$(Build.ArtifactStagingDirectory)/**/*.nupkg"
       nuGetFeedType: external
       publishFeedCredentials: NUGET
+
+  - task: PublishPipelineArtifact@1
+    condition: not(eq(variables.pushPackages, true))
+    displayName: "Publish packages as artifact"
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: packages


### PR DESCRIPTION
The pipeline build was not including TPR uSync files in ThePensionsRegulator.Frontend.Umbraco package. The local build was fine. This led to v8.0.0 and v8.1.0 being published with essential files missing.

This was caused by a bug that's been around a long time, but just got more important. The pipeline was not building all the projects it was packaging, meaning that build actions in ThePensionsRegulator.Frontend.Umbraco were not being run.

I've also updated the pipeline so that when we don't publish to nuget.org, we instead get packages published to the pipeline so that we can inspect the result.

[AB#227959](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/227959)