### PR TITLE
#AB233391 - Published date still showing on documents component when empty

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.4.1</Version>
+    <Version>8.4.2</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
@@ -24,7 +24,8 @@
             var docLinkType = documentLink.Type;
             var docTitle = documentLink.Name;
             var docPages = document.Content.Value<string>(TprPropertyAliases.DocumentNumberOfPages);
-            var docDatePublished = document.Content.Value<DateTime>(TprPropertyAliases.DocumentDatePublished).ToString("MMMM yyyy");
+            var dteValue = document.Content.Value<DateTime>(TprPropertyAliases.DocumentDatePublished);
+            var docDatePublished = dteValue > DateTime.MinValue ? dteValue.ToString("MMMM yyyy") : null;
             var docDescription = document.Content.Value<string>(TprPropertyAliases.DocumentDescription);
 
             if (docLinkType == LinkType.Media)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1eb43e00-fcc0-4fb1-9675-8be7e80c9769)
