### PR TITLE
Updates to the Umbraco document component when pulling titles

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.6.1</Version>
+    <Version>8.6.2</Version>
   </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprImageSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprImageSettings.generated.cs
@@ -50,6 +50,13 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		// properties
 
 		///<summary>
+		/// Decorative image: Sets the alt text to "" if the image is for decorative purposes only.
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.9.2+b414456")]
+		[ImplementPropertyType("decorativeImage")]
+		public virtual bool DecorativeImage => this.Value<bool>(_publishedValueFallback, "decorativeImage");
+
+		///<summary>
 		/// Image size: Fits full width of container if left blank.
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.9.2+b414456")]

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/documents.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/documents.config
@@ -85,11 +85,11 @@
           {
             "contentTypeKey": "ddf26d5b-0ebd-4ec4-b89f-3b422ca7c230",
             "datePublished": "2025-05-01T00:00:00",
-            "description": "This is an example PDF file, uploaded for example purposes.",
+            "description": "This is an example PDF file, uploaded for example purposes with the title being set using the 'link title' value.",
             "document": [
               {
-                "name": "Example PDF file",
-                "target": "_blank",
+                "name": "Example PDF file (using link title)",
+                "target": "",
                 "udi": "umb://media/48e78158d1b04a0e81ed3f982ad62481"
               }
             ],
@@ -99,7 +99,7 @@
           {
             "contentTypeKey": "ddf26d5b-0ebd-4ec4-b89f-3b422ca7c230",
             "datePublished": "2025-05-01T00:00:00",
-            "description": "This is an example Word file, uploaded for example purposes.",
+            "description": "This is an example Word file, uploaded for example purposes which uses the media 'document title' to set the title.",
             "document": [
               {
                 "name": "Example Word file",
@@ -164,7 +164,7 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "text": {
-        "markup": "<p>This is an example of a list of documents. Each document in the list is made up of a link to the respective document, the date the document was published, and a description of the document. If the document is a piece of media, such as a '.pdf', '.docx', or '.pptx', then the size of the file in KB (Kilobytes) and how many pages the document consists of will be included. However, if the media is a varient of an excel file such as '.xlsx', '.xlst', or '.csv', then the listing will not include pages.</p>\n<p>By default, the document node name is used to display the file name. However, if a 'Document Title' has been set in the media library, this title will be used instead. The first item in the document list below demonstrates this behaviour.</p>",
+        "markup": "<p>This is an example of a list of documents. Each document in the list is made up of a link to the respective document, the date the document was published, and a description of the document. If the document is a piece of media, such as a '.pdf', '.docx', or '.pptx', then the size of the file in KB (Kilobytes) and how many pages the document consists of will be included. However, if the media is a variant of an excel file such as '.xlsx', '.xlst', or '.csv', then the listing will not include pages.</p>\n<p>The title is determined by the following rules</p>\n<ul>\n<li>If a 'link title' is set, it will be used as the title.</li>\n<li>If no 'link title' is set, but a 'document title' is set in the media library, the 'document title' will be used.</li>\n<li>If neither a 'link title' nor a 'document title' is set, the 'document node' name will be used as the title.</li>\n</ul>",
         "blocks": {
           "contentData": [],
           "settingsData": []

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Media/example-word-file.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Media/example-word-file.config
@@ -11,7 +11,7 @@
   </Info>
   <Properties>
     <documentTitle>
-      <Value><![CDATA[]]></Value>
+      <Value><![CDATA[Example word file (document title)]]></Value>
     </documentTitle>
     <umbracoFile>
       <Value><![CDATA[/media/pjebff53/example-word-file.docx]]></Value>

--- a/ThePensionsRegulator.Frontend.Umbraco/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRDocuments.html
+++ b/ThePensionsRegulator.Frontend.Umbraco/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRDocuments.html
@@ -1,132 +1,36 @@
 ﻿<dl class="tpr-documents backoffice-block-view govuk-list {{block.settingsData.cssClasses}}">
     <ng-content ng-repeat="doc in block.data.documents.contentData">
-        <div ng-if="doc.document[0].url.endsWith('.pdf')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="pdf fileicon">PDF</span> --KB, {{doc.numberOfPages}} page(s)
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-bind="doc.description"></dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.docx') || doc.document[0].url.endsWith('.doc')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="doc fileicon">Word</span> --KB, {{doc.numberOfPages}} page(s)
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.dotx')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="doc fileicon">DOTX</span> --KB
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.pptx')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="powerpoint fileicon">PPTX</span> --KB, {{doc.numberOfPages}} page(s)
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.rtf')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="misc fileicon">RTF</span> --KB, {{doc.numberOfPages}} page(s)
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.odt')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="misc fileicon">ODT</span> --KB, {{doc.numberOfPages}} page(s)
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.xlsx')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="excel fileicon">Excel</span> --KB
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.xlst')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="excel fileicon">XLST</span> --KB
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
-        <div ng-if="doc.document[0].url.endsWith('.csv')" class="tpr-document">
-            <dt>
-                <a class="govuk-link" href="{{doc.document[0].url}}">
-                    {{doc.document[0].name}}
-                    <br>
-                    <span class="excel fileicon">CSV</span> --KB
-                </a>
-            </dt>
-            <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-            <dd ng-if="doc.description != ''">{{doc.description}}</dd>
-        </div>
-
         <ng-content ng-init="
-                ext = doc.document[0].url.split('.').pop().toLowerCase();
-                known = ['pdf','docx','dotx','pptx','xlsx','xlst','csv','rtf','odt','doc'];
-                isUnknown = known.indexOf(ext) === -1;
-                docName = doc.document[0].name != '' ? doc.document[0].name : doc.document[0].nodeName;">
-            <div ng-if="isUnknown === true" class="tpr-document">
-                <dt>
-                    <ng-content ng-switch="!!doc.document[0].name">
-                        <a ng-switch-when="true" class="govuk-link" href="{{doc.document[0].url}}">
-                            {{doc.document[0].name}}
-                        </a>
+            ext = doc.document[0].url.split('.').pop().toLowerCase();
+            known = ['csv', 'doc', 'docx', 'dotx', 'odt', 'pdf', 'pptx', 'rtf', 'xlst', 'xlsx'];
+            isKnown = known.indexOf(ext) !== -1;
+            docName = doc.document[0].name ? doc.document[0].name : doc.document[0].nodeName;">
 
-                        <a ng-switch-when="false" class="govuk-link" href="{{doc.document[0].url}}">
-                            {{doc.document[0].nodeName}}
-                        </a>
-                    </ng-content>
+            <div class="tpr-document">
+                <dt>
+                    <a class="govuk-link" href="{{doc.document[0].url}}">
+                        {{docName}}
+                        <ng-content ng-if="isKnown === true">
+                            <br>
+                            <span ng-if="ext == 'csv'" class="excel fileicon">CSV</span>
+                            <span ng-if="ext == 'doc'" class="doc fileicon">Word</span>
+                            <span ng-if="ext == 'docx'" class="doc fileicon">Word</span>
+                            <span ng-if="ext == 'dotx'" class="doc fileicon">DOTX</span>
+                            <span ng-if="ext == 'odt'" class="misc fileicon">ODT</span>
+                            <span ng-if="ext == 'pdf'" class="pdf fileicon">PDF</span>
+                            <span ng-if="ext == 'pptx'" class="powerpoint fileicon">PPTX</span>
+                            <span ng-if="ext == 'rtf'" class="misc fileicon">RTF</span>
+                            <span ng-if="ext == 'xlst'" class="excel fileicon">XLST</span>
+                            <span ng-if="ext == 'xlsx'" class="excel fileicon">Excel</span>
+                            <span>--KB, </span>
+                            <ng-content ng-if="doc.numberOfPages">
+                                {{doc.numberOfPages}} page(s)
+                            </ng-content>
+                        </ng-content>
+                    </a>
                 </dt>
-                <dd ng-if="doc.datePublished != ''">Published: {{doc.datePublished}}</dd>
-                <dd ng-if="doc.description != ''">{{doc.description}}</dd>
+                <dd ng-if="doc.datePublished">Published: {{doc.datePublished}}</dd>
+                <dd ng-if="doc.description">{{doc.description}}</dd>
             </div>
         </ng-content>
     </ng-content>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
@@ -9,7 +9,6 @@
 @{
     var outerCssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
     var documents = Model.Content.Value<IEnumerable<BlockListItem>>(TprPropertyAliases.DocumentsBlockList);
-    var imageExtensions = new[] { ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg" }.ToList();
 }
 
 <tpr-documents outercss="@outerCssClasses">
@@ -30,12 +29,21 @@
             if (docLinkType == LinkType.Media)
             {
                 var docKB = documentLink.Content.UmbracoBytes / 1024;
-                var docTitle = documentLink.Name;
-                var extension = System.IO.Path.GetExtension(docHref)?.ToLowerInvariant();
+                var docTitle = "";
 
-                if (!imageExtensions.Contains(extension) && !string.IsNullOrEmpty(documentLink.Content?.DocumentTitle))
+                var mediaLinkDocName = documentLink.Content.Name;
+                var mediaLinkTitle = documentLink.Name;
+                var mediaType = documentLink.Content?.ContentType?.Alias;
+
+                if (!string.Equals(mediaLinkDocName, mediaLinkTitle, StringComparison.OrdinalIgnoreCase))
                 {
-                    docTitle = documentLink.Content.DocumentTitle;
+                    docTitle = mediaLinkTitle;
+                }
+                else
+                {
+                    docTitle = (mediaType == "File" && !string.IsNullOrEmpty(documentLink.Content?.DocumentTitle))
+                        ? documentLink.Content.DocumentTitle
+                        : mediaLinkDocName;
                 }
 
                 <tpr-document href="@docHref" kbsize="@docKB" pages="@docPages" datepublished="@docDatePublished" innercss="@innerCssClasses">


### PR DESCRIPTION
Document component updates and bump version

Updated the Umbraco document component to pull the title using the following rules

If a link title is set, it will be used as the title.

If no link title is set, but a document title is set in the media library, the document title will be used.

If neither a link title nor a document title is set, the document node name will be used as the title.