### PR TITLE
Section cards need to work in layouts other than full width

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.6.5</Version>
+    <Version>8.6.6</Version>
   </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/section-cards.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/section-cards.config
@@ -960,22 +960,23 @@
         "rowSpan": 1
       },
       {
-        "contentUdi": "umb://element/fa33c5e834c945578bdaa0401eb105ce",
-        "settingsUdi": "umb://element/152f448395e34041b443257b68d51c50",
-        "areas": [
-          {
-            "key": "466b98ba-8154-445d-b2b0-dc51ce5d2c9d",
-            "items": [
-              {
-                "areas": [],
-                "columnSpan": 12,
-                "rowSpan": 1,
-                "contentUdi": "umb://element/16fa21ba03bd40b5b7173ec30482eed3",
-                "settingsUdi": "umb://element/cbb4fb4489d045d6bd0b208af5eba3c8"
-              }
-            ]
-          }
-        ],
+        "contentUdi": "umb://element/ee88b039e9d44b20b3b4e2fd4d1fc534",
+        "settingsUdi": "umb://element/abbfafcaf77348f8ad66e4ede072c3f6",
+        "areas": [],
+        "columnSpan": 12,
+        "rowSpan": 1
+      },
+      {
+        "areas": [],
+        "columnSpan": 12,
+        "rowSpan": 1,
+        "contentUdi": "umb://element/ac7e2d5d967f4fab90b3c76129634043",
+        "settingsUdi": "umb://element/b5aa8b3feb86456091ec1dcada90fbb5"
+      },
+      {
+        "contentUdi": "umb://element/0b5739c47a23477cb1efe975b35c6d49",
+        "settingsUdi": "umb://element/4bd06681a3574eb49e5ce8f8b9f01de7",
+        "areas": [],
         "columnSpan": 12,
         "rowSpan": 1
       },
