### PR TITLE
Enable superscript, subscript and inserting symbols in rich text areas

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditor.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditor.config
@@ -7,7 +7,7 @@
     <Folder>GOV.UK</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
       "styles",
@@ -17,7 +17,10 @@
       "numlist",
       "link",
       "unlink",
-      "table"
+      "table",
+      "subscript",
+      "superscript",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
@@ -7,7 +7,7 @@
     <Folder>GOV.UK</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
       "styles",
@@ -17,7 +17,10 @@
       "numlist",
       "link",
       "unlink",
-      "table"
+      "table",
+      "subscript",
+      "superscript",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInlineAndInverse.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInlineAndInverse.config
@@ -7,7 +7,7 @@
     <Folder>GOV.UK</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
       "styles",
@@ -17,7 +17,10 @@
       "numlist",
       "link",
       "unlink",
-      "table"
+      "table",
+      "subscript",
+      "superscript",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorPhaseBanner.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorPhaseBanner.config
@@ -7,13 +7,14 @@
     <Folder>GOV.UK</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
       "bold",
       "italic",
       "link",
-      "unlink"
+      "unlink",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorSummaryListItem.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorSummaryListItem.config
@@ -7,7 +7,7 @@
     <Folder>GOV.UK</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
       "bold",
@@ -15,7 +15,10 @@
       "bullist",
       "numlist",
       "link",
-      "unlink"
+      "unlink",
+      "subscript",
+      "superscript",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorTask.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorTask.config
@@ -7,11 +7,14 @@
     <Folder>GOV.UK</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
       "bold",
-      "italic"
+      "italic",
+      "subscript",
+      "superscript",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
@@ -7,7 +7,7 @@
     <Folder>GOV.UK</Folder>
   </Info>
   <Config><![CDATA[{
-  "Blocks": null,
+  "Blocks": [],
   "Editor": {
     "toolbar": [
       "styles",
@@ -17,7 +17,10 @@
       "numlist",
       "link",
       "unlink",
-      "table"
+      "table",
+      "subscript",
+      "superscript",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRRichTextEditorHeaderAndFooter.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRRichTextEditorHeaderAndFooter.config
@@ -12,7 +12,8 @@
     "toolbar": [
       "bullist",
       "link",
-      "unlink"
+      "unlink",
+      "charmap"
     ],
     "stylesheets": [],
     "maxImageSize": 500,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRRichTextEditorSectionCard.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRRichTextEditorSectionCard.config
@@ -15,7 +15,10 @@
       "italic",
       "bullist",
       "numlist",
-      "link"
+      "link",
+      "subscript",
+      "superscript",
+      "charmap"
     ],
     "stylesheets": [
       "/css/govuk-umbraco-backoffice.css",


### PR DESCRIPTION
Fixes [AB#231918](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/231918)