### PR TITLE
Update docs to match current recommendation for TinyMCE config

### DIFF
--- a/docs/umbraco/new-umbraco-project-govuk.md
+++ b/docs/umbraco/new-umbraco-project-govuk.md
@@ -23,7 +23,7 @@
            "ModelsDirectory": "~/Models/ModelsBuilder"
          },
          "RichTextEditor": {
-           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|style|class],-ol[style|class|reversed|start|type],-ul[style|class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
+           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|style|class],-ol[style|class|reversed|start|type],-ul[style|class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],#td[id|lang|class|colspan|rowspan|width],#th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
            "CustomConfig": {
              "table_advtab": "false",
              "table_cell_advtab": "false",

--- a/docs/umbraco/new-umbraco-project-tpr.md
+++ b/docs/umbraco/new-umbraco-project-tpr.md
@@ -27,7 +27,7 @@
            "ModelsDirectory": "~/Models/ModelsBuilder"
          },
          "RichTextEditor": {
-           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|style|class],-ol[style|class|reversed|start|type],-ul[style|class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],td[id|lang|class|colspan|rowspan|width],-th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
+           "ValidElements": "+a[id|rel|data-id|data-udi|rev|charset|hreflang|lang|tabindex|type|name|href|target|class],-strong/-b[class],-em/-i[class],-strike[class],p[id|style|class],-ol[style|class|reversed|start|type],-ul[style|class],-li[class],br[class],-sub[class],-sup[class],-blockquote[class],-table[class|id|lang],-tr[id|lang|class|rowspan],tbody[id|class],thead[id|class],tfoot[id|class],#td[id|lang|class|colspan|rowspan|width],#th[id|lang|class|colspan|rowspan|width|scope],caption[id|lang|class],-div[id|class],-span[class],-pre[class],-h1[id|class],-h2[id|class],-h3[id|class],-h4[id|class],-h5[id|class],-h6[id|class],hr[class],small[class],dd[id|class|lang],dl[id|class|lang],dt[id|class|dir|lang]",
            "CustomConfig": {
              "table_advtab": "false",
              "table_cell_advtab": "false",


### PR DESCRIPTION
[PR #480](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/pull/480) updated config to prevent empty table cells from being removed, but it neglected to update the docs.

[AB#236089](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/236089)