### PR TITLE
Minor editor bug fixes

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/related-links.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/related-links.config
@@ -62,19 +62,26 @@
         ],
         "columnSpan": 12,
         "rowSpan": 1
+      },
+      {
+        "contentUdi": "umb://element/9b5693e4a71342e9b85f6ee71027a66b",
+        "settingsUdi": "umb://element/ff21e09184454e5eb1ac6a0ab1026c3c",
+        "areas": [],
+        "columnSpan": 12,
+        "rowSpan": 1
       }
     ]
   },
   "contentData": [
     {
+      "caption": "Example application in Umbraco",
       "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
-      "udi": "umb://element/4ca481a2677e4da381f7fedfc16f9392",
-      "caption": "Example application in Umbraco"
+      "udi": "umb://element/4ca481a2677e4da381f7fedfc16f9392"
     },
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
-      "udi": "umb://element/b43ec17e590e4211a36f8c826033aad8",
-      "text": ""
+      "text": "",
+      "udi": "umb://element/b43ec17e590e4211a36f8c826033aad8"
     },
     {
       "contentTypeKey": "650d7119-e9cf-4c26-a08c-21cf2ffbbbbc",
@@ -82,18 +89,17 @@
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
-      "udi": "umb://element/6a2f2abdfeaf46bc832cba38acdb9fde",
       "text": {
         "markup": "<p>Related links is a TPR component normally found in the right column of desktop layouts.</p>\n<p>The heading defaults to 'Related' if left blank. It can be overridden sitewide by creating a dictionary entry called 'TPR Related links heading'. This in turn can be overridden by setting the heading on an individual component.</p>",
         "blocks": {
           "contentData": [],
           "settingsData": []
         }
-      }
+      },
+      "udi": "umb://element/6a2f2abdfeaf46bc832cba38acdb9fde"
     },
     {
       "contentTypeKey": "a2f4c028-e009-402b-a292-8cc898bb5aa9",
-      "udi": "umb://element/631cd921c6a647d6be62027f75b02a97",
       "heading": "Related links",
       "links": [
         {
@@ -108,46 +114,66 @@
           "name": "Example link 2",
           "udi": "umb://document/b32c5acb3eb54a348555579554021ed4"
         }
-      ]
+      ],
+      "udi": "umb://element/631cd921c6a647d6be62027f75b02a97"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-m\">In Page Anchors</h2>\n<p><a href=\"#section1\" data-anchor=\"#section1\">Section 1</a></p>\n<p><a href=\"#section2\" data-anchor=\"#section2\">Section 2&nbsp;</a></p>\n<p><a href=\"#section3\" data-anchor=\"#section3\">Section 3</a></p>\n<p></p>\n<h3 class=\"govuk-heading-m\"><a id=\"section1\"></a>Section 1</h3>\n<p>This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.</p>\n<p></p>\n<p></p>\n<h3 class=\"govuk-heading-m\"><a id=\"section2\"></a>Section 2</h3>\n<p>This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.</p>\n<h3 class=\"govuk-heading-m\"><a id=\"section3\"></a>Section 3</h3>\n<p>This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.This is an example section, users will be directed towards this section within page using in page anchor links. These anchors can be used to guide users navigating large content pages.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/9b5693e4a71342e9b85f6ee71027a66b"
     }
   ],
   "settingsData": [
     {
-      "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
-      "udi": "umb://element/fca618b9d1b04ec181ec4ac4c57084ae",
-      "cssClasses": "",
-      "cssClassesForRow": "",
       "columnSize": "",
       "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/fca618b9d1b04ec181ec4ac4c57084ae"
     },
     {
-      "contentTypeKey": "6ca199b3-814c-4aa9-b466-fc0533f2b543",
-      "udi": "umb://element/7fcbddbddb8f40e3bbc7e25fcb32c461",
-      "cssClasses": "",
-      "cssClassesForRow": "",
       "columnSize": "",
       "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "contentTypeKey": "6ca199b3-814c-4aa9-b466-fc0533f2b543",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/7fcbddbddb8f40e3bbc7e25fcb32c461"
     },
     {
       "contentTypeKey": "53edb934-ee79-4ff0-b23a-84b91e9fef7a",
-      "udi": "umb://element/46bad573908c4514ab5b4285c8a5c723",
       "cssClassesForRow": "",
-      "stackColumns": ""
+      "stackColumns": "",
+      "udi": "umb://element/46bad573908c4514ab5b4285c8a5c723"
     },
     {
-      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
-      "udi": "umb://element/d3ac4554734641458317b1ac23d48fe2",
-      "cssClassesForRow": "",
       "columnSize": "",
       "columnSizeFromDesktop": "",
-      "cssClassesForColumn": ""
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/d3ac4554734641458317b1ac23d48fe2"
     },
     {
       "contentTypeKey": "bfe62807-47c4-47b0-bb4b-c4a1d991886b",
-      "udi": "umb://element/f28cba82d468406fbee71281dddc05c5",
-      "cssClasses": ""
+      "cssClasses": "",
+      "udi": "umb://element/f28cba82d468406fbee71281dddc05c5"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/ff21e09184454e5eb1ac6a0ab1026c3c"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorInline.config
@@ -22,6 +22,7 @@
       "indent",
       "link",
       "unlink",
+      "anchor",
       "table",
       "subscript",
       "superscript",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/GOVUKRichTextEditorText.config
@@ -22,6 +22,7 @@
       "indent",
       "link",
       "unlink",
+      "anchor",
       "table",
       "subscript",
       "superscript",

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
@@ -28,7 +28,6 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (string.IsNullOrEmpty(Href)) { throw new ArgumentNullException(nameof(Href), "Document href cannot be null"); }
-            if (DatePublished == "January 0001" || DatePublished == "Ionawr 0001") { DatePublished = null; }
 
             var documentContext = (TprDocumentContext)context.Items[typeof(TprDocumentsTagHelper)];
             documentContext.Href = Href;


### PR DESCRIPTION
#AB233390 - Enable in page navigation anchors for rich text fields
![image](https://github.com/user-attachments/assets/54cfd364-0780-4e32-9786-8a1a7d1f196c)

#AB#AB233391 - Pass null to documents tag helper when document date picker is empty