### PR TITLE
Pass through target attribute to links, styled as a button 

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
@@ -933,7 +933,7 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "text": {
-        "markup": "<p>Links, styled as a button can be set to open in a new tab. Enabiling this setting will also add a visually hidden span with the text \"(opens in a new tab)\".</p>",
+        "markup": "<p>Links, styled as a button can be set to open in a new tab. Enabiling this setting will also add a visually hidden span with the text \"(opens in a new tab)\", which can be customised with the dictionary key of \"(opens in a new tab)\".</p>",
         "blocks": {
           "contentData": [],
           "settingsData": []

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/button.config
@@ -64,23 +64,29 @@
       {
         "contentUdi": "umb://element/6ea1565f8aee4e20b7f3421b406e3dcb",
         "settingsUdi": "umb://element/e841d223d47b420c91a57ed3c77a9f3a"
+      },
+      {
+        "contentUdi": "umb://element/1b69183672814b87ae1799ef1b888ec4",
+        "settingsUdi": "umb://element/feb5cc42ebf4454496e95af5d1a9a090"
+      },
+      {
+        "contentUdi": "umb://element/9e6cf1ea478d44d48aafaedac43e1323",
+        "settingsUdi": "umb://element/2d439e41195648a6a2e38fd7077016ce"
       }
     ]
   },
   "contentData": [
     {
+      "caption": "Example application in Umbraco",
       "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
-      "udi": "umb://element/146bcf147d944fc3a1dfc2d6f345b5e6",
-      "caption": "Example application in Umbraco"
+      "udi": "umb://element/146bcf147d944fc3a1dfc2d6f345b5e6"
     },
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
-      "udi": "umb://element/f811ee68ac3e43f997ca73bcdcbc06dc",
-      "text": ""
+      "text": "",
+      "udi": "umb://element/f811ee68ac3e43f997ca73bcdcbc06dc"
     },
     {
-      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
-      "udi": "umb://element/66a0f09f95ae426da4af813094e9efa2",
       "buttons": {
         "layout": {
           "Umbraco.BlockList": [
@@ -125,205 +131,205 @@
         "contentData": [
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/b759811136de470c8192a7143bbf8056",
-            "text": "Primary button"
+            "text": "Primary button",
+            "udi": "umb://element/b759811136de470c8192a7143bbf8056"
           },
           {
             "contentTypeKey": "64a0406a-8b4d-46d7-a976-af6d6616dffc",
-            "udi": "umb://element/6bd81e10dad343dabe6c50c8f14225b3",
-            "text": "Cancel",
             "link": [
               {
                 "name": "Home",
                 "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
               }
-            ]
+            ],
+            "text": "Cancel",
+            "udi": "umb://element/6bd81e10dad343dabe6c50c8f14225b3"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/f980ec15f038472b952147f174667545",
-            "text": "Secondary button"
+            "text": "Secondary button",
+            "udi": "umb://element/f980ec15f038472b952147f174667545"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/e1f174f2405e4760a2cf52350538284e",
-            "text": "Warning button"
+            "text": "Warning button",
+            "udi": "umb://element/e1f174f2405e4760a2cf52350538284e"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/ae66c309d6bb4f4f9aa2d1d68d80ddec",
-            "text": "Secondary warning button"
+            "text": "Secondary warning button",
+            "udi": "umb://element/ae66c309d6bb4f4f9aa2d1d68d80ddec"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/a2fd2454a4404efdbf7bf5f743c31d51",
-            "text": "Primary disabled"
+            "text": "Primary disabled",
+            "udi": "umb://element/a2fd2454a4404efdbf7bf5f743c31d51"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/f67a867dc52d456bbb7aa859ffe340cd",
-            "text": "Secondary disabled"
+            "text": "Secondary disabled",
+            "udi": "umb://element/f67a867dc52d456bbb7aa859ffe340cd"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/b33f034a34394a5ab1d1ac6b5003dee6",
-            "text": "Warning disabled"
+            "text": "Warning disabled",
+            "udi": "umb://element/b33f034a34394a5ab1d1ac6b5003dee6"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/0f3c2f136f324c9ea14452c9456ad61c",
-            "text": "Secondary warning disabled"
+            "text": "Secondary warning disabled",
+            "udi": "umb://element/0f3c2f136f324c9ea14452c9456ad61c"
           }
         ],
         "settingsData": [
           {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/c5b40f0183cd4839b412a84b16f3393a",
-            "typeOfButton": "Primary",
-            "styleOfButton": "",
             "columnSize": "",
             "columnSizeFromDesktop": "",
-            "preventDoubleClick": "0",
-            "modelProperty": "",
-            "disabled": "0",
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
             "cssClasses": "",
+            "cssClassesForColumn": "",
             "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "disabled": "0",
+            "modelProperty": "",
+            "preventDoubleClick": "0",
+            "styleOfButton": "",
+            "typeOfButton": "Primary",
+            "udi": "umb://element/c5b40f0183cd4839b412a84b16f3393a"
           },
           {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/d78e075f2a284fb3a2a79a161860035c",
-            "typeOfButton": "Secondary",
             "columnSize": "",
             "columnSizeFromDesktop": "",
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "",
+            "modelProperty": "",
+            "preventDoubleClick": "",
             "styleOfButton": [
               "Secondary"
             ],
-            "preventDoubleClick": "",
-            "modelProperty": "",
-            "disabled": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/d78e075f2a284fb3a2a79a161860035c"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/327ff8c2709a4ccdba6cc49b673358d0",
-            "typeOfButton": "Secondary",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "",
+            "modelProperty": "",
+            "preventDoubleClick": "",
             "styleOfButton": [
               "Warning"
             ],
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "preventDoubleClick": "",
-            "modelProperty": "",
-            "disabled": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/327ff8c2709a4ccdba6cc49b673358d0"
           },
           {
             "contentTypeKey": "236a3fde-d8b7-4b7d-aaad-6f49d2a3ddf2",
-            "udi": "umb://element/224bfd6342fa4404ac1b6cb0489fafa2",
-            "cssClasses": ""
+            "cssClasses": "",
+            "udi": "umb://element/224bfd6342fa4404ac1b6cb0489fafa2"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/56010e1aa7064527b2310f52b495f044",
-            "typeOfButton": "Secondary",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "",
+            "modelProperty": "",
+            "preventDoubleClick": "",
             "styleOfButton": [
               "Secondary",
               "Warning"
             ],
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "preventDoubleClick": "",
-            "modelProperty": "",
-            "disabled": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
-          },
-          {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/adba8035d957445893a71539509eca97",
-            "typeOfButton": "Primary",
-            "styleOfButton": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "disabled": "1",
-            "preventDoubleClick": "0",
-            "modelProperty": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
-          },
-          {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/685408f4cb66489bb258356cae7109bd",
             "typeOfButton": "Secondary",
+            "udi": "umb://element/56010e1aa7064527b2310f52b495f044"
+          },
+          {
             "columnSize": "",
             "columnSizeFromDesktop": "",
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "1",
+            "modelProperty": "",
+            "preventDoubleClick": "0",
+            "styleOfButton": "",
+            "typeOfButton": "Primary",
+            "udi": "umb://element/adba8035d957445893a71539509eca97"
+          },
+          {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "1",
+            "modelProperty": "",
+            "preventDoubleClick": "",
             "styleOfButton": [
               "Secondary"
             ],
-            "disabled": "1",
-            "preventDoubleClick": "",
-            "modelProperty": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/685408f4cb66489bb258356cae7109bd"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/766361ea6cc94d4491f04a6ab91a4a3d",
-            "typeOfButton": "Secondary",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "1",
+            "modelProperty": "",
+            "preventDoubleClick": "",
             "styleOfButton": [
               "Warning"
             ],
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "disabled": "1",
-            "preventDoubleClick": "",
-            "modelProperty": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/766361ea6cc94d4491f04a6ab91a4a3d"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/064a92606c19414882a73afae442b6e6",
-            "typeOfButton": "Secondary",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "1",
+            "modelProperty": "",
+            "preventDoubleClick": "",
             "styleOfButton": [
               "Secondary",
               "Warning"
             ],
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "disabled": "1",
-            "preventDoubleClick": "",
-            "modelProperty": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/064a92606c19414882a73afae442b6e6"
           }
         ]
-      }
+      },
+      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "udi": "umb://element/66a0f09f95ae426da4af813094e9efa2"
     },
     {
       "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-      "udi": "umb://element/f62d7e2eec954b618b88fac62018fc37",
       "link": [
         {
           "name": "Home",
           "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
         }
       ],
-      "text": "Start now"
+      "text": "Start now",
+      "udi": "umb://element/f62d7e2eec954b618b88fac62018fc37"
     },
     {
-      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
-      "udi": "umb://element/fb7b700c676d4312a439f03c60cb4340",
       "buttons": {
         "layout": {
           "Umbraco.BlockList": [
@@ -348,107 +354,108 @@
         "contentData": [
           {
             "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/9b3a8f4f5e2f42eebdf965441abee485",
+            "link": [
+              {
+                "name": "Home",
+                "target": "",
+                "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
+              }
+            ],
+            "text": "Link to next page",
+            "udi": "umb://element/9b3a8f4f5e2f42eebdf965441abee485"
+          },
+          {
+            "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
             "link": [
               {
                 "name": "Home",
                 "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
               }
             ],
-            "text": "Link to next page"
+            "text": "Secondary link",
+            "udi": "umb://element/aa9b68d9091d41c1a43c37da302b3e8d"
           },
           {
             "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/aa9b68d9091d41c1a43c37da302b3e8d",
             "link": [
               {
                 "name": "Home",
                 "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
               }
             ],
-            "text": "Secondary link"
+            "text": "Warning link",
+            "udi": "umb://element/020d42dd6e3a40eda3e17414eb17e6cf"
           },
           {
             "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/020d42dd6e3a40eda3e17414eb17e6cf",
             "link": [
               {
                 "name": "Home",
                 "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
               }
             ],
-            "text": "Warning link"
-          },
-          {
-            "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/74f226a5ae1a45a0a79baa702bd612f3",
             "text": "Secondary warning link",
-            "link": [
-              {
-                "name": "Home",
-                "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
-              }
-            ]
+            "udi": "umb://element/74f226a5ae1a45a0a79baa702bd612f3"
           }
         ],
         "settingsData": [
           {
-            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/964e029f6cdf410dad070800ad8c03aa",
-            "isStartButton": "0",
             "columnSize": "",
             "columnSizeFromDesktop": "",
-            "styleOfButton": "",
+            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
             "cssClasses": "",
+            "cssClassesForColumn": "",
             "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "isStartButton": "0",
+            "styleOfButton": "",
+            "udi": "umb://element/964e029f6cdf410dad070800ad8c03aa"
           },
           {
-            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/64522f384142412b800efd06694cac4d",
-            "isStartButton": "0",
             "columnSize": "",
             "columnSizeFromDesktop": "",
+            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "isStartButton": "0",
             "styleOfButton": [
               "Secondary"
             ],
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "udi": "umb://element/64522f384142412b800efd06694cac4d"
           },
           {
-            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/803bc3471a454eaa8bde16fe712fbf2e",
-            "isStartButton": "0",
             "columnSize": "",
             "columnSizeFromDesktop": "",
+            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "isStartButton": "0",
             "styleOfButton": [
               "Warning"
             ],
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "udi": "umb://element/803bc3471a454eaa8bde16fe712fbf2e"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/257740a3e3ee462cb7121ebf6fd180f5",
+            "cssClasses": "",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
             "isStartButton": "0",
             "styleOfButton": [
               "Warning",
               "Secondary"
             ],
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClasses": "",
-            "cssClassesForRow": "",
-            "cssClassesForColumn": ""
+            "udi": "umb://element/257740a3e3ee462cb7121ebf6fd180f5"
           }
         ]
-      }
+      },
+      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "udi": "umb://element/fb7b700c676d4312a439f03c60cb4340"
     },
     {
-      "contentTypeKey": "43d6f04c-2ce0-440c-9e13-05d856b8aafe",
-      "udi": "umb://element/baf1f69e39d74032a35473d3dd049b3a",
       "blocks": {
         "layout": {
           "Umbraco.BlockList": [
@@ -461,23 +468,25 @@
         "contentData": [
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/c556e75ab6744cfe87e501fa53f724bf",
-            "text": "Reversed button"
+            "text": "Reversed button",
+            "udi": "umb://element/c556e75ab6744cfe87e501fa53f724bf"
           }
         ],
         "settingsData": [
           {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/37cb353469154ff7be15388397229a98",
             "columnSize": "",
             "columnSizeFromDesktop": "",
-            "typeOfButton": "Secondary",
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
             "styleOfButton": [
               "Reversed"
-            ]
+            ],
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/37cb353469154ff7be15388397229a98"
           }
         ]
       },
+      "contentTypeKey": "43d6f04c-2ce0-440c-9e13-05d856b8aafe",
+      "heading": "",
       "text": {
         "markup": "<p>Reversed buttons should be used inside a notification banner.</p>",
         "blocks": {
@@ -485,11 +494,9 @@
           "settingsData": []
         }
       },
-      "heading": ""
+      "udi": "umb://element/baf1f69e39d74032a35473d3dd049b3a"
     },
     {
-      "contentTypeKey": "43d6f04c-2ce0-440c-9e13-05d856b8aafe",
-      "udi": "umb://element/6ea1565f8aee4e20b7f3421b406e3dcb",
       "blocks": {
         "layout": {
           "Umbraco.BlockList": [
@@ -502,23 +509,25 @@
         "contentData": [
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/193cf473f47e485188871eb55590cb04",
-            "text": "Reversed button"
+            "text": "Reversed button",
+            "udi": "umb://element/193cf473f47e485188871eb55590cb04"
           }
         ],
         "settingsData": [
           {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/2a96df7379a845a690b75ec46e7d3f9b",
             "columnSize": "",
             "columnSizeFromDesktop": "",
-            "typeOfButton": "Secondary",
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
             "styleOfButton": [
               "Reversed"
-            ]
+            ],
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/2a96df7379a845a690b75ec46e7d3f9b"
           }
         ]
       },
+      "contentTypeKey": "43d6f04c-2ce0-440c-9e13-05d856b8aafe",
+      "heading": "",
       "text": {
         "markup": "<p>Reversed buttons should be used inside a notification banner.</p>",
         "blocks": {
@@ -526,22 +535,20 @@
           "settingsData": []
         }
       },
-      "heading": ""
+      "udi": "umb://element/6ea1565f8aee4e20b7f3421b406e3dcb"
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
-      "udi": "umb://element/9476ebde6c114904bfd69eadcea3456c",
       "text": {
         "markup": "<p>The following button styles are supported when using The Pensions Regulator branding. It is possible to configure other combinations in Umbraco, but they are not yet supported.</p>\n<p>You can bind a button to a string property on your view model. On a page with multiple buttons this will let you detect which button was clicked.</p>",
         "blocks": {
           "contentData": [],
           "settingsData": []
         }
-      }
+      },
+      "udi": "umb://element/9476ebde6c114904bfd69eadcea3456c"
     },
     {
-      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
-      "udi": "umb://element/7da467d436234410b7822564ada2a965",
       "buttons": {
         "layout": {
           "Umbraco.BlockList": [
@@ -554,28 +561,28 @@
         "contentData": [
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/f6ed5ac1bf784eb8aac8d95f994cd910",
-            "text": "Reversed button"
+            "text": "Reversed button",
+            "udi": "umb://element/f6ed5ac1bf784eb8aac8d95f994cd910"
           }
         ],
         "settingsData": [
           {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/6c03bb348f304b5cb48eb1f2cf29092e",
-            "typeOfButton": "Secondary",
             "columnSize": "",
             "columnSizeFromDesktop": "",
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
             "cssClassesForRow": "govuk-grid-row--dark-background",
             "styleOfButton": [
               "Reversed"
-            ]
+            ],
+            "typeOfButton": "Secondary",
+            "udi": "umb://element/6c03bb348f304b5cb48eb1f2cf29092e"
           }
         ]
-      }
+      },
+      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "udi": "umb://element/7da467d436234410b7822564ada2a965"
     },
     {
-      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
-      "udi": "umb://element/10cf18f6ea0f4927aa37eaa55bb34f99",
       "buttons": {
         "layout": {
           "Umbraco.BlockList": [
@@ -600,118 +607,118 @@
         "contentData": [
           {
             "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/3b12d172a3b54135ab0a7035382738be",
+            "link": [
+              {
+                "name": "Home",
+                "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
+              }
+            ],
             "text": "Link to next page",
+            "udi": "umb://element/3b12d172a3b54135ab0a7035382738be"
+          },
+          {
+            "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
             "link": [
               {
                 "name": "Home",
                 "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
               }
-            ]
-          },
-          {
-            "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/c452bec7c1bd4428934d2d1322b84068",
+            ],
             "text": "Secondary link",
+            "udi": "umb://element/c452bec7c1bd4428934d2d1322b84068"
+          },
+          {
+            "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
             "link": [
               {
                 "name": "Home",
                 "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
               }
-            ]
-          },
-          {
-            "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/d974c27b1ad84772b5ae30376f5d181d",
+            ],
             "text": "Warning link",
-            "link": [
-              {
-                "name": "Home",
-                "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
-              }
-            ]
+            "udi": "umb://element/d974c27b1ad84772b5ae30376f5d181d"
           },
           {
             "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
-            "udi": "umb://element/b449b6819b924096b73f68cb9b11b1ee",
-            "text": "Secondary warning link",
             "link": [
               {
                 "name": "Home",
                 "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
               }
-            ]
+            ],
+            "text": "Secondary warning link",
+            "udi": "umb://element/b449b6819b924096b73f68cb9b11b1ee"
           }
         ],
         "settingsData": [
           {
-            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/8a1cfe42592c4a9eb1ae007e177d74ec",
-            "isStartButton": "0",
-            "styleOfButton": "",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
             "columnSize": "",
             "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "isStartButton": "0",
+            "styleOfButton": "",
+            "udi": "umb://element/8a1cfe42592c4a9eb1ae007e177d74ec"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/426d82ac5fce43bb9a1fbfa9f8462bcf",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
             "isStartButton": "0",
             "styleOfButton": [
               "Secondary"
             ],
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "udi": "umb://element/426d82ac5fce43bb9a1fbfa9f8462bcf"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/2ba34f31eac54c86ad1eab7ee65255bb",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
             "isStartButton": "0",
             "styleOfButton": [
               "Warning"
             ],
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "udi": "umb://element/2ba34f31eac54c86ad1eab7ee65255bb"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-            "udi": "umb://element/689b5df680d741029f68f18befb8c4df",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
             "isStartButton": "0",
             "styleOfButton": [
               "Secondary",
               "Warning"
             ],
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "udi": "umb://element/689b5df680d741029f68f18befb8c4df"
           }
         ]
-      }
+      },
+      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "udi": "umb://element/10cf18f6ea0f4927aa37eaa55bb34f99"
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
-      "udi": "umb://element/aef2ff7834054b0bb506fdd57adaffaa",
       "text": {
         "markup": "<p>The following group of buttons have a TPR-specific style applied which indicates that the button ends a process. With GOV.UK styling they will look the same as the previous group of buttons.</p>",
         "blocks": {
           "contentData": [],
           "settingsData": []
         }
-      }
+      },
+      "udi": "umb://element/aef2ff7834054b0bb506fdd57adaffaa"
     },
     {
-      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
-      "udi": "umb://element/6640c0a7ccc743e3bb21fcb9b1ab5ae2",
       "buttons": {
         "layout": {
           "Umbraco.BlockList": [
@@ -752,300 +759,343 @@
         "contentData": [
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/ad881935e99c4a15a4ae8b5ceecd1083",
-            "text": "Primary button"
+            "text": "Primary button",
+            "udi": "umb://element/ad881935e99c4a15a4ae8b5ceecd1083"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/8908ba0567a84c77968a7730ac735a1f",
-            "text": "Secondary button"
+            "text": "Secondary button",
+            "udi": "umb://element/8908ba0567a84c77968a7730ac735a1f"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/7ef00d9b1cbd40b9b79e899c824454e1",
-            "text": "Warning button"
+            "text": "Warning button",
+            "udi": "umb://element/7ef00d9b1cbd40b9b79e899c824454e1"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/48c0ec776db8426c9b649a48e457e79d",
-            "text": "Secondary warning button"
+            "text": "Secondary warning button",
+            "udi": "umb://element/48c0ec776db8426c9b649a48e457e79d"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/421494ea278c44f3a25d8fb2da55769b",
-            "text": "Primary disabled"
+            "text": "Primary disabled",
+            "udi": "umb://element/421494ea278c44f3a25d8fb2da55769b"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/6aff31945e8743899b50e73fd3ac3b76",
-            "text": "Secondary disabled"
+            "text": "Secondary disabled",
+            "udi": "umb://element/6aff31945e8743899b50e73fd3ac3b76"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/84066a97b7ef45eda56302d7e1ae69de",
-            "text": "Warning disabled"
+            "text": "Warning disabled",
+            "udi": "umb://element/84066a97b7ef45eda56302d7e1ae69de"
           },
           {
             "contentTypeKey": "35584ae7-feb5-4de8-9008-5d2d8cfb34ce",
-            "udi": "umb://element/e033981b4cfe454cbe34a2b2c97f554b",
-            "text": "Secondary warning disabled"
+            "text": "Secondary warning disabled",
+            "udi": "umb://element/e033981b4cfe454cbe34a2b2c97f554b"
           }
         ],
         "settingsData": [
           {
-            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/fba0a32ef09f4350801918bb72bf1373",
-            "preventDoubleClick": "0",
-            "modelProperty": "",
-            "typeOfButton": "Primary",
-            "styleOfButton": "",
-            "disabled": "0",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
             "columnSize": "",
             "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "0",
+            "modelProperty": "",
+            "preventDoubleClick": "0",
+            "styleOfButton": "",
+            "typeOfButton": "Primary",
+            "udi": "umb://element/fba0a32ef09f4350801918bb72bf1373"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/e410a40ebb9d4c5fb7da101261f525eb",
-            "preventDoubleClick": "0",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "0",
             "modelProperty": "",
-            "typeOfButton": "Primary",
+            "preventDoubleClick": "0",
             "styleOfButton": [
               "Secondary"
             ],
-            "disabled": "0",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Primary",
+            "udi": "umb://element/e410a40ebb9d4c5fb7da101261f525eb"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/bde95f67b02e4cb3a51c9503c9ed9647",
-            "preventDoubleClick": "0",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "0",
             "modelProperty": "",
-            "typeOfButton": "Primary",
+            "preventDoubleClick": "0",
             "styleOfButton": [
               "Warning"
             ],
-            "disabled": "0",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Primary",
+            "udi": "umb://element/bde95f67b02e4cb3a51c9503c9ed9647"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/ef79a6a569b74bb985861aae00c944d4",
-            "preventDoubleClick": "0",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "0",
             "modelProperty": "",
-            "typeOfButton": "Primary",
+            "preventDoubleClick": "0",
             "styleOfButton": [
               "Secondary",
               "Warning"
             ],
-            "disabled": "0",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Primary",
+            "udi": "umb://element/ef79a6a569b74bb985861aae00c944d4"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/96c36f62a5d14e5c831157912d540143",
-            "preventDoubleClick": "0",
-            "modelProperty": "",
-            "typeOfButton": "Primary",
-            "styleOfButton": "",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
             "disabled": "1",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "modelProperty": "",
+            "preventDoubleClick": "0",
+            "styleOfButton": "",
+            "typeOfButton": "Primary",
+            "udi": "umb://element/96c36f62a5d14e5c831157912d540143"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/75b4e7129a564728b3727f8b8bfca146",
-            "preventDoubleClick": "0",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "1",
             "modelProperty": "",
-            "typeOfButton": "Primary",
+            "preventDoubleClick": "0",
             "styleOfButton": [
               "Secondary"
             ],
-            "disabled": "1",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Primary",
+            "udi": "umb://element/75b4e7129a564728b3727f8b8bfca146"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/285b567ae042487cbf7eeee624a9a69c",
-            "preventDoubleClick": "0",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "1",
             "modelProperty": "",
-            "typeOfButton": "Primary",
+            "preventDoubleClick": "0",
             "styleOfButton": [
               "Warning"
             ],
-            "disabled": "1",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Primary",
+            "udi": "umb://element/285b567ae042487cbf7eeee624a9a69c"
           },
           {
+            "columnSize": "",
+            "columnSizeFromDesktop": "",
             "contentTypeKey": "e683e885-8aa0-4bdd-9eff-56966f353540",
-            "udi": "umb://element/bbb3bed5ef2248318487716fb30d5825",
-            "preventDoubleClick": "0",
+            "cssClasses": "tpr-button--no-next-step",
+            "cssClassesForColumn": "",
+            "cssClassesForRow": "",
+            "disabled": "1",
             "modelProperty": "",
-            "typeOfButton": "Primary",
+            "preventDoubleClick": "0",
             "styleOfButton": [
               "Secondary",
               "Warning"
             ],
-            "disabled": "1",
-            "cssClasses": "tpr-button--no-next-step",
-            "cssClassesForRow": "",
-            "columnSize": "",
-            "columnSizeFromDesktop": "",
-            "cssClassesForColumn": ""
+            "typeOfButton": "Primary",
+            "udi": "umb://element/bbb3bed5ef2248318487716fb30d5825"
           }
         ]
-      }
+      },
+      "contentTypeKey": "d1324abd-7504-44e1-9b9a-2cc12d527175",
+      "udi": "umb://element/6640c0a7ccc743e3bb21fcb9b1ab5ae2"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>Links, styled as a button can be set to open in a new tab. Enabiling this setting will also add a visually hidden span with the text \"(opens in a new tab)\".</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/1b69183672814b87ae1799ef1b888ec4"
+    },
+    {
+      "contentTypeKey": "94737fb0-c49c-44db-8a59-6a65f14a0c47",
+      "link": [
+        {
+          "target": "_blank",
+          "udi": "umb://document/5e682cbeb867491a955f3382446d5663"
+        }
+      ],
+      "text": "Link to another site",
+      "udi": "umb://element/9e6cf1ea478d44d48aafaedac43e1323"
     }
   ],
   "settingsData": [
     {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
-      "udi": "umb://element/ab8cb888878545c495eafa4a997312e7",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
       "isStartButton": "1",
-      "cssClasses": "",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
       "styleOfButton": "",
-      "cssClassesForRow": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/ab8cb888878545c495eafa4a997312e7"
     },
     {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
-      "udi": "umb://element/092bee77a08b4527bbe90ffe43de1d06",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
       "cssClasses": "",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/092bee77a08b4527bbe90ffe43de1d06"
     },
     {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "6ca199b3-814c-4aa9-b466-fc0533f2b543",
-      "udi": "umb://element/b0c36b8c2dd0496395e8bfa7fa896b0c",
       "cssClasses": "",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/b0c36b8c2dd0496395e8bfa7fa896b0c"
     },
     {
-      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
-      "udi": "umb://element/2eb09fa3c1a24b55b7c5893e87f0fb0a",
       "columnSize": [
         "full"
       ],
       "columnSizeFromDesktop": "",
+      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
       "cssClasses": "",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/2eb09fa3c1a24b55b7c5893e87f0fb0a"
     },
     {
-      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
-      "udi": "umb://element/81252747b25e462d917999d199a1f61f",
       "columnSize": [
         "full"
       ],
       "columnSizeFromDesktop": "",
+      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
       "cssClasses": "",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/81252747b25e462d917999d199a1f61f"
     },
     {
+      "columnSize": [
+        "full"
+      ],
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "f7827cba-7c37-4ddd-9234-11bf31e17818",
-      "udi": "umb://element/b422ef19f18b4751a89a0e0184b69b48",
-      "columnSize": [
-        "full"
-      ],
-      "columnSizeFromDesktop": "",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "title": "",
       "type": "",
-      "title": "",
-      "cssClasses": "",
-      "cssClassesForRow": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/b422ef19f18b4751a89a0e0184b69b48"
     },
     {
+      "columnSize": [
+        "full"
+      ],
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "f7827cba-7c37-4ddd-9234-11bf31e17818",
-      "udi": "umb://element/e841d223d47b420c91a57ed3c77a9f3a",
-      "columnSize": [
-        "full"
-      ],
-      "columnSizeFromDesktop": "",
-      "type": "Success",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
       "title": "",
-      "cssClasses": "",
-      "cssClassesForRow": "",
-      "cssClassesForColumn": ""
+      "type": "Success",
+      "udi": "umb://element/e841d223d47b420c91a57ed3c77a9f3a"
     },
     {
-      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/70e757e163b84f4dbb697d211904278a",
-      "cssClassesForRow": "",
       "columnSize": "",
       "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/70e757e163b84f4dbb697d211904278a"
     },
     {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
-      "udi": "umb://element/2d37cdb7e6754577b48d19ac287508e2",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "govuk-grid-row--dark-background",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
-      "cssClasses": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/2d37cdb7e6754577b48d19ac287508e2"
     },
     {
-      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
-      "udi": "umb://element/03794ae644b148b695a8c45104056d3c",
-      "cssClasses": "",
-      "cssClassesForRow": "",
       "columnSize": [
         "full"
       ],
       "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/03794ae644b148b695a8c45104056d3c"
     },
     {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/32ee4c04e6dc44169e2b168c59c90364",
+      "cssClassesForColumn": "",
       "cssClassesForRow": "",
-      "columnSize": "",
-      "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "udi": "umb://element/32ee4c04e6dc44169e2b168c59c90364"
     },
     {
-      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
-      "udi": "umb://element/4ef229e693624af3a0f4b1d3a6740ca2",
-      "cssClasses": "",
-      "cssClassesForRow": "",
       "columnSize": [
         "full"
       ],
       "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "contentTypeKey": "bb140093-52f9-4ec4-9240-ab246b574ebd",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/4ef229e693624af3a0f4b1d3a6740ca2"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/feb5cc42ebf4454496e95af5d1a9a090"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "2a5587ef-96fa-41dd-a2be-c5f97e00dfef",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "isStartButton": "0",
+      "styleOfButton": "",
+      "udi": "umb://element/2d439e41195648a6a2e38fd7077016ce"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco/DictionaryConstants.cs
+++ b/GovUk.Frontend.Umbraco/DictionaryConstants.cs
@@ -16,5 +16,7 @@
         public const string TaskListStatusCompleted = "Task list - Completed";
         public const string TaskListStatusNotApplicable = "Task list - Not applicable";
         public const string TaskListStatusError = "Task list - Error";
+
+        public const string OpensInNewTab = "(opens in a new tab)";
     }
 }

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
@@ -24,14 +24,23 @@
 
 @if(!string.IsNullOrEmpty(target))
 {
-    <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="@target">
-        @text
+    @if (openInNewTab)
+    {
+        <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="@target" rel="noreferrer noopener">
+            @text
 
-        @if (openInNewTab)
-        {
-            <span class="govuk-visually-hidden">(opens in new tab)</span>
-        }
-    </govuk-button-link>
+            @if (openInNewTab)
+            {
+                <span class="govuk-visually-hidden">(opens in new tab)</span>
+            }
+        </govuk-button-link>
+    }
+    else
+    {
+        <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="@target">
+            @text
+        </govuk-button-link>
+    }
 }
 else
 {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
@@ -9,10 +9,12 @@
 @{
     var text = Model.Content.Value<string>(PropertyAliases.LinkText);
     var link = Model.Content.Value<Link>(PropertyAliases.Link);
+    var target = link?.Target;
+    var openInNewTab = target?.Equals("_blank") ?? false;
+
     var isStartButton = Model.Settings.Value<bool>(PropertyAliases.LinkAsStartButton);
     var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
     var buttonStyle = Model.Settings.Value<string[]>(PropertyAliases.ButtonStyle) ?? Array.Empty<string>();
-    var openInNewTab = link?.Target?.Equals("_blank") ?? false;
 
     if (buttonStyle.Contains("Secondary")) { buttonStyle[buttonStyle.IndexOf("Secondary")] = "govuk-button--secondary"; }
     if (buttonStyle.Contains("Warning")) { buttonStyle[buttonStyle.IndexOf("Warning")] = "govuk-button--warning"; }
@@ -20,12 +22,15 @@
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
 }
 
-
-@if (openInNewTab)
+@if(!string.IsNullOrEmpty(target))
 {
-    <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="_blank">
+    <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="@target">
         @text
-        <span class="govuk-visually-hidden">(opens in new tab)</span>
+
+        @if (openInNewTab)
+        {
+            <span class="govuk-visually-hidden">(opens in new tab)</span>
+        }
     </govuk-button-link>
 }
 else
@@ -34,4 +39,3 @@ else
         @text
     </govuk-button-link>
 }
