### PR TITLE
Custom bullet styles were not rendered when a strict CSP was applied

### DIFF
--- a/GovUk.Frontend.ExampleApp/Middleware/SecurityHeadersMiddleware.cs
+++ b/GovUk.Frontend.ExampleApp/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,37 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Security;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading.Tasks;
+
+namespace GovUk.Frontend.ExampleApp.Middleware
+{
+    public class SecurityHeadersMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IWebHostEnvironment _webHostEnvironment;
+        public SecurityHeadersMiddleware(RequestDelegate next, IWebHostEnvironment webHostEnvironment)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _webHostEnvironment = webHostEnvironment;
+        }
+
+        public async Task InvokeAsync(HttpContext context, INonceProvider nonceProvider)
+        {
+            var connectSrcForHotReload = _webHostEnvironment.IsDevelopment() ? "'self' ws://localhost:* http://localhost:64300" : string.Empty;
+            var scriptSrcForAblePlayer = "https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js";
+            var styleSrcForAblePlayer = "'sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f' 'sha384-ETDm/j6COkRSUfVFsGNM5WYE4WjyRgfDhy4Pf4Fsc8eNw/eYEMqYZWuxTzMX6FBa'";
+            var nonce = nonceProvider.GetNonce();
+            context.Response.Headers.Append("Content-Security-Policy",
+                    "default-src 'self'; " +
+                    $"script-src 'self' 'nonce-{nonce}' {scriptSrcForAblePlayer} youtube.com www.youtube.com www.youtube-nocookie.com;" +
+                    $"style-src 'self' {styleSrcForAblePlayer};" +
+                    "img-src 'self' https://i.ytimg.com; " +
+                    "frame-src youtube.com www.youtube.com www.youtube-nocookie.com; " +
+                    $"connect-src {connectSrcForHotReload}");
+
+            await _next(context);
+        }
+    }
+}

--- a/GovUk.Frontend.ExampleApp/Middleware/SecurityHeadersMiddlewareExtensions.cs
+++ b/GovUk.Frontend.ExampleApp/Middleware/SecurityHeadersMiddlewareExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace GovUk.Frontend.ExampleApp.Middleware
+{
+    public static class SecurityHeadersMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<SecurityHeadersMiddleware>();
+        }
+    }
+}

--- a/GovUk.Frontend.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.ExampleApp/Startup.cs
@@ -1,5 +1,6 @@
 using GovUk.Frontend.AspNetCore.Extensions;
 using GovUk.Frontend.AspNetCore.Extensions.Validation;
+using GovUk.Frontend.ExampleApp.Middleware;
 using GovUk.Frontend.ExampleApp.Models.Validators;
 using GovUk.Frontend.ExampleSharedResource;
 using Microsoft.AspNetCore.Builder;
@@ -89,6 +90,7 @@ namespace GovUk.Frontend.ExampleApp
             }
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+            app.UseSecurityHeaders();
 
             app.UseRouting();
 