@@ -1000,8 +1001,62 @@
         "settingsUdi": "umb://element/88212d05dae74b24bf494e82a107fb6b"
       },
       {
-        "contentUdi": "umb://element/45f52c92db2d4c90a2309a022e63d587",
-        "settingsUdi": "umb://element/0fb9ed374ed54ec38e469bce643e8e4e",
+        "contentUdi": "umb://element/fa33c5e834c945578bdaa0401eb105ce",
+        "settingsUdi": "umb://element/152f448395e34041b443257b68d51c50",
+        "areas": [
+          {
+            "key": "466b98ba-8154-445d-b2b0-dc51ce5d2c9d",
+            "items": [
+              {
+                "contentUdi": "umb://element/066d1a32459b4a949fff3295f9eb25eb",
+                "settingsUdi": "umb://element/9d73612984d14718bbc83450f5fa4192",
+                "areas": [],
+                "columnSpan": 12,
+                "rowSpan": 1
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/16fa21ba03bd40b5b7173ec30482eed3",
+                "settingsUdi": "umb://element/cbb4fb4489d045d6bd0b208af5eba3c8"
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/e0d467c26f5744e384f1c7fa54eef403",
+                "settingsUdi": "umb://element/14e79fc633f64c51bdbce90213bf20c4"
+              },
+              {
+                "areas": [
+                  {
+                    "key": "e3d17c0e-a303-4d7e-9cbb-52752a355127",
+                    "items": [
+                      {
+                        "areas": [],
+                        "columnSpan": 12,
+                        "rowSpan": 1,
+                        "contentUdi": "umb://element/ca784d72e7284c8da739f689a592a9a6",
+                        "settingsUdi": "umb://element/d8852b77392041e09f01d0c3739d330b"
+                      }
+                    ]
+                  }
+                ],
+                "columnSpan": 12,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/3b643ba672b247f6bf8c2fc886d3f401",
+                "settingsUdi": "umb://element/ab8f5a2b58f64ac090341481a5b8c786"
+              }
+            ]
+          }
+        ],
+        "columnSpan": 12,
+        "rowSpan": 1
+      },
+      {
+        "contentUdi": "umb://element/2cbb67847af04c10b7b1e63271e689b6",
+        "settingsUdi": "umb://element/9594e976f2e84f068219f14be9034956",
         "areas": [],
         "columnSpan": 12,
         "rowSpan": 1
@@ -1025,6 +1080,182 @@
         "rowSpan": 1,
         "contentUdi": "umb://element/1d1f77f59ed64b0d87fbf55a2988b121",
         "settingsUdi": "umb://element/775ec2b1b8294382bb0d5d3d9f60a27b"
+      },
+      {
+        "contentUdi": "umb://element/d15c5f7a24794eeabcf64ce8901d1e1c",
+        "settingsUdi": "umb://element/c5945ac07e114b82860c10dce76c8dae",
+        "areas": [],
+        "columnSpan": 12,
+        "rowSpan": 1
+      },
+      {
+        "contentUdi": "umb://element/63f90b43bd4049ec92f1f311f8ba3ae0",
+        "settingsUdi": "umb://element/2c14ae4bc8a54129a661c4927345b016",
+        "areas": [
+          {
+            "key": "93d7d2e0-b4b9-498e-9b88-5d19b257d926",
+            "items": [
+              {
+                "contentUdi": "umb://element/81e4362a1d5842fb988342a37dc2d9ea",
+                "settingsUdi": "umb://element/fbd8e8f93f5b454887c5d4d035b3fbcb",
+                "areas": [],
+                "columnSpan": 9,
+                "rowSpan": 1
+              },
+              {
+                "areas": [],
+                "columnSpan": 9,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/99aea6c30b76497ebdb035af8c00779b",
+                "settingsUdi": "umb://element/8218d9af9ad04b3ea6be6233466d3000"
+              },
+              {
+                "areas": [],
+                "columnSpan": 9,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/8e13acf9615342dab8f0881f6472e169",
+                "settingsUdi": "umb://element/fc48b2c5a73f44e394599f4bd9b029b4"
+              },
+              {
+                "contentUdi": "umb://element/4b82603af884452eafa1b55beaa7b6db",
+                "settingsUdi": "umb://element/90ab6f92a1ca456985859e54e8e1e6e4",
+                "areas": [
+                  {
+                    "key": "e3d17c0e-a303-4d7e-9cbb-52752a355127",
+                    "items": [
+                      {
+                        "areas": [],
+                        "columnSpan": 12,
+                        "rowSpan": 1,
+                        "contentUdi": "umb://element/e59f1285508d4438b575cbef2d891d9a",
+                        "settingsUdi": "umb://element/9d0b6e1d2e7f493c898f06f75a4c79a3"
+                      }
+                    ]
+                  }
+                ],
+                "columnSpan": 9,
+                "rowSpan": 1
+              }
+            ]
+          }
+        ],
+        "columnSpan": 12,
+        "rowSpan": 1
+      },
+      {
+        "contentUdi": "umb://element/3f01fb308b7248118ef62b05c95f086f",
+        "settingsUdi": "umb://element/3e2aedf1125446c189cbb4a237891cb8",
+        "areas": [
+          {
+            "key": "c64c075c-f8ba-465f-8ea8-c5b692b10360",
+            "items": [
+              {
+                "contentUdi": "umb://element/69bf9cf5a5fb45868a92652bba861e11",
+                "settingsUdi": "umb://element/2f64e57a5a47407ab88f3fe8f8846f65",
+                "areas": [],
+                "columnSpan": 8,
+                "rowSpan": 1
+              },
+              {
+                "areas": [],
+                "columnSpan": 8,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/3d9c31b454ba43f5ab6aab7643f28cfc",
+                "settingsUdi": "umb://element/153afa31f925464cb3f1109eea622cd3"
+              },
+              {
+                "areas": [],
+                "columnSpan": 8,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/70fb531c54704321babbd8afc817f54e",
+                "settingsUdi": "umb://element/0a2be706cba6474ab0bc06b1cfd9daaf"
+              },
+              {
+                "contentUdi": "umb://element/a4d658212a634d9eb0bda1910c7e443c",
+                "settingsUdi": "umb://element/811afdcbc433442db2c23ec0ec2201d9",
+                "areas": [
+                  {
+                    "key": "e3d17c0e-a303-4d7e-9cbb-52752a355127",
+                    "items": [
+                      {
+                        "areas": [],
+                        "columnSpan": 12,
+                        "rowSpan": 1,
+                        "contentUdi": "umb://element/de1ceb429c9646d8b3ba6d21bae8447e",
+                        "settingsUdi": "umb://element/41d85a0f1f6a47d0a2c0de29fec2a1a2"
+                      }
+                    ]
+                  }
+                ],
+                "columnSpan": 8,
+                "rowSpan": 1
+              }
+            ]
+          }
+        ],
+        "columnSpan": 12,
+        "rowSpan": 1
+      },
+      {
+        "contentUdi": "umb://element/45f52c92db2d4c90a2309a022e63d587",
+        "settingsUdi": "umb://element/0fb9ed374ed54ec38e469bce643e8e4e",
+        "areas": [],
+        "columnSpan": 12,
+        "rowSpan": 1
+      },
+      {
+        "contentUdi": "umb://element/41ae7f11f5874adb9892dda857c07f9a",
+        "settingsUdi": "umb://element/d2fc52cca4ad4f55b590eeed748ea1cc",
+        "areas": [
+          {
+            "key": "9d720628-1287-4eb9-92be-2c880919b76b",
+            "items": [
+              {
+                "contentUdi": "umb://element/22fb9084af4d42b4b7327d65048e69c0",
+                "settingsUdi": "umb://element/cd7cec3b187b4a048ea7ba7d7353df69",
+                "areas": [],
+                "columnSpan": 6,
+                "rowSpan": 1
+              },
+              {
+                "areas": [],
+                "columnSpan": 6,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/bc078252008d4b679c0b280af9d0a465",
+                "settingsUdi": "umb://element/a76c74ae756f4e40ab5f55bb1643f4a2"
+              },
+              {
+                "areas": [],
+                "columnSpan": 6,
+                "rowSpan": 1,
+                "contentUdi": "umb://element/9985f403858b43938da84bf810720487",
+                "settingsUdi": "umb://element/faff0723f7e0470aa29849d041525dc4"
+              },
+              {
+                "contentUdi": "umb://element/1dd2e31d15d84ab78f804852b1d1564c",
+                "settingsUdi": "umb://element/d9bb86f5ef864b78879ad80ed09a8861",
+                "areas": [
+                  {
+                    "key": "e3d17c0e-a303-4d7e-9cbb-52752a355127",
+                    "items": [
+                      {
+                        "areas": [],
+                        "columnSpan": 12,
+                        "rowSpan": 1,
+                        "contentUdi": "umb://element/443187b3f2d7493c8804ebe7557d4d88",
+                        "settingsUdi": "umb://element/5d62454f1a7840f68d2ab783ae8b6cd0"
+                      }
+                    ]
+                  }
+                ],
+                "columnSpan": 6,
+                "rowSpan": 1
+              }
+            ]
+          }
+        ],
+        "columnSpan": 12,
+        "rowSpan": 1
       }
     ]
   },