-

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
@@ -12,9 +12,26 @@
     var isStartButton = Model.Settings.Value<bool>(PropertyAliases.LinkAsStartButton);
     var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
     var buttonStyle = Model.Settings.Value<string[]>(PropertyAliases.ButtonStyle) ?? Array.Empty<string>();
+    var openInNewTab = link?.Target?.Equals("_blank") ?? false;
+
     if (buttonStyle.Contains("Secondary")) { buttonStyle[buttonStyle.IndexOf("Secondary")] = "govuk-button--secondary"; }
     if (buttonStyle.Contains("Warning")) { buttonStyle[buttonStyle.IndexOf("Warning")] = "govuk-button--warning"; }
     if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--inverse"; }
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
 }
-<govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses">@text</govuk-button-link>
+
+
+@if (openInNewTab)
+{
+    <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="_blank">
+        @text
+        <span class="govuk-visually-hidden">(opens in new tab)</span>
+    </govuk-button-link>
+}
+else
+{
+    <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses">
+        @text
+    </govuk-button-link>
+}
+

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
@@ -9,8 +9,7 @@
 @{
     var text = Model.Content.Value<string>(PropertyAliases.LinkText);
     var link = Model.Content.Value<Link>(PropertyAliases.Link);
-    var target = link?.Target;
-    var openInNewTab = target?.Equals("_blank") ?? false;
+    var openInNewTab = link?.Target?.Equals("_blank") ?? false;
 
     var isStartButton = Model.Settings.Value<bool>(PropertyAliases.LinkAsStartButton);
     var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
@@ -22,25 +21,12 @@
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
 }
 
-@if(!string.IsNullOrEmpty(target))
+@if (openInNewTab)
 {
-    @if (openInNewTab)
-    {
-        <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="@target" rel="noreferrer noopener">
-            @text
-
-            @if (openInNewTab)
-            {
-                <span class="govuk-visually-hidden">(opens in new tab)</span>
-            }
-        </govuk-button-link>
-    }
-    else
-    {
-        <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="@target">
-            @text
-        </govuk-button-link>
-    }
+    <govuk-button-link is-start-button="@isStartButton" href="@link?.Url" id="@Model.Content.Key" class="@string.Join(' ', buttonStyle)@cssClasses" target="_blank" rel="noreferrer noopener">
+        @text
+        <span class="govuk-visually-hidden">@Umbraco.GetDictionaryValueOrDefault(DictionaryConstants.OpensInNewTab, DictionaryConstants.OpensInNewTab)</span>
+    </govuk-button-link>
 }
 else
 {


### PR DESCRIPTION
Changes:
- Pass through target attribute if available
- If target attribute is `_blank` set `rel="noreferrer noopener"` and add `<span class="govuk-visually-hidden">(opens in a new tab)</span> as per [govuk standard](https://design-system.service.gov.uk/styles/links/#opening-links-in-a-new-tab)