--- a/GovUk.Frontend.Umbraco.ExampleApp/Middleware/SecurityHeadersMiddleware.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,42 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Security;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading.Tasks;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Middleware
+{
+    public class SecurityHeadersMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IWebHostEnvironment _webHostEnvironment;
+        public SecurityHeadersMiddleware(RequestDelegate next, IWebHostEnvironment webHostEnvironment)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _webHostEnvironment = webHostEnvironment;
+        }
+
+        public async Task InvokeAsync(HttpContext context, INonceProvider nonceProvider, DatabaseBuilder databaseBuilder)
+        {
+            string path = context.Request.Path;
+            if (databaseBuilder.IsDatabaseConfigured && path.StartsWith("/umbraco", StringComparison.OrdinalIgnoreCase) == false)
+            {
+                var connectSrcForHotReload = _webHostEnvironment.IsDevelopment() ? "'self' ws://localhost:* http://localhost:64300" : string.Empty;
+                var scriptSrcForAblePlayer = "https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js";
+                var styleSrcForAblePlayer = "'sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f' 'sha384-ETDm/j6COkRSUfVFsGNM5WYE4WjyRgfDhy4Pf4Fsc8eNw/eYEMqYZWuxTzMX6FBa'";
+                var nonce = nonceProvider.GetNonce();
+                context.Response.Headers.Append("Content-Security-Policy",
+                        "default-src 'self'; " +
+                        $"script-src 'self' 'nonce-{nonce}' {scriptSrcForAblePlayer} youtube.com www.youtube.com www.youtube-nocookie.com;" +
+                        $"style-src 'self' {styleSrcForAblePlayer};" +
+                        "img-src 'self' https://i.ytimg.com; " +
+                        "frame-src youtube.com www.youtube.com www.youtube-nocookie.com; " +
+                        $"connect-src {connectSrcForHotReload}");
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/Middleware/SecurityHeadersMiddlewareExtensions.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Middleware/SecurityHeadersMiddlewareExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Middleware
+{
+    public static class SecurityHeadersMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<SecurityHeadersMiddleware>();
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
@@ -1,3 +1,4 @@
+using GovUk.Frontend.Umbraco.ExampleApp.Middleware;
 using GovUk.Frontend.Umbraco.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -75,6 +76,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp
             }
 
             app.UseHttpsRedirection();
+            app.UseSecurityHeaders();
 
             app.UseUmbraco()
                 .WithMiddleware(u =>

--- a/GovUk.Frontend.Umbraco.ExampleApp/appsettings.json
+++ b/GovUk.Frontend.Umbraco.ExampleApp/appsettings.json
@@ -27,7 +27,7 @@
         "ModelsDirectory": "~/Models/ModelsBuilder"
       },
       "RichTextEditor": {
-        "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
+        "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[style|class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
         "CustomConfig": {
           "table_advtab": "false",
           "table_cell_advtab": "false",

--- a/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/GovUkTypographyPropertyValueFormatterTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/GovUkTypographyPropertyValueFormatterTests.cs
@@ -57,7 +57,22 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
         [TestCase("upper-roman")]
         public void Permitted_style_attribute_is_converted_to_class_from_ordered_lists(string listStyleType)
         {
-            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassFromOrderedLists(
+            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnOrderedLists(
+                new GovUkTypographyPropertyValueFormatter(), listStyleType);
+        }
+
+        [Test]
+        public void Style_attribute_is_removed_from_unordered_lists()
+        {
+            TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromUnorderedLists(
+                new GovUkTypographyPropertyValueFormatter());
+        }
+
+        [TestCase("circle")]
+        [TestCase("square")]
+        public void Permitted_style_attribute_is_converted_to_class_on_unordered_lists(string listStyleType)
+        {
+            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnUnorderedLists(
                 new GovUkTypographyPropertyValueFormatter(), listStyleType);
         }
     }

--- a/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphInversePropertyValueFormatterTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphInversePropertyValueFormatterTests.cs
@@ -72,8 +72,23 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
         [TestCase("upper-roman")]
         public void Permitted_style_attribute_is_converted_to_class_from_ordered_lists(string listStyleType)
         {
-            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassFromOrderedLists(
+            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnOrderedLists(
                 new NoParagraphInversePropertyValueFormatter(), listStyleType);
+        }
+
+        [Test]
+        public void Style_attribute_is_removed_from_unordered_lists()
+        {
+            TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromUnorderedLists(
+                new GovUkTypographyPropertyValueFormatter());
+        }
+
+        [TestCase("circle")]
+        [TestCase("square")]
+        public void Permitted_style_attribute_is_converted_to_class_on_unordered_lists(string listStyleType)
+        {
+            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnUnorderedLists(
+                new GovUkTypographyPropertyValueFormatter(), listStyleType);
         }
     }
 }

--- a/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphPropertyValueFormatterTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphPropertyValueFormatterTests.cs
@@ -71,8 +71,23 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
         [TestCase("upper-roman")]
         public void Permitted_style_attribute_is_converted_to_class_from_ordered_lists(string listStyleType)
         {
-            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassFromOrderedLists(
+            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnOrderedLists(
                 new NoParagraphPropertyValueFormatter(), listStyleType);
+        }
+
+        [Test]
+        public void Style_attribute_is_removed_from_unordered_lists()
+        {
+            TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromUnorderedLists(
+                new GovUkTypographyPropertyValueFormatter());
+        }
+
+        [TestCase("circle")]
+        [TestCase("square")]
+        public void Permitted_style_attribute_is_converted_to_class_on_unordered_lists(string listStyleType)
+        {
+            TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnUnorderedLists(
+                new GovUkTypographyPropertyValueFormatter(), listStyleType);
         }
     }
 }

--- a/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TinyMCEValueFormattersTestHelper.cs
+++ b/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TinyMCEValueFormattersTestHelper.cs
@@ -39,7 +39,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
         }
 
-        internal static void TestPermittedStyleAttributeIsConvertedToClassFromOrderedLists(IPropertyValueFormatter formatter, string listStyleType)
+        internal static void TestPermittedStyleAttributeIsConvertedToClassOnOrderedLists(IPropertyValueFormatter formatter, string listStyleType)
         {
             var html = $"<ol style=\"list-style-type: {listStyleType};\"><li>Item 1</li><li>Item 2</li></ol>";
 
@@ -50,6 +50,31 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//ol").Count);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//ol[contains(@class,'govuk-list--{listStyleType}')]").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
+        }
+
+        internal static void TestStyleAttributeIsRemovedFromUnorderedLists(IPropertyValueFormatter formatter)
+        {
+            var html = "<ul style=\"list-style-type: circle;\"><li>Item 1</li><li>Item 2</li></ul><ul style=\"color: red;\"><li>Item 3</li><li>Item 4</li></ul>";
+
+            var result = (IHtmlEncodedString)formatter.FormatValue(html);
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(result.ToHtmlString());
+            Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//ul").Count);
+            Assert.Null(doc.DocumentNode.SelectNodes("//ul[@style]"));
+        }
+
+        internal static void TestPermittedStyleAttributeIsConvertedToClassOnUnorderedLists(IPropertyValueFormatter formatter, string listStyleType)
+        {
+            var html = $"<ul style=\"list-style-type: {listStyleType};\"><li>Item 1</li><li>Item 2</li></ul>";
+
+            var result = (IHtmlEncodedString)formatter.FormatValue(html);
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(result.ToHtmlString());
+            Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//ul").Count);
+            Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//ul[contains(@class,'govuk-list--{listStyleType}')]").Count);
+            Assert.Null(doc.DocumentNode.SelectNodes("//ul[@style]"));
         }
     }
 }