@@ -1555,13 +1786,949 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "text": {
-        "markup": "<p>The section cards component displays a list of cards which can be added manually or generated automatically from child pages.</p>\n<p>The second child page is missing from the generated cards because it has the <em>umbracoNaviHide</em> property set to true, which hides it from navigation.</p>",
+        "markup": "<p>The section cards component displays a list of cards which can be added manually or generated automatically from child pages.</p>\n<p>The second child page is missing from the generated cards because it has the&nbsp;<em>umbracoNaviHide</em>&nbsp;property set to true, which hides it from navigation.</p>\n<p>Section cards are normally added inside a 'Box' or 'Nested box' block. If a 'Box' or 'Nested box' block is not used there must still be a coloured background so that the individual cards stand out. When used inside a 'Box' or 'Nested box' this background must be removed.</p>\n<p>The end result should be that section cards look exactly the same whether they are inside a 'Box' or 'Nested box' with default settings or not, but using a 'Box' or 'Nested box' adds the flexibility to use other settings like breaking out of the width container or changing the background colour.</p>\n<p>The number of section cards on a row should adapt to the size of the browser viewport.</p>\n<h2 class=\"govuk-heading-m\">Break out of the width container</h2>\n<p>The first two examples show section cards inside a 'Box' block that has its style set to 'Full-width', to break out of the width container. This is the most common usage. There are two examples in order to show that section cards respect different background colour settings on the 'Box'.</p>",
         "blocks": {
           "contentData": [],
           "settingsData": []
         }
       },
       "udi": "umb://element/3e7f714e3c984b6da4715531d7df22a1"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards inside a 'Full width' layout block, but not using a 'Nested box'.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/066d1a32459b4a949fff3295f9eb25eb"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards inside a 'Box' which is at the block grid root.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/0b5739c47a23477cb1efe975b35c6d49"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows a section cards block at the root of the block grid, but with no cards configured. It should not render anything.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/d15c5f7a24794eeabcf64ce8901d1e1c"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards in a 'Box' which is added at the block grid root, with its style set to 'Bordered'.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/2cbb67847af04c10b7b1e63271e689b6"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards in a 'Two thirds' layout block, but not using a 'Nested box'.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/69bf9cf5a5fb45868a92652bba861e11"
