### PR TITLE
#436 / AB#225624 - Extend consent cookie reader to check for user cookie presence

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Security/IConsentCookieReader.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Security/IConsentCookieReader.cs
@@ -13,5 +13,11 @@
         /// </summary>
         /// <returns><c>true</c> if consent granted. <c>false</c> if consent refused, or no response recorded.</returns>
         bool HasConsent(string category);
+
+        /// <summary>
+        /// Checks whether the consent cookie is present in the user browser.
+        /// </summary>
+        /// <returns><c>true</c> if cookie is present. <c>false</c> if cookie is not present.</returns>
+        bool IsConsentCookiePresent();
     }
 }

--- a/ThePensionsRegulator.Frontend.Tests/Security/TprConsentCookieReaderTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Security/TprConsentCookieReaderTests.cs
@@ -17,14 +17,15 @@ namespace ThePensionsRegulator.Frontend.Tests.Security
             _contextAccessor.Setup(x => x.HttpContext).Returns(_context);
         }
 
-        private static IRequestCookieCollection MockRequestCookieCollection(string key, string value)
+        private static IRequestCookieCollection MockRequestCookieCollection(string key, string? value)
         {
             var requestFeature = new HttpRequestFeature();
             var featureCollection = new FeatureCollection();
 
             requestFeature.Headers = new HeaderDictionary();
-            requestFeature.Headers.Append(HeaderNames.Cookie, new StringValues(key + "=" + value));
-
+            if (value != null) {
+                requestFeature.Headers.Append(HeaderNames.Cookie, new StringValues(key + "=" + value));
+            }
             featureCollection.Set<IHttpRequestFeature>(requestFeature);
 
             var cookiesFeature = new RequestCookiesFeature(featureCollection);
@@ -91,6 +92,25 @@ namespace ThePensionsRegulator.Frontend.Tests.Security
 
             // Act
             var result = reader.HasConsent(category);
+
+            // Assert
+            Assert.Equal(expectedResponse, result);
+        }
+
+        [Theory]
+        [InlineData($"{TprConsentCookieReader.TPR_CONSENT_COOKIE_NAME}=All|", true)]
+        [InlineData($"{TprConsentCookieReader.TPR_CONSENT_COOKIE_NAME}=Reject|", true)]
+        [InlineData($"{TprConsentCookieReader.TPR_CONSENT_COOKIE_NAME}={TprConsentCookieReader.TPR_CONSENT_CATEGORY_FUNCTIONALITY}=On|", true)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void Validate_ConsentCookie_Presence(string? cookieValue, bool expectedResponse)
+        {
+            // Arrange
+            _context.Request.Cookies = MockRequestCookieCollection(TprConsentCookieReader.TPR_CONSENT_COOKIE_NAME, cookieValue);
+            var reader = new TprConsentCookieReader(_contextAccessor.Object);
+
+            // Act
+            var result = reader.IsConsentCookiePresent();
 
             // Assert
             Assert.Equal(expectedResponse, result);

--- a/ThePensionsRegulator.Frontend/Security/TprConsentCookieReader.cs
+++ b/ThePensionsRegulator.Frontend/Security/TprConsentCookieReader.cs
@@ -42,5 +42,12 @@ namespace ThePensionsRegulator.Frontend.Security
             }
             return false;
         }
+
+        public bool IsConsentCookiePresent()
+        {
+            var context = _httpContextAccessor.HttpContext ?? throw new InvalidOperationException("HttpContext cannot be null");
+            return context.Request?.Cookies != null 
+                && context.Request.Cookies.Any(x=>x.Key.Equals(TPR_CONSENT_COOKIE_NAME,StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/docs/aspnet/consent-cookie.md
+++ b/docs/aspnet/consent-cookie.md
@@ -14,5 +14,17 @@ TPR has a single consent cookie that is valid across the public `*.thepensionsre
     // do protected activity
 }
 ```
+Aditionally, subscribers can test for the consent cookie presence to assess whether a user has explicitly specified cookie consent levels.
+
+```razor
+@using GovUk.Frontend.AspNetCore.Extensions.Security
+@using ThePensionsRegulator.Frontend.Security
+@inject IConsentCookieReader consentCookie
+
+@if (!consentCookie.IsConsentCookiePresent())
+{
+    // Display cookie banner, and collect user preferences
+}
+```
 
 The `TprConsentCookieReader` class contains constants representing each category of consent which can be granted for the `*.thepensionsregulator.gov.uk` domain.


### PR DESCRIPTION
Added support to check for the consent cookie presence 