--- a/GovUk.Frontend.Umbraco/PropertyEditors/ValueFormatters/TinyMCEPropertyValueFormatterBase.cs
+++ b/GovUk.Frontend.Umbraco/PropertyEditors/ValueFormatters/TinyMCEPropertyValueFormatterBase.cs
@@ -9,11 +9,14 @@ namespace GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters
     {
         protected IHtmlEncodedString ApplyGovUkTypographyToTinyMCE(object value, TypographyOptions? options = null)
         {
-            return ApplyPermittedStylesToOrderedLists(
-                new HtmlEncodedString(
-                    GovUkTypography.Apply(
-                        value is IHtmlEncodedString html ? html.ToHtmlString() : value as string,
-                        options
+            return
+                ApplyPermittedStylesToUnorderedLists(
+                    ApplyPermittedStylesToOrderedLists(
+                    new HtmlEncodedString(
+                        GovUkTypography.Apply(
+                            value is IHtmlEncodedString html ? html.ToHtmlString() : value as string,
+                            options
+                        )
                     )
                 )
             );
@@ -45,6 +48,21 @@ namespace GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters
             return html;
         }
 
+        /// <summary>
+        /// TinyMCE's unordered lists button has a setting for selecting the style of the unordered list, so we need to enable it or it looks broken.
+        /// However it is serialized to the style attribute which we don't want to allow free use of, so convert permitted style attribute values
+        /// to classes for display, and remove any others.
+        /// </summary>
+        /// <param name="document"></param>
+        protected static IHtmlEncodedString ApplyPermittedStylesToUnorderedLists(IHtmlEncodedString html)
+        {
+            var permittedStyleAttributes = new Dictionary<string, string> {
+                {"list-style-type: circle;" , "govuk-list--circle" },
+                {"list-style-type: square;" , "govuk-list--square" }
+            };
+
+            return ApplyPermittedStylesToLists(html, permittedStyleAttributes, "ul", "govuk-list--bullet");
+        }
 
         /// <summary>
         /// TinyMCE's ordered lists button has a setting for selecting the style of the ordered list, so we need to enable it or it looks broken.
@@ -62,12 +80,17 @@ namespace GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters
                 {"list-style-type: upper-roman;" , "govuk-list--upper-roman" }
             };
 
+            return ApplyPermittedStylesToLists(html, permittedStyleAttributes, "ol", "govuk-list--number");
+        }
+
+        private static IHtmlEncodedString ApplyPermittedStylesToLists(IHtmlEncodedString html, Dictionary<string, string> permittedStyleAttributes, string tagName, string defaultStyleClass)
+        {
             if (!string.IsNullOrWhiteSpace(html.ToHtmlString()))
             {
                 var document = new HtmlDocument();
                 document.LoadHtml(html.ToHtmlString());
 
-                var nodes = document.DocumentNode.SelectNodes("//ol[@style]");
+                var nodes = document.DocumentNode.SelectNodes($"//{tagName}[@style]");
                 if (nodes != null)
                 {
                     foreach (var node in nodes)
@@ -76,7 +99,7 @@ namespace GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters
                         {
                             if (node.Attributes["style"].Value.Contains(permittedStyle))
                             {
-                                node.RemoveClass("govuk-list--number");
+                                node.RemoveClass(defaultStyleClass);
                                 node.AddClass(permittedStyleAttributes[permittedStyle]);
                                 break;
                             }

--- a/GovUk.Frontend.Umbraco/Styles/_govuk-list.scss
+++ b/GovUk.Frontend.Umbraco/Styles/_govuk-list.scss
@@ -1,7 +1,15 @@
 ﻿/* Extra list styles not in govuk-frontend, but available in the Umbraco UI and therefore supported */
+.govuk-list--circle {
+    padding-left: govuk-spacing(4);
+    list-style-type: circle;
+}
+.govuk-list--square {
+    padding-left: govuk-spacing(4);
+    list-style-type: square;
+}
 .govuk-list--lower-alpha {
     padding-left: govuk-spacing(4);
-    list-style-type: lower-alpha
+    list-style-type: lower-alpha;
 }
 .govuk-list--lower-greek {
     padding-left: govuk-spacing(4);

--- a/docs/umbraco/new-umbraco-project-govuk.md
+++ b/docs/umbraco/new-umbraco-project-govuk.md
@@ -23,7 +23,7 @@
            "ModelsDirectory": "~/Models/ModelsBuilder"
          },
          "RichTextEditor": {
-           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
+           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[style|class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
            "CustomConfig": {
              "table_advtab": "false",
              "table_cell_advtab": "false",

--- a/docs/umbraco/new-umbraco-project-tpr.md
+++ b/docs/umbraco/new-umbraco-project-tpr.md
@@ -27,7 +27,7 @@
            "ModelsDirectory": "~/Models/ModelsBuilder"
          },
          "RichTextEditor": {
-           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
+           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|class],-ol[style|class|reversed|start|type],-ul[style|class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
            "CustomConfig": {
              "table_advtab": "false",
              "table_cell_advtab": "false",


### PR DESCRIPTION
Selecting custom bullet styles for an unordered list in the backoffice did not change the bullet style in the rendered page when a strict CSP was applied. This was because Umbraco applied the bullet style using a `style` attribute, which is often blocked with a strict CSP.

This was already solved for ordered lists in https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/pull/182 and the same solution is applied here. This removes all style attributes from unordered lists, but where a attribute value is recognised as representing a bullet style choice in the backoffice, a class is applied instead, which is allowed.

This PR also applies a CSP to both example apps, both as a test for this issue and to better represent how all of these components are used in practice.

[AB#231921](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/231921)