### PR TITLE
Fix inconsistent name

### DIFF
--- a/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             services.AddTransient<IRichTextPropertyEditorAliasProvider, TprRichTextPropertyEditorAliasProvider>();
             services.AddTransient<IBlockViewInterceptor, TprBoxViewInterceptor>();
             services.AddTransient<IBlockViewInterceptor, TprDividerViewInterceptor>();
-            services.AddTransient<IDefaultColumnClassProvider, TPRSectionCardsColumnClassProvider>();
+            services.AddTransient<IDefaultColumnClassProvider, TprSectionCardsColumnClassProvider>();
             services.AddTransient<IYouTubeVideoIdParser, YouTubeVideoIdParser>();
 
             return services;

--- a/ThePensionsRegulator.Frontend.Umbraco/Services/TprSectionCardsColumnClassProvider.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Services/TprSectionCardsColumnClassProvider.cs
@@ -1,5 +1,10 @@
-﻿namespace GovUk.Frontend.Umbraco.Services
+﻿using System;
+
+namespace GovUk.Frontend.Umbraco.Services
 {
+    [Obsolete("Use TprSectionCardsColumnClassProvider")]
+    public class TPRSectionCardsColumnClassProvider : TprSectionCardsColumnClassProvider { }
+
     /// <inheritdoc />
     public class TprSectionCardsColumnClassProvider : IDefaultColumnClassProvider
     {

--- a/ThePensionsRegulator.Frontend.Umbraco/Services/TprSectionCardsColumnClassProviderRename.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Services/TprSectionCardsColumnClassProviderRename.cs
@@ -1,7 +1,7 @@
 ﻿namespace GovUk.Frontend.Umbraco.Services
 {
     /// <inheritdoc />
-    public class TPRSectionCardsColumnClassProvider : IDefaultColumnClassProvider
+    public class TprSectionCardsColumnClassProvider : IDefaultColumnClassProvider
     {
         /// <inheritdoc />
         public string ColumnClasses => GovUkClassNames.ColumnFullWidth;


### PR DESCRIPTION
This PR just fixes the incorrect casing of a class name, where "TPR" is inconsistent with every other class named "Tpr".

By keeping the old name with an `[Obsolete]` marker this can be treated as a non-breaking change.