### PR TITLE
Bullet and numeric styles were not displayed correctly in backoffice previews

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/typography.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/typography.config
@@ -42,53 +42,53 @@
   },
   "contentData": [
     {
+      "caption": "Example application in Umbraco",
       "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
-      "udi": "umb://element/d9f263c5a379442ca3670d45445ccf92",
-      "caption": "Example application in Umbraco"
+      "udi": "umb://element/d9f263c5a379442ca3670d45445ccf92"
     },
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
-      "udi": "umb://element/04d3231dbc1943a5a384504b4ad1a805",
-      "text": ""
+      "text": "",
+      "udi": "umb://element/04d3231dbc1943a5a384504b4ad1a805"
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
-      "udi": "umb://element/71e9f75cdd8a4eb1b2609cb4912fa37b",
       "text": {
-        "markup": "<p class=\"govuk-body\">This text and this application is using&nbsp;<a href=\"https://design-system.service.gov.uk/styles/typography/\" class=\"govuk-link\">GOV.UK Design System typography</a>.</p>\n<p class=\"govuk-body\">Typical pages start heading sizes at using&nbsp;<em>govuk-heading-l</em>. Where pages are expected to have deeply nested section hierarchies, we use&nbsp;<a href=\"/{localLink:umb://document/cccc7f8f877447de8f2d336d4b754377}\" class=\"govuk-link\">larger headings</a>.</p>\n<p class=\"govuk-body\">The heading above demonstrates the type scale at Heading 1, using&nbsp;<em>govuk-heading-l</em>.</p>\n<h2 class=\"govuk-heading-m\">Heading 2</h2>\n<p class=\"govuk-body\">On a typical page this is the type scale for headings.</p>\n<h3 class=\"govuk-heading-s\">Heading 3</h3>\n<p class=\"govuk-body\">On a typical page this is the type scale for headings. We would not expect to need headings beyond Heading 3.</p>",
+        "markup": "<p class=\"govuk-body\">This text and this application is using&nbsp;<a href=\"https://design-system.service.gov.uk/styles/typography/\" class=\"govuk-link\">GOV.UK Design System typography</a>.</p>\n<p class=\"govuk-body\">Typical pages start heading sizes at using&nbsp;<em>govuk-heading-l</em>. Where pages are expected to have deeply nested section hierarchies, we use&nbsp;<a href=\"/{localLink:umb://document/cccc7f8f877447de8f2d336d4b754377}\" class=\"govuk-link\">larger headings</a>.</p>\n<p class=\"govuk-body\">The heading above demonstrates the type scale at Heading 1, using&nbsp;<em>govuk-heading-l</em>.</p>\n<h2 class=\"govuk-heading-m\">Heading 2</h2>\n<p class=\"govuk-body\">On a typical page this is the type scale for headings.</p>\n<h3 class=\"govuk-heading-s\">Heading 3</h3>\n<p class=\"govuk-body\">On a typical page this is the type scale for headings. We would not expect to need headings beyond Heading 3.</p>\n<h2 class=\"govuk-heading-m\">Unordered lists</h2>\n<p class=\"govuk-body\">The unordered list toolbar button in Umbraco supports three styles, and these style settings should be rendered on the page.</p>\n<ul>\n<li>filled circles</li>\n<li>filled circles</li>\n</ul>\n<ul style=\"list-style-type: circle;\">\n<li>empty circles</li>\n<li>empty circles</li>\n</ul>\n<ul style=\"list-style-type: square;\">\n<li>filled squares</li>\n<li>filled squares</li>\n</ul>\n<h2 class=\"govuk-heading-m\">Ordered lists</h2>\n<p>The ordered list toolbar button in Umbraco supports six styles, and these style settings should be rendered on the page.</p>\n<ol>\n<li>Arabic numerals</li>\n<li>Arabic numerals</li>\n</ol>\n<ol style=\"list-style-type: lower-alpha;\">\n<li>Lowercase alpha</li>\n<li>Lowercase alpha</li>\n</ol>\n<ol style=\"list-style-type: upper-alpha;\">\n<li>Uppercase alpha</li>\n<li>Uppercase alpha</li>\n</ol>\n<ol style=\"list-style-type: lower-roman;\">\n<li>Lowercase Roman</li>\n<li>Lowercase Roman</li>\n</ol>\n<ol style=\"list-style-type: upper-roman;\">\n<li>Uppercase Roman</li>\n<li>Uppercase Roman</li>\n</ol>\n<ol style=\"list-style-type: lower-greek;\">\n<li>Lowercase Greek</li>\n<li>Lowercase Greek</li>\n</ol>",
         "blocks": {
           "contentData": [],
           "settingsData": []
         }
-      }
+      },
+      "udi": "umb://element/71e9f75cdd8a4eb1b2609cb4912fa37b"
     }
   ],
   "settingsData": [
     {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
-      "udi": "umb://element/3bb63c6115234c08aed71bb242270a9e",
       "cssClasses": "",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/3bb63c6115234c08aed71bb242270a9e"
     },
     {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "6ca199b3-814c-4aa9-b466-fc0533f2b543",
-      "udi": "umb://element/b7940cb237284a89915ae7ffd198b653",
       "cssClasses": "",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/b7940cb237284a89915ae7ffd198b653"
     },
     {
-      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/c3ca4ca4bd094be699940eb90ba75dbd",
-      "cssClassesForRow": "",
       "columnSize": "",
       "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/c3ca4ca4bd094be699940eb90ba75dbd"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkCheckboxesPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkCheckboxesPreview.html
@@ -6,12 +6,12 @@
             <p class="backoffice-additional-blocks" ng-if="!block.data.fieldsetBlocks.contentData">No blocks.</p>
             <p class="backoffice-additional-blocks" ng-if="block.data.fieldsetBlocks.contentData.length===1">1 block.</p>
             <p class="backoffice-additional-blocks" ng-if="block.data.fieldsetBlocks.contentData.length>1">{{checkbox.fieldsetBlocks.contentData.length}} blocks.</p>
-            <div class="govuk-hint" ng-bind-html="block.data.hint.markup" ng-if="block.data.hint.markup"></div>
+            <div class="govuk-hint" ng-bind-html="block.data.hint.markup | safe_html" ng-if="block.data.hint.markup"></div>
             <div class="govuk-checkboxes">
                 <div class="govuk-checkboxes__item" ng-repeat="checkbox in block.data.checkboxes.contentData">
                     <input class="govuk-checkboxes__input" type="checkbox" value="{{checkbox.value}}">
                     <label class="govuk-checkboxes__label govuk-label">{{checkbox.label}}</label>
-                    <div class="govuk-checkboxes__hint govuk-hint" ng-bind-html="checkbox.hint.markup" ng-if="checkbox.hint.markup"></div>
+                    <div class="govuk-checkboxes__hint govuk-hint" ng-bind-html="checkbox.hint.markup | safe_html" ng-if="checkbox.hint.markup"></div>
                     <p class="backoffice-additional-blocks" ng-if="!checkbox.conditionalBlocks.contentData">No conditional blocks.</p>
                     <p class="backoffice-additional-blocks" ng-if="checkbox.conditionalBlocks.contentData.length===1">1 conditional block.</p>
                     <p class="backoffice-additional-blocks" ng-if="checkbox.conditionalBlocks.contentData.length>1">{{checkbox.conditionalBlocks.contentData.length}} conditional blocks.</p>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkDateInputPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkDateInputPreview.html
@@ -5,7 +5,7 @@
         <p class="backoffice-additional-blocks" ng-if="block.data.fieldsetBlocks.contentData.length===1">1 block.</p>
         <p class="backoffice-additional-blocks" ng-if="block.data.fieldsetBlocks.contentData.length>1">{{checkbox.fieldsetBlocks.contentData.length}} blocks.</p>
         <div class="govuk-form-group">
-            <div class="govuk-hint" ng-bind-html="block.data.hint.markup" ng-if="block.data.hint.markup"></div>
+            <div class="govuk-hint" ng-bind-html="block.data.hint.markup | safe_html" ng-if="block.data.hint.markup"></div>
             <div class="govuk-date-input">
                 <div class="govuk-date-input__item" ng-if="block.settingsData.showDay==='1'">
                     <div class="govuk-form-group">

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkFileUploadPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkFileUploadPreview.html
@@ -1,6 +1,6 @@
 ﻿<div class="govuk-form-group backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" aria-label="Edit file input component">
     <label class="govuk-label" ng-bind-html="block.data.label" aria-hidden="true"></label>
-    <div class="govuk-hint" ng-bind-html="block.data.hint.markup" ng-if="block.data.hint.markup" aria-hidden="true"></div>
+    <div class="govuk-hint" ng-bind-html="block.data.hint.markup | safe_html" ng-if="block.data.hint.markup" aria-hidden="true"></div>
     <input aria-hidden="true" ng-click="$event.preventDefault()" class="govuk-file-upload" type="file" />
 </div>
 

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkInsetTextPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkInsetTextPreview.html
@@ -1,1 +1,1 @@
-﻿<div class="govuk-inset-text backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.text.markup" aria-label="Edit inset text component"></div>
+﻿<div class="govuk-inset-text backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.text.markup | safe_html" aria-label="Edit inset text component"></div>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkNotificationBannerPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkNotificationBannerPreview.html
@@ -3,8 +3,8 @@
         <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title" ng-bind-html="block.settingsData.title || 'Important'"></h2>
     </div>
     <div class="govuk-notification-banner__content" aria-hidden="true">
-        <h3 class="govuk-notification-banner__heading" ng-bind-html="block.data.heading.markup"></h3>
-        <p class="govuk-body" ng-bind-html="block.data.text.markup" ng-if="block.data.text.markup != ''"></p>
+        <h3 class="govuk-notification-banner__heading" ng-bind-html="block.data.heading.markup | safe_html"></h3>
+        <p class="govuk-body" ng-bind-html="block.data.text.markup | safe_html" ng-if="block.data.text.markup != ''"></p>
         <p class="backoffice-additional-blocks" ng-if="!block.data.blocks.contentData">No blocks.</p>
         <p class="backoffice-additional-blocks" ng-if="block.data.blocks.contentData.length===1">1 block.</p>
         <p class="backoffice-additional-blocks" ng-if="block.data.blocks.contentData.length>1">{{checkbox.blocks.contentData.length}} blocks.</p>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkPanelPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkPanelPreview.html
@@ -1,4 +1,4 @@
 ﻿<div class="govuk-panel--confirmation govuk-panel backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" aria-label="Edit panel component">
     <h1 class="govuk-panel__title" aria-hidden="true" ng-bind-html="block.data.panelHeading" ng-if="block.data.panelHeading"></h1>
-    <div class="govuk-panel__body" aria-hidden="true" ng-bind-html="block.data.panelText.markup" ng-if="block.data.panelText.markup"></div>
+    <div class="govuk-panel__body" aria-hidden="true" ng-bind-html="block.data.panelText.markup | safe_html" ng-if="block.data.panelText.markup"></div>
 </div>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkRadiosPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkRadiosPreview.html
@@ -5,12 +5,12 @@
             <p class="backoffice-additional-blocks" ng-if="!block.data.fieldsetBlocks.contentData">No blocks.</p>
             <p class="backoffice-additional-blocks" ng-if="block.data.fieldsetBlocks.contentData.length===1">1 block.</p>
             <p class="backoffice-additional-blocks" ng-if="block.data.fieldsetBlocks.contentData.length>1">{{block.data.fieldsetBlocks.contentData.length}} blocks.</p>
-            <div class="govuk-hint" ng-bind-html="block.data.hint.markup" ng-if="block.data.hint.markup"></div>
+            <div class="govuk-hint" ng-bind-html="block.data.hint.markup | safe_html" ng-if="block.data.hint.markup"></div>
             <div class="govuk-radios">
                 <div class="govuk-radios__item" ng-repeat="radio in block.data.radioButtons.contentData">
                     <input class="govuk-radios__input" type="radio" value="{{radio.value}}">
                     <label class="govuk-radios__label govuk-label">{{radio.label}}</label>
-                    <div class="govuk-radios__hint govuk-hint" ng-bind-html="radio.hint.markup" ng-if="radio.hint.markup"></div>
+                    <div class="govuk-radios__hint govuk-hint" ng-bind-html="radio.hint.markup | safe_html" ng-if="radio.hint.markup"></div>
                     <p class="backoffice-additional-blocks" ng-if="!radio.conditionalBlocks.contentData">No conditional blocks.</p>
                     <p class="backoffice-additional-blocks" ng-if="radio.conditionalBlocks.contentData.length===1">1 conditional block.</p>
                     <p class="backoffice-additional-blocks" ng-if="radio.conditionalBlocks.contentData.length>1">{{radio.conditionalBlocks.contentData.length}} conditional blocks.</p>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html
@@ -1,6 +1,6 @@
 ﻿<div class="govuk-form-group backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" aria-label="Edit select component">
     <label class="govuk-label" ng-bind-html="block.data.label" aria-hidden="true"></label>
-    <div class="govuk-hint" ng-bind-html="block.data.hint.markup" ng-if="block.data.hint.markup" aria-hidden="true"></div>
+    <div class="govuk-hint" ng-bind-html="block.data.hint.markup | safe_html" ng-if="block.data.hint.markup" aria-hidden="true"></div>
     <select class="govuk-select" aria-hidden="true" ng-click="$event.preventDefault()">
         <option ng-repeat="option in block.data.options.contentData" value="{{option.value}}">{{option.label}}</option>
     </select>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryCardPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryCardPreview.html
@@ -11,7 +11,7 @@
             <div class="backoffice-additional-blocks" ng-if="!block.data.summaryListItems.contentData.length">Summary list with no list items.</div>
             <div class="govuk-summary-list__row" ng-repeat="item in block.data.summaryListItems.contentData">
                 <dt class="govuk-summary-list__key" ng-bind-html="item.itemKey"></dt>
-                <dd class="govuk-summary-list__value" ng-bind-html="item.itemValue.markup"></dd>
+                <dd class="govuk-summary-list__value" ng-bind-html="item.itemValue.markup | safe_html"></dd>
                 <dd class="govuk-summary-list__actions" ng-if="item.actions.contentData.length > 0">
                     <a class="govuk-link" href="#" ng-repeat="action in item.actions.contentData" ng-bind-html="action.text" ng-click="$event.preventDefault()"></a>
                 </dd>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryListPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkSummaryListPreview.html
@@ -2,7 +2,7 @@
     <div class="backoffice-additional-blocks" ng-if="!block.data.items.contentData.length" aria-hidden="true">Summary list with no list items.</div>
     <div class="govuk-summary-list__row" ng-repeat="item in block.data.items.contentData" aria-hidden="true">
         <dt class="govuk-summary-list__key" ng-bind-html="item.itemKey"></dt>
-        <dd class="govuk-summary-list__value" ng-bind-html="item.itemValue.markup"></dd>
+        <dd class="govuk-summary-list__value" ng-bind-html="item.itemValue.markup | safe_html"></dd>
         <dd class="govuk-summary-list__actions" ng-if="item.actions.contentData.length > 0">
             <a class="govuk-link" href="#" ng-repeat="action in item.actions.contentData" ng-bind-html="action.text" ng-click="$event.preventDefault()"></a>
         </dd>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTaskListPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTaskListPreview.html
@@ -3,7 +3,7 @@
     <li class="govuk-task-list__item--with-link govuk-task-list__item" ng-repeat="task in block.data.tasks.contentData" aria-hidden="true">
         <div class="govuk-task-list__name-and-hint">
             <span class="govuk-task-list__link govuk-link" href="#" ng-bind-html="task.taskName"></span>
-            <div class="govuk-task-list__hint" ng-bind-html="task.hint.markup" ng-if="task.hint.markup"></div>
+            <div class="govuk-task-list__hint" ng-bind-html="task.hint.markup | safe_html" ng-if="task.hint.markup"></div>
         </div>
         <div class="govuk-task-list__status govuk-task-list__status--not-started">
             <strong class="govuk-tag">Status</strong>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTextAreaPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTextAreaPreview.html
@@ -1,5 +1,5 @@
 ﻿<div class="govuk-form-group backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" aria-label="Edit textarea component">
     <label class="govuk-label" ng-bind-html="block.data.label" aria-hidden="true"></label>
-    <div class="govuk-hint" ng-bind-html="block.data.hint.markup" ng-if="block.data.hint.markup" aria-hidden="true"></div>
+    <div class="govuk-hint" ng-bind-html="block.data.hint.markup | safe_html" ng-if="block.data.hint.markup" aria-hidden="true"></div>
     <textarea class="govuk-textarea" rows="5" aria-hidden="true"></textarea>
 </div>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTextInputPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTextInputPreview.html
@@ -1,5 +1,5 @@
 ﻿<div class="govuk-form-group backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" aria-label="Edit text input component">
     <label class="govuk-label" ng-bind-html="block.data.label" aria-hidden="true"></label>
-    <div class="govuk-hint" ng-bind-html="block.data.hint.markup" ng-if="block.data.hint.markup" aria-hidden="true"></div>
+    <div class="govuk-hint" ng-bind-html="block.data.hint.markup | safe_html" ng-if="block.data.hint.markup" aria-hidden="true"></div>
     <input class="govuk-input" type="text" aria-hidden="true" />
 </div>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTypographyPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkTypographyPreview.html
@@ -1,1 +1,1 @@
-﻿<div class="govuk-body backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.text.markup" aria-label="Edit text component"></div>
+﻿<div class="govuk-body backoffice-block-view" ng-click="block.edit()" ng-focus="block.focus" ng-bind-html="block.data.text.markup | safe_html" aria-label="Edit text component"></div>

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkWarningTextPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkWarningTextPreview.html
@@ -2,6 +2,6 @@
     <span aria-hidden="true" class="govuk-warning-text__icon">!</span>
     <strong class="govuk-warning-text__text" aria-hidden="true">
         <span class="govuk-visually-hidden">Warning</span>
-        <span ng-bind-html="block.data.text.markup"></span>
+        <span ng-bind-html="block.data.text.markup | safe_html"></span>
     </strong>
 </div>


### PR DESCRIPTION
Umbraco includes the option to select the numbering style for an ordered list:

![Ordered list styles](https://github.com/user-attachments/assets/6e0fb016-3821-4f55-99d4-fafb38848fe7)

and similar style options for unordered lists:

![Unordered list styles](https://github.com/user-attachments/assets/cab72634-5777-4bd6-bdf1-f2995bf6e7d6)

The selection of styles was not being reflected in backoffice previews, which always showed the default option. 

The problem was that the `safe_html` filter applied in the [out-of-the-box backoffice preview](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Cms.StaticAssets/wwwroot/App_Plugins/Umbraco.BlockGridEditor.DefaultCustomViews/umbBlockGridDemoRichTextBlock.html) for a rich text block was missing. This PR adds it wherever we render rich text in all backoffice previews.

Backoffice previews now work for ordered lists:

![Backoffice preview of an ordered list](https://github.com/user-attachments/assets/e96becec-a652-4256-a4c4-06b65ffb7342)

and unordered lists:

![Backoffice preview of an unordered list](https://github.com/user-attachments/assets/e472d2db-a013-4e84-aa78-ee3dde8451f1)

I have added example lists to the 'Typography' example page for Umbraco to demonstrate/test these options. 

There is another separate issue with the rendering of these styles in the final markup for unordered lists only, but it is out-of-scope for this PR.

[AB#231921](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/231921) [AB#231924](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/231924)