### PR TITLE
TprHostUpdater was incorrectly matching and updating TPR automatic enrolment websites

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.4.0</Version>
+    <Version>8.4.1</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend.Tests/Services/TprHostUpdaterTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Services/TprHostUpdaterTests.cs
@@ -1,0 +1,97 @@
+﻿using ThePensionsRegulator.Frontend.Services;
+
+namespace ThePensionsRegulator.Frontend.Tests.Services
+{
+    public class TprHostUpdaterTests
+    {
+        [Fact]
+        public void Local_is_replaced_by_non_production()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.tpr.local/somepage", "example.nonprod.tpr.gov.uk");
+
+            Assert.Equal("https://example.nonprod.tpr.gov.uk/somepage", result);
+        }
+
+        [Fact]
+        public void Local_is_replaced_by_production()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.tpr.local/somepage", "example.thepensionsregulator.gov.uk");
+
+            Assert.Equal("https://example.thepensionsregulator.gov.uk/somepage", result);
+        }
+
+        [Fact]
+        public void Non_production_is_replaced_by_local()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.nonprod.tpr.gov.uk/somepage", "example.tpr.local");
+
+            Assert.Equal("https://example.tpr.local/somepage", result);
+        }
+
+        [Fact]
+        public void Non_production_is_replaced_by_production()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.nonprod.tpr.gov.uk/somepage", "example.thepensionsregulator.gov.uk");
+
+            Assert.Equal("https://example.thepensionsregulator.gov.uk/somepage", result);
+        }
+
+        [Fact]
+        public void Production_is_replaced_by_non_production()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.thepensionsregulator.gov.uk/somepage", "example.nonprod.tpr.gov.uk");
+
+            Assert.Equal("https://example.nonprod.tpr.gov.uk/somepage", result);
+        }
+
+        [Fact]
+        public void Production_is_replaced_by_local()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.thepensionsregulator.gov.uk/somepage", "example.tpr.local");
+
+            Assert.Equal("https://example.tpr.local/somepage", result);
+        }
+
+        [Fact]
+        public void Automatic_enrolment_domain_is_ignored()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.ae.tpr.gov.uk/somepage", "example.tpr.local");
+
+            Assert.Equal("https://example.ae.tpr.gov.uk/somepage", result);
+        }
+
+        [Fact]
+        public void Hostname_not_matching_pattern_is_ignored()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("https://example.org/somepage", "example.tpr.local");
+
+            Assert.Equal("https://example.org/somepage", result);
+        }
+
+        [Fact]
+        public void Relative_link_is_ignored()
+        {
+            var updater = new TprHostUpdater();
+
+            var result = updater.UpdateHost("/somepage", "example.tpr.local");
+
+            Assert.Equal("/somepage", result.ToString());
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend/Services/TprHostUpdater.cs
+++ b/ThePensionsRegulator.Frontend/Services/TprHostUpdater.cs
@@ -22,7 +22,7 @@ namespace ThePensionsRegulator.Frontend.Services
 
             var destination = new Uri(destinationUrl, UriKind.RelativeOrAbsolute);
 
-            if (!destination.IsAbsoluteUri || !IsTprHost(destination.Host) || !IsTprHost(requestHost))
+            if (!destination.IsAbsoluteUri || !IsTprHost(destination.Host) || IsTprAutomaticEnrolmentHost(destination.Host) || !IsTprHost(requestHost))
             {
                 return destinationUrl;
             }
@@ -72,19 +72,25 @@ namespace ThePensionsRegulator.Frontend.Services
             return IsTprLocal(segments) || IsTprNonProd(segments) || IsTprProd(segments);
         }
 
+        private static bool IsTprAutomaticEnrolmentHost(string host)
+        {
+            var segments = host.ToLowerInvariant().Split(".");
+            return segments.Length > 4 && segments[^4] == "ae" && segments[^3] == "tpr" && segments[^2] == "gov" && segments[^1] == "uk";
+        }
+
         private static bool IsTprProd(string[] segments)
         {
-            return segments.Length > 3 && segments[segments.Length - 3] == "thepensionsregulator" && segments[segments.Length - 2] == "gov" && segments[segments.Length - 1] == "uk";
+            return segments.Length > 3 && segments[^3] == "thepensionsregulator" && segments[^2] == "gov" && segments[^1] == "uk";
         }
 
         private static bool IsTprNonProd(string[] segments)
         {
-            return segments.Length > 4 && segments[segments.Length - 3] == "tpr" && segments[segments.Length - 2] == "gov" && segments[segments.Length - 1] == "uk";
+            return segments.Length > 4 && segments[^3] == "tpr" && segments[^2] == "gov" && segments[^1] == "uk";
         }
 
         private static bool IsTprLocal(string[] segments)
         {
-            return segments.Length > 2 && segments[segments.Length - 2] == "tpr" && segments[segments.Length - 1] == "local";
+            return segments.Length > 2 && segments[^2] == "tpr" && segments[^1] == "local";
         }
     }
 }


### PR DESCRIPTION
This PR fixes the bug and also moves the unit tests to the correct project.

[AB#233726](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/233726)