### PR TITLE
#238214 - Search results component should have the govuk-heading-m default 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.6.2</Version>
+    <Version>8.6.3</Version>
   </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprSearchResultsSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprSearchResultsSettings.generated.cs
@@ -50,7 +50,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		// properties
 
 		///<summary>
-		/// Heading class: Defaults to 'govuk-heading-l' if left blank.
+		/// Heading class: Defaults to 'govuk-heading-m' if left blank.
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.9.2+b414456")]
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprsearchresultssettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprsearchresultssettings.config
@@ -31,7 +31,7 @@
       <Type>Umbraco.DropDown.Flexible</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[Defaults to 'govuk-heading-l' if left blank.]]></Description>
+      <Description><![CDATA[Defaults to 'govuk-heading-m' if left blank.]]></Description>
       <SortOrder>1</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSearchResults.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSearchResults.cshtml
@@ -25,7 +25,7 @@
 
     if (string.IsNullOrEmpty(headingClass))
     {
-        headingClass = "govuk-heading-l";
+        headingClass = "govuk-heading-m";
     }
 }
 


### PR DESCRIPTION
Based on the guidance here https://design-system.service.gov.uk/styles/headings/ the default class for a `<h2>` should be `govuk-heading-m`.