### PR TITLE
Updated js to remove reference for headerclass as it can be changed u…

### DIFF
--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
@@ -169,7 +169,7 @@ document.addEventListener("DOMContentLoaded", function () {
     searchContentApiUrl = searchAside.getAttribute("data-search-content-url");
     getContentByIdApiUrl = searchAside.getAttribute("data-content-by-id-url");
 
-    const searchResultsSection = document.getElementsByClassName("govuk-heading-m tpr-search-results__heading")[0];
+    const searchResultsSection = document.getElementsByClassName("tpr-search-results__heading")[0];
     const headingLevel = searchResultsSection.tagName.toLowerCase();
 
     const headingLevelNumber = parseInt(headingLevel.replace('h', ''));


### PR DESCRIPTION
Updated tpr-search-results.js to remove hardcoded reference to heading class which can changed to a different value depending on the header style required.

Current implementation broke the Javascript when the header class was changed to something other than govuk-heading-m