+    },
+    {
+      "contentTypeKey": "77726c2e-3248-4fab-bb3a-478e65ba9256",
+      "udi": "umb://element/3f01fb308b7248118ef62b05c95f086f"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/6e7fcfcc51714a1b88c628d2ea69467a",
+              "settingsUdi": "umb://element/5b02547350904953a31b83c11f436e69"
+            },
+            {
+              "contentUdi": "umb://element/ac3db95e71f14fb19d827483107547dd",
+              "settingsUdi": "umb://element/a2ede76a9233497da2a55053f5a631e7"
+            },
+            {
+              "contentUdi": "umb://element/9457041f4c394359acbc68645c7734e0",
+              "settingsUdi": "umb://element/6fa328b55b4d495180e7d22d1df273aa"
+            },
+            {
+              "contentUdi": "umb://element/cc98bf62a707413baf4250dc37118105",
+              "settingsUdi": "umb://element/433b6913ba3747e080ca61e1d3f0715f"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/6e7fcfcc51714a1b88c628d2ea69467a"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/ac3db95e71f14fb19d827483107547dd"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/9457041f4c394359acbc68645c7734e0"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/cc98bf62a707413baf4250dc37118105"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/5b02547350904953a31b83c11f436e69"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/a2ede76a9233497da2a55053f5a631e7"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/6fa328b55b4d495180e7d22d1df273aa"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/433b6913ba3747e080ca61e1d3f0715f"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/3d9c31b454ba43f5ab6aab7643f28cfc"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards inside a 'Nested box', which is inside a 'Two thirds' layout block.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/70fb531c54704321babbd8afc817f54e"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/1398122a85f3496d95d4062d495838c1",
+              "settingsUdi": "umb://element/97114e905b0c4a289169627aefabcf83"
+            },
+            {
+              "contentUdi": "umb://element/3222e915038d4e6899013820f3238bfe",
+              "settingsUdi": "umb://element/beef7f576dc24145b27a706fdec266d6"
+            },
+            {
+              "contentUdi": "umb://element/fe7f40dd36c74e8c90f6774aa18868a2",
+              "settingsUdi": "umb://element/8675dd5ad02c4a68aed9c40ffa7fd8d2"
+            },
+            {
+              "contentUdi": "umb://element/ec022d6b16be4815b48cee0bee35a9d6",
+              "settingsUdi": "umb://element/115dfaf063b6446f9aa3d9db7ec34fcb"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/1398122a85f3496d95d4062d495838c1"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/3222e915038d4e6899013820f3238bfe"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/fe7f40dd36c74e8c90f6774aa18868a2"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/ec022d6b16be4815b48cee0bee35a9d6"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/97114e905b0c4a289169627aefabcf83"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/beef7f576dc24145b27a706fdec266d6"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/8675dd5ad02c4a68aed9c40ffa7fd8d2"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/115dfaf063b6446f9aa3d9db7ec34fcb"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/de1ceb429c9646d8b3ba6d21bae8447e"
+    },
+    {
+      "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
+      "udi": "umb://element/a4d658212a634d9eb0bda1910c7e443c"
+    },
+    {
+      "contentTypeKey": "e5faf6a4-e1bd-4b25-9d3e-9076ba19c6e2",
+      "udi": "umb://element/63f90b43bd4049ec92f1f311f8ba3ae0"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<h2 class=\"govuk-heading-m\">Limit the width</h2>\n<p>Section cards can also be added inside other layout blocks with narrower widths. The number of section cards on a row should adapt to the size of the parent element as well as the size of the browser viewport.</p>\n<p>The next example shows section cards in a 'Three quarters' layout block, but not using a 'Nested box'.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/81e4362a1d5842fb988342a37dc2d9ea"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards inside a 'Nested box', which is inside a 'Three quarters' layout block.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/8e13acf9615342dab8f0881f6472e169"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/fccd4e1cac60467d80ea9cec860b4596",
+              "settingsUdi": "umb://element/a388d566d9a04c5cad43a54ad33f0e48"
+            },
+            {
+              "contentUdi": "umb://element/b5a414446f4740c38a260b07a0ca6c5e",
+              "settingsUdi": "umb://element/8dd36ffa466f4cb78368a6397e355c95"
+            },
+            {
+              "contentUdi": "umb://element/6ca93909e17a4d7fa53df81b6ab9b754",
+              "settingsUdi": "umb://element/5f6eb674249144e8a9223abc63fd29e3"
+            },
+            {
+              "contentUdi": "umb://element/00dfcb75df5f46e282e0cc457429771e",
+              "settingsUdi": "umb://element/247f53f8313c480c99ac8a81f691e892"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/fccd4e1cac60467d80ea9cec860b4596"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/b5a414446f4740c38a260b07a0ca6c5e"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/6ca93909e17a4d7fa53df81b6ab9b754"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/00dfcb75df5f46e282e0cc457429771e"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/a388d566d9a04c5cad43a54ad33f0e48"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/8dd36ffa466f4cb78368a6397e355c95"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/5f6eb674249144e8a9223abc63fd29e3"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/247f53f8313c480c99ac8a81f691e892"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/99aea6c30b76497ebdb035af8c00779b"
+    },
+    {
+      "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
+      "udi": "umb://element/4b82603af884452eafa1b55beaa7b6db"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/80cb9675c6d34a5c8e151159254f45e5",
+              "settingsUdi": "umb://element/498d2b849ce645b29c3d141b50f6fbab"
+            },
+            {
+              "contentUdi": "umb://element/2156a940244f47fbb89a9d20287337eb",
+              "settingsUdi": "umb://element/68b163e68d79469aa05223edebc1f0c0"
+            },
+            {
+              "contentUdi": "umb://element/32b9e1733b8c4a9ea0d59d7882d03df7",
+              "settingsUdi": "umb://element/faba22e0906c4a28b16784326c8a354d"
+            },
+            {
+              "contentUdi": "umb://element/ee8a708ac653419b99e675bcd43a81b0",
+              "settingsUdi": "umb://element/054c0411cd40456f94f847a5a688487f"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/80cb9675c6d34a5c8e151159254f45e5"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/2156a940244f47fbb89a9d20287337eb"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/32b9e1733b8c4a9ea0d59d7882d03df7"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/ee8a708ac653419b99e675bcd43a81b0"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/498d2b849ce645b29c3d141b50f6fbab"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/68b163e68d79469aa05223edebc1f0c0"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/faba22e0906c4a28b16784326c8a354d"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/054c0411cd40456f94f847a5a688487f"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/e59f1285508d4438b575cbef2d891d9a"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards in a 'One half' layout block, but not using a 'Nested box'.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/22fb9084af4d42b4b7327d65048e69c0"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/03820d8e1e284305a9e3aaa00c6dcf97",
+              "settingsUdi": "umb://element/0718164580984234bb44ad7f6b0a1a24"
+            },
+            {
+              "contentUdi": "umb://element/192273b9d3ea4c11a4cec5decfd767bd",
+              "settingsUdi": "umb://element/e8db1fbe3f8a461e8eff37596ea43507"
+            },
+            {
+              "contentUdi": "umb://element/35d5744fe9694764a31f3f2dd55cbe91",
+              "settingsUdi": "umb://element/e224ce5fdfa24f4b9dedd276b20a8a5d"
+            },
+            {
+              "contentUdi": "umb://element/e91d1dec88ea474983ed9dba0fd750b8",
+              "settingsUdi": "umb://element/15d92db3be214233a4284dfe1f9b55d2"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/03820d8e1e284305a9e3aaa00c6dcf97"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/192273b9d3ea4c11a4cec5decfd767bd"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/35d5744fe9694764a31f3f2dd55cbe91"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/e91d1dec88ea474983ed9dba0fd750b8"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/0718164580984234bb44ad7f6b0a1a24"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/e8db1fbe3f8a461e8eff37596ea43507"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/e224ce5fdfa24f4b9dedd276b20a8a5d"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/15d92db3be214233a4284dfe1f9b55d2"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/bc078252008d4b679c0b280af9d0a465"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards inside a 'Nested box', which is inside a 'One half' layout block.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/9985f403858b43938da84bf810720487"
+    },
+    {
+      "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
+      "udi": "umb://element/1dd2e31d15d84ab78f804852b1d1564c"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/7d23c64d92e24d0bb4d8ccabd4161126",
+              "settingsUdi": "umb://element/e90f323ae54f4149baeaf2a5bbb8c349"
+            },
+            {
+              "contentUdi": "umb://element/bf8b9a06c4ef45a08a1e05816b5ace03",
+              "settingsUdi": "umb://element/adcd62ddd6ea4d60a62d4e28817b00ea"
+            },
+            {
+              "contentUdi": "umb://element/d320ea28f69b4510a9cf3818b2f82097",
+              "settingsUdi": "umb://element/05f57c518a4f4f82a4d66efa5651fa0f"
+            },
+            {
+              "contentUdi": "umb://element/57cad99f57f84d14bdc1d96324a2bb5c",
+              "settingsUdi": "umb://element/05657df58c2b4b49840f57bce40058a7"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/7d23c64d92e24d0bb4d8ccabd4161126"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/bf8b9a06c4ef45a08a1e05816b5ace03"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/d320ea28f69b4510a9cf3818b2f82097"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/57cad99f57f84d14bdc1d96324a2bb5c"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/e90f323ae54f4149baeaf2a5bbb8c349"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/adcd62ddd6ea4d60a62d4e28817b00ea"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/05f57c518a4f4f82a4d66efa5651fa0f"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/05657df58c2b4b49840f57bce40058a7"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/443187b3f2d7493c8804ebe7557d4d88"
+    },
+    {
+      "contentTypeKey": "c4f050a6-959e-46c2-8889-71090289cce8",
+      "udi": "umb://element/41ae7f11f5874adb9892dda857c07f9a"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p class=\"govuk-heading-m govuk-body\">All examples from this point forward use a blue background to show when a 'Box' or 'Nested box' block is used. Aside from the colour they should look the same as the examples that are not inside a 'Box' or 'Nested box'.</p>\n<h2 class=\"govuk-heading-m\">Fill the width container</h2>\n<p>The next examples show section cards filling the width container. The first one shows section boxes added at the block grid root, but not using a 'Box'.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/ee88b039e9d44b20b3b4e2fd4d1fc534"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/e1ec6d2871e3434587ace1fa6da3a43a",
+              "settingsUdi": "umb://element/d91d7ff080884fa8b7dd29cbc07126e9"
+            },
+            {
+              "contentUdi": "umb://element/ab78cf2c749b4bfe9c6188bc7afa97ad",
+              "settingsUdi": "umb://element/7f13003084eb4a60a4848f4241df5977"
+            },
+            {
+              "contentUdi": "umb://element/b1de9ea6984b4dae887b6fbfb42ca38f",
+              "settingsUdi": "umb://element/9aaeae9b58f7467ca93e4c2ce3e5fe40"
+            },
+            {
+              "contentUdi": "umb://element/afc81950acd54db7ae81a7a8015810e3",
+              "settingsUdi": "umb://element/67bd936c3cd3431692febfb652419289"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/e1ec6d2871e3434587ace1fa6da3a43a"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/ab78cf2c749b4bfe9c6188bc7afa97ad"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/b1de9ea6984b4dae887b6fbfb42ca38f"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/afc81950acd54db7ae81a7a8015810e3"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/d91d7ff080884fa8b7dd29cbc07126e9"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/7f13003084eb4a60a4848f4241df5977"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/9aaeae9b58f7467ca93e4c2ce3e5fe40"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/67bd936c3cd3431692febfb652419289"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/ac7e2d5d967f4fab90b3c76129634043"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The next example shows section cards inside a 'Nested box', which is inside a 'Full width' layout block.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/e0d467c26f5744e384f1c7fa54eef403"
+    },
+    {
+      "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
+      "udi": "umb://element/3b643ba672b247f6bf8c2fc886d3f401"
+    },
+    {
+      "cards": {
+        "layout": {
+          "Umbraco.BlockList": [
+            {
+              "contentUdi": "umb://element/1763768d8a1940169bffacb7895268de",
+              "settingsUdi": "umb://element/3d52d53b2336452e965b9cf81121888f"
+            },
+            {
+              "contentUdi": "umb://element/04afda51339e45659b0a782134ee2728",
+              "settingsUdi": "umb://element/4f6f0a4e310649a59be8a18acae2fc3f"
+            },
+            {
+              "contentUdi": "umb://element/059d8927567e4cb5b4fd5b3cc78a2960",
+              "settingsUdi": "umb://element/43063c2b2468434f9827d087df951ec3"
+            },
+            {
+              "contentUdi": "umb://element/121aee6151f6441baa250c0dd53f07f3",
+              "settingsUdi": "umb://element/d03519288af746bc9d1c6fbb9a89d010"
+            }
+          ]
+        },
+        "contentData": [
+          {
+            "contentTypeKey": "73260d9d-6a32-4791-bda8-6b992526ec9d",
+            "udi": "umb://element/1763768d8a1940169bffacb7895268de"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "name": "Employers",
+                "url": "/employers"
+              }
+            ],
+            "udi": "umb://element/04afda51339e45659b0a782134ee2728"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": {
+              "markup": "<p>Lorem ipsum dolor sit amet, <strong>consectetur </strong>adipiscing elit. Duis sollicitudin nibh nisi, vitae sollicitudin nisl interdum <em>sed</em>. Nullam scelerisque maximus massa a tempus. Sed risus felis, eleifend id vestibulum sed, finibus quis massa. Quisque pellentesque commodo ante, nec commodo dolor porttitor sed.</p>\n<ul>\n<li>Bullet 1</li>\n<li>Bullet 2</li>\n<li>Bullet 3</li>\n</ul>",
+              "blocks": {
+                "contentData": [],
+                "settingsData": []
+              }
+            },
+            "link": [
+              {
+                "udi": "umb://document/449dad988cd84579be6be4a5868e4baa"
+              }
+            ],
+            "udi": "umb://element/059d8927567e4cb5b4fd5b3cc78a2960"
+          },
+          {
+            "contentTypeKey": "fa51167e-c0be-45ec-be60-88487f2d2c73",
+            "description": "",
+            "link": [
+              {
+                "udi": "umb://document/22a4a3efd9d74129b573ea9a707040b3"
+              }
+            ],
+            "udi": "umb://element/121aee6151f6441baa250c0dd53f07f3"
+          }
+        ],
+        "settingsData": [
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/3d52d53b2336452e965b9cf81121888f"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/4f6f0a4e310649a59be8a18acae2fc3f"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/43063c2b2468434f9827d087df951ec3"
+          },
+          {
+            "contentTypeKey": "2fd0c09e-c2ed-4ed1-b891-dd3470d2a3e3",
+            "cssClasses": "",
+            "udi": "umb://element/d03519288af746bc9d1c6fbb9a89d010"
+          }
+        ]
+      },
+      "contentTypeKey": "559cf32c-9e48-4498-9a08-e9c82c57c725",
+      "udi": "umb://element/ca784d72e7284c8da739f689a592a9a6"
     }
   ],
   "settingsData": [
@@ -1611,10 +2778,10 @@
     },
     {
       "backgroundColour": {
-        "value": "ededed",
-        "label": "Grey",
-        "sortOrder": 0,
-        "id": "1"
+        "value": "ebf5f7",
+        "label": "Blue",
+        "sortOrder": 1,
+        "id": "2"
       },
       "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
       "cssClasses": "",
@@ -1686,6 +2853,224 @@
       "cssClassesForColumn": "",
       "cssClassesForRow": "",
       "udi": "umb://element/885147836f00433899d5225e1da61c3c"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/9d73612984d14718bbc83450f5fa4192"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/4bd06681a3574eb49e5ce8f8b9f01de7"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/c5945ac07e114b82860c10dce76c8dae"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/9594e976f2e84f068219f14be9034956"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/2f64e57a5a47407ab88f3fe8f8846f65"
+    },
+    {
+      "contentTypeKey": "085fe7f7-9496-44bd-bda7-fe27726abed3",
+      "cssClassesForRow": "",
+      "stackColumns": "",
+      "udi": "umb://element/3e2aedf1125446c189cbb4a237891cb8"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/153afa31f925464cb3f1109eea622cd3"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/0a2be706cba6474ab0bc06b1cfd9daaf"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/41d85a0f1f6a47d0a2c0de29fec2a1a2"
+    },
+    {
+      "backgroundColour": {
+        "value": "ebf5f7",
+        "label": "Blue",
+        "sortOrder": 1,
+        "id": "2"
+      },
+      "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
+      "cssClasses": "",
+      "styleOfBox": "",
+      "udi": "umb://element/811afdcbc433442db2c23ec0ec2201d9"
+    },
+    {
+      "contentTypeKey": "085fe7f7-9496-44bd-bda7-fe27726abed3",
+      "cssClassesForRow": "",
+      "stackColumns": "",
+      "udi": "umb://element/2c14ae4bc8a54129a661c4927345b016"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/fbd8e8f93f5b454887c5d4d035b3fbcb"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/fc48b2c5a73f44e394599f4bd9b029b4"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/8218d9af9ad04b3ea6be6233466d3000"
+    },
+    {
+      "backgroundColour": {
+        "value": "ebf5f7",
+        "label": "Blue",
+        "sortOrder": 1,
+        "id": "2"
+      },
+      "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
+      "cssClasses": "",
+      "styleOfBox": "",
+      "udi": "umb://element/90ab6f92a1ca456985859e54e8e1e6e4"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/9d0b6e1d2e7f493c898f06f75a4c79a3"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/cd7cec3b187b4a048ea7ba7d7353df69"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/a76c74ae756f4e40ab5f55bb1643f4a2"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/faff0723f7e0470aa29849d041525dc4"
+    },
+    {
+      "backgroundColour": {
+        "value": "ebf5f7",
+        "label": "Blue",
+        "sortOrder": 1,
+        "id": "2"
+      },
+      "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
+      "cssClasses": "",
+      "styleOfBox": "",
+      "udi": "umb://element/d9bb86f5ef864b78879ad80ed09a8861"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/5d62454f1a7840f68d2ab783ae8b6cd0"
+    },
+    {
+      "contentTypeKey": "085fe7f7-9496-44bd-bda7-fe27726abed3",
+      "cssClassesForRow": "",
+      "stackColumns": "",
+      "udi": "umb://element/d2fc52cca4ad4f55b590eeed748ea1cc"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/abbfafcaf77348f8ad66e4ede072c3f6"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/b5aa8b3feb86456091ec1dcada90fbb5"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/14e79fc633f64c51bdbce90213bf20c4"
+    },
+    {
+      "backgroundColour": {
+        "value": "ebf5f7",
+        "label": "Blue",
+        "sortOrder": 1,
+        "id": "2"
+      },
+      "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
+      "cssClasses": "",
+      "styleOfBox": "",
+      "udi": "umb://element/ab8f5a2b58f64ac090341481a5b8c786"
+    },
+    {
+      "contentTypeKey": "0544d56d-431c-4ede-91b5-bf194b47c6e1",
+      "cssClasses": "",
+      "descriptionFieldName": "",
+      "titleFieldName": "",
+      "udi": "umb://element/d8852b77392041e09f01d0c3739d330b"
     }
   ]
 }]]></Value>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRBox.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRBox.cshtml
