### PR TITLE
Revert accidental commit that broke example app layout 

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
@@ -55,7 +55,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp
 
             if (_config.GetValue<bool>("TPRStyles"))
             {
-                services.AddTprFrontendUmbraco(options => options.UpdateDestinationHostnames = []);
+                services.AddTprFrontendUmbraco(options => options.RenderWidthContainerForBlocks = true);
             }
             else
             {


### PR DESCRIPTION
Revert a change committed in https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/pull/484 for [AB#235487](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/235487) that breaks the example app layout.

This change was just a temporary test of a new overload and was not meant to be committed.