### PR TITLE
233391 Hide welsh published date in document component if empty

### DIFF
--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
@@ -28,7 +28,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (string.IsNullOrEmpty(Href)) { throw new ArgumentNullException(nameof(Href), "Document href cannot be null"); }
-            if (DatePublished == "January 0001") { DatePublished = null; }
+            if (DatePublished == "January 0001" || DatePublished == "Ionawr 0001") { DatePublished = null; }
 
             var documentContext = (TprDocumentContext)context.Items[typeof(TprDocumentsTagHelper)];
             documentContext.Href = Href;


### PR DESCRIPTION
In this PR:
- Added a check for the Welsh version of an empty date picker to the document component's tag helper.