@@ -12,7 +12,7 @@
 @if (Model.Areas is not null && Model.Areas.Any())
 {
     var styleOfBox = Model.Settings.Value<string>(TprPropertyAliases.BoxStyle);
-    var isSolid = styleOfBox == TprBoxStyles.Solid;
+    var isSolid = string.IsNullOrEmpty(styleOfBox) || styleOfBox == TprBoxStyles.Solid;
     var isFullWidth = styleOfBox == TprBoxStyles.FullWidth;
     var boxClass = (string.IsNullOrEmpty(styleOfBox) || isSolid) ? null : " tpr-box--" + styleOfBox.ToLowerInvariant();
     var cssClasses = (" " + Model.Settings.Value<string>(GovUkPropertyAliases.CssClasses)).TrimEnd();

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
@@ -74,7 +74,7 @@
 .govuk-grid-row--tpr-divider > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
 .govuk-grid-row--tpr-divider > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
 .tpr-box > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button), 
-.tpr-box > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button), 
+.tpr-box > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .tpr-section-cards),
 .tpr-box.govuk-grid-row > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button), 
 .tpr-box.govuk-grid-row > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
 .tpr-box > .govuk-grid-row > .govuk-grid-column:last-child > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-section-cards.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-section-cards.scss
@@ -1,56 +1,63 @@
+@use "sass:map";
 @import '_tpr-variables.scss';
 @import 'govuk/base';
 
+/* .tpr-section-cards needs a default background and padding for the cards to contrast against. 
+    Display the cards in rows, where extra cards can wrap to the next row.
+*/
 .tpr-section-cards {
-    margin-top: 0;
-    margin-left: -$govuk-gutter-half;
-    margin-right: -$govuk-gutter-half;
     @include govuk-responsive-margin(6, "bottom");
-}
+    
+    background: $tpr-colour-whisper; 
+    padding: $govuk-gutter;
 
-.tpr-section-cards > ul {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: left;
-    margin: 0;
-    padding: 0;
-    background: $tpr-colour-whisper;
+    container-type: inline-size;
 
-    .tpr-box--full-width & {
-        background: transparent;
-        margin-left: $govuk-gutter*-1.5;
-        margin-right: $govuk-gutter*-1.5;
+    > ul {
+        display: flex;
+        flex-wrap: wrap;
+        gap: $govuk-gutter;
+        margin: 0;
+        padding: 0;
     }
 
-    @include govuk-media-query($from:1020px) {
-        .tpr-box--full-width & {
-            margin-left: -$govuk-gutter-half;
-            margin-right: -$govuk-gutter-half;
-        }
-    }
-}
+    .tpr-section-card {
+        flex-grow: 1; /* Fills unused space to make section boxes equal width */
+        display: flex; /* Fills unused space to make section boxes equal height */
 
-.tpr-section-card {
-    flex-grow: 1;
-    max-width: calc(100% / 3);
-    padding: 0;
-    box-sizing: border-box;
-    display: flex;
+        margin: 0;
+        padding: 0;
 
-    @include govuk-media-query($until:desktop) {
-        max-width: calc(100% / 2);
-    }
-
-    @include govuk-media-query($until:tablet) {
+        $tablet-breakpoint: map.get($govuk-breakpoints, "tablet")-($govuk-gutter*3);
+        $desktop-breakpoint: map.get($govuk-breakpoints, "desktop")-($govuk-gutter*3);
         max-width: 100%;
+
+        @container (width >= #{$tablet-breakpoint}) {
+            max-width: calc((100% - $govuk-gutter) / 2 );
+        }
+
+        @container (width >= #{$desktop-breakpoint}) {
+            max-width: calc((100% - ($govuk-gutter*2)) / 3);
+        }
+
     }
 }
+
+/* If .tpr-section-cards is added within .tpr-box, let .tpr-box handle the background and padding. */
+.tpr-box:not(.tpr-box--bordered) .tpr-section-cards {
+    padding: 0;
+    background: none; 
+}
+
+.tpr-box .tpr-section-cards:last-child {
+    margin: 0;
+}
+
 
 .tpr-section-card__body {
     background-color: $tpr-colour-white;
     margin: 0;
     @include govuk-responsive-padding(6);
-    margin: 0.9rem;
     flex-grow: 1;
 }
 
@@ -63,14 +70,7 @@
 }
 
 .tpr-section-card__title {
-    @include govuk-responsive-padding(6,"right");
-    @include govuk-responsive-padding(6,"bottom");
-    @include govuk-responsive-padding(6,"left");
-    margin: 0 govuk-spacing(-4);
+    @include govuk-responsive-padding(4,"bottom");
+    margin: 0;
     border-bottom: solid 1px $tpr-colour-very-light-grey;
-    
-    @include govuk-media-query($from:tablet) {
-        margin: 0 govuk-spacing(-6);
-    }
-
 }


### PR DESCRIPTION
There are a few issues with the existing implementation of section cards, as described in [AB#236415](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/236415).

- A horizontal scrollbar is triggered at small screen sizes
- Section cards assume three cards on a row for large screens, but this only works when using the full width container, not when added to a narrower column like two-thirds
- There are some minor differences to layout, visible in the example app, depending on whether the section cards are added inside a 'box' block or not

This PR resolves all of the above by:
- Refactoring the CSS to remove the use of negative margins
- Using the `gap` property to manage the space between boxes. [`gap` is widely supported since 2021](https://caniuse.com/flexbox-gap).
- Using container queries to make the number of boxes in a row responsive to the actual context rather than the viewport [Container queries are widely supported since 2023](https://caniuse.com/?search=%40container).
- Adding more examples and more explanation to the Umbraco example page for 'Section cards'.

It also fixes another bug  found along the way. In the 'Box' component if you don't select the style it should default to 'Solid'. This worked but if you selected a different colour (blue is the only non-default option currently) without selecting a style, the colour wasn't applied.