### PR TITLE
An empty href in a rich text area would throw an exception

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.8.1</Version>
+    <Version>8.8.2</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
@@ -27,4 +27,10 @@
     <ProjectReference Include="..\ThePensionsRegulator.Frontend\ThePensionsRegulator.Frontend.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInMultiUrlPickerPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInMultiUrlPickerPropertyValueFormatterTests.cs
@@ -7,10 +7,9 @@ using Umbraco.Cms.Core.Models;
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
 {
-    [TestFixture]
     public class HostNameInMultiUrlPickerPropertyValueFormatterTests
     {
-        [Test]
+        [Fact]
         public void Accepts_Link_as_input_and_replaces_link()
         {
             // Arrange
@@ -30,10 +29,10 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             var result = formatter.FormatValue(input);
 
             // Assert
-            Assert.That(((Link?)result)?.Url, Is.EqualTo(expected));
+            Assert.Equal(expected, ((Link?)result)?.Url);
         }
 
-        [Test]
+        [Fact]
         public void Accepts_List_of_Link_as_input_and_replaces_all_links()
         {
             // Arrange
@@ -61,7 +60,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             Assert.NotNull(links);
             foreach (var result in links!)
             {
-                Assert.That(((Link?)result)?.Url, Is.EqualTo(expected));
+                Assert.Equal(expected, ((Link?)result)?.Url);
             }
         }
     }

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatterTests.cs
@@ -7,10 +7,9 @@ using Umbraco.Cms.Core.Strings;
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
 {
-    [TestFixture]
     public class HostNameInRichTextEditorPropertyValueFormatterTests
     {
-        [Test]
+        [Fact]
         public void Accepts_string_or_HtmlEncodedString_as_input_and_replaces_links()
         {
             // Arrange
@@ -31,11 +30,11 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
 
             // Assert
-            Assert.That(((HtmlEncodedString)resultOfString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
-            Assert.That(((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfString)?.ToHtmlString());
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
         }
 
-        [Test]
+        [Fact]
         public void Ignores_anchor_link_targets()
         {
             // Arrange
@@ -54,13 +53,13 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             var result = formatter.FormatValue(INPUT);
 
             // Assert
-            Assert.That(((HtmlEncodedString)result)?.ToHtmlString(), Is.EqualTo(INPUT));
+            Assert.Equal(INPUT, ((HtmlEncodedString)result)?.ToHtmlString());
         }
 
-
-        [TestCase("")]
-        [TestCase(" ")]
-        [TestCase("  ")]
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
         public void Ignores_empty_href(string hrefValue)
         {
             // Arrange
@@ -79,7 +78,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             var result = formatter.FormatValue(INPUT);
 
             // Assert
-            Assert.That(((HtmlEncodedString)result)?.ToHtmlString(), Is.EqualTo(INPUT));
+            Assert.Equal(INPUT, ((HtmlEncodedString)result)?.ToHtmlString());
         }
     }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatterTests.cs
@@ -56,5 +56,30 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             // Assert
             Assert.That(((HtmlEncodedString)result)?.ToHtmlString(), Is.EqualTo(INPUT));
         }
+
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("  ")]
+        public void Ignores_empty_href(string hrefValue)
+        {
+            // Arrange
+            string INPUT = $"<p><a href='{hrefValue}'>Example</a></p>";
+
+            var context = new UmbracoTestContext();
+            var accessor = new Mock<IHttpContextAccessor>();
+            accessor.Setup(x => x.HttpContext).Returns(context.HttpContext.Object);
+
+            var hostUpdater = new Mock<IContextAwareHostUpdater>();
+            hostUpdater.Setup(x => x.UpdateHost("", context.HttpContext.Object.Request.Host.Host)).Returns("https://example.com");
+
+            var formatter = new HostNameInRichTextEditorPropertyValueFormatter(accessor.Object, hostUpdater.Object);
+
+            // Act
+            var result = formatter.FormatValue(INPUT);
+
+            // Assert
+            Assert.That(((HtmlEncodedString)result)?.ToHtmlString(), Is.EqualTo(INPUT));
+        }
     }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphsPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphsPropertyValueFormatterTests.cs
@@ -6,13 +6,13 @@ using Umbraco.Cms.Core.Strings;
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
 {
-    [TestFixture]
     public class NoParagraphsPropertyValueFormatterTests
     {
-        [TestCase(Constants.PropertyEditors.Aliases.TinyMce, false)]
-        [TestCase(GovUk.Frontend.Umbraco.PropertyEditorAliases.GovUkInlineRichText, false)]
-        [TestCase(GovUk.Frontend.Umbraco.PropertyEditorAliases.GovUkInlineInverseRichText, false)]
-        [TestCase(TprPropertyEditorAliases.TprHeaderFooterRichText, true)]
+        [Theory]
+        [InlineData(Constants.PropertyEditors.Aliases.TinyMce, false)]
+        [InlineData(GovUk.Frontend.Umbraco.PropertyEditorAliases.GovUkInlineRichText, false)]
+        [InlineData(GovUk.Frontend.Umbraco.PropertyEditorAliases.GovUkInlineInverseRichText, false)]
+        [InlineData(TprPropertyEditorAliases.TprHeaderFooterRichText, true)]
         public void Applies_only_to_correct_rich_text_property_editor(string propertyEditorAlias, bool expected)
         {
             // Arrange
@@ -23,10 +23,10 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             var result = formatter.IsFormatter(propertyType);
 
             // Assert
-            Assert.That(result, Is.EqualTo(expected));
+            Assert.Equal(expected, result);
         }
 
-        [Test]
+        [Fact]
         public void Accepts_string_or_HtmlEncodedString_as_input()
         {
             // Arrange
@@ -39,8 +39,8 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
 
             // Assert
-            Assert.That(((HtmlEncodedString)resultOfString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
-            Assert.That(((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfString)?.ToHtmlString());
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
         }
     }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprBoxViewInterceptorTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprBoxViewInterceptorTests.cs
@@ -9,8 +9,9 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
 {
     public class TprBoxViewInterceptorTests
     {
-        [TestCase(true)]
-        [TestCase(false)]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void Full_width_box_should_not_render_width_container_if_RenderWidthContainerForBlocks_enabled(bool renderWidthContainerInitialValue)
         {
             // Arrange
@@ -22,12 +23,13 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             interceptor.InterceptBlockView(blockView);
 
             // Assert
-            Assert.That(blockView.OpenWidthContainer, Is.False);
-            Assert.That(blockView.CloseWidthContainer, Is.False);
+            Assert.False(blockView.OpenWidthContainer);
+            Assert.False(blockView.CloseWidthContainer);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void Full_width_box_should_not_change_whether_to_render_width_container_if_RenderWidthContainerForBlocks_disabled(bool renderWidthContainerInitialValue)
         {
             // Arrange
@@ -39,12 +41,13 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             interceptor.InterceptBlockView(blockView);
 
             // Assert
-            Assert.That(blockView.OpenWidthContainer, Is.EqualTo(renderWidthContainerInitialValue));
-            Assert.That(blockView.CloseWidthContainer, Is.EqualTo(renderWidthContainerInitialValue));
+            Assert.Equal(renderWidthContainerInitialValue, blockView.OpenWidthContainer);
+            Assert.Equal(renderWidthContainerInitialValue, blockView.CloseWidthContainer);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void Other_box_should_not_change_whether_to_render_width_container(bool renderWidthContainerInitialValue)
         {
             // Arrange
@@ -56,12 +59,13 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             interceptor.InterceptBlockView(blockView);
 
             // Assert
-            Assert.That(blockView.OpenWidthContainer, Is.EqualTo(renderWidthContainerInitialValue));
-            Assert.That(blockView.CloseWidthContainer, Is.EqualTo(renderWidthContainerInitialValue));
+            Assert.Equal(renderWidthContainerInitialValue, blockView.OpenWidthContainer);
+            Assert.Equal(renderWidthContainerInitialValue, blockView.CloseWidthContainer);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void Other_block_should_not_change_whether_to_render_width_container(bool renderWidthContainerInitialValue)
         {
             // Arrange
@@ -78,25 +82,26 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             interceptor.InterceptBlockView(blockView);
 
             // Assert
-            Assert.That(blockView.OpenWidthContainer, Is.EqualTo(renderWidthContainerInitialValue));
-            Assert.That(blockView.CloseWidthContainer, Is.EqualTo(renderWidthContainerInitialValue));
+            Assert.Equal(renderWidthContainerInitialValue, blockView.OpenWidthContainer);
+            Assert.Equal(renderWidthContainerInitialValue, blockView.CloseWidthContainer);
         }
 
-        [TestCase(false, false, false, true)]
-        [TestCase(true, false, false, true)]
-        [TestCase(false, true, false, true)]
-        [TestCase(false, false, true, true)]
-        [TestCase(true, true, false, true)]
-        [TestCase(true, false, true, true)]
-        [TestCase(false, true, true, true)]
+        [Theory]
+        [InlineData(false, false, false, true)]
+        [InlineData(true, false, false, true)]
+        [InlineData(false, true, false, true)]
+        [InlineData(false, false, true, true)]
+        [InlineData(true, true, false, true)]
+        [InlineData(true, false, true, true)]
+        [InlineData(false, true, true, true)]
 
-        [TestCase(false, false, false, false)]
-        [TestCase(true, false, false, false)]
-        [TestCase(false, true, false, false)]
-        [TestCase(false, false, true, false)]
-        [TestCase(true, true, false, false)]
-        [TestCase(true, false, true, false)]
-        [TestCase(false, true, true, false)]
+        [InlineData(false, false, false, false)]
+        [InlineData(true, false, false, false)]
+        [InlineData(false, true, false, false)]
+        [InlineData(false, false, true, false)]
+        [InlineData(true, true, false, false)]
+        [InlineData(true, false, true, false)]
+        [InlineData(false, true, true, false)]
         public void WidthContainer_is_updated_to_reflect_whether_blocks_are_full_width_boxes(bool previousIsBox, bool currentIsBox, bool nextIsBox, bool boxesAreFullWidth)
         {
             // Arrange
@@ -131,19 +136,19 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             // Assert
             if (boxesAreFullWidth)
             {
-                Assert.That(blockViewWidthContainer.OpenWidthContainer, Is.EqualTo(!currentIsBox));
-                Assert.That(blockViewNoWidthContainer.OpenWidthContainer, Is.EqualTo(previousIsBox && !currentIsBox));
-                Assert.That(blockViewWidthContainer.CloseWidthContainer, Is.EqualTo(!currentIsBox));
-                Assert.That(blockViewNoWidthContainer.CloseWidthContainer, Is.EqualTo(!currentIsBox && nextIsBox));
+                Assert.Equal(!currentIsBox, blockViewWidthContainer.OpenWidthContainer);
+                Assert.Equal(previousIsBox && !currentIsBox, blockViewNoWidthContainer.OpenWidthContainer);
+                Assert.Equal(!currentIsBox, blockViewWidthContainer.CloseWidthContainer);
+                Assert.Equal(!currentIsBox && nextIsBox, blockViewNoWidthContainer.CloseWidthContainer);
             }
 
             // Assert - should not be updated
             if (!boxesAreFullWidth)
             {
-                Assert.That(blockViewWidthContainer.OpenWidthContainer, Is.True);
-                Assert.That(blockViewWidthContainer.CloseWidthContainer, Is.True);
-                Assert.That(blockViewNoWidthContainer.OpenWidthContainer, Is.False);
-                Assert.That(blockViewNoWidthContainer.CloseWidthContainer, Is.False);
+                Assert.True(blockViewWidthContainer.OpenWidthContainer);
+                Assert.True(blockViewWidthContainer.CloseWidthContainer);
+                Assert.False(blockViewNoWidthContainer.OpenWidthContainer);
+                Assert.False(blockViewNoWidthContainer.CloseWidthContainer);
             }
 
         }

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprDividerViewInterceptorTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprDividerViewInterceptorTests.cs
@@ -9,214 +9,219 @@ using GovUkPropertyAliases = GovUk.Frontend.Umbraco.PropertyAliases;
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
 {
-	public class TprDividerViewInterceptorTests
-	{
-		[TestCase(TprElementTypeAliases.Box, TprElementTypeAliases.BoxSettings)]
-		[TestCase(GovUkElementTypeAliases.GridOneQuarter, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridOneThird, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridOneHalf, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridTwoThirds, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridThreeQuarters, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridFullWidth, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridOneQuarterThreeQuarters, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridOneThirdTwoThirds, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridTwoEqualColumns, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridTwoThirdsOneThird, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridThreeQuartersOneQuarter, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridThreeEqualColumns, GovUkElementTypeAliases.GridThreeColumnLayoutSettings)]
-		[TestCase(GovUkElementTypeAliases.GridFourEqualColumns, GovUkElementTypeAliases.GridFourColumnLayoutSettings)]
-		public void Layout_block_is_not_updated(string contentAlias, string settingsAlias)
-		{
-			// Arrange
-			var blockViewModel = CreateBlockView(contentAlias, settingsAlias, false);
-			((OverridableBlockGridItem)blockViewModel.CurrentBlock)
-				.AddArea(UmbracoBlockGridFactory.CreateOverridableBlockGridArea([], "area"));
+    public class TprDividerViewInterceptorTests
+    {
+        [Theory]
+        [InlineData(TprElementTypeAliases.Box, TprElementTypeAliases.BoxSettings)]
+        [InlineData(GovUkElementTypeAliases.GridOneQuarter, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridOneThird, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridOneHalf, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridTwoThirds, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridThreeQuarters, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridFullWidth, GovUkElementTypeAliases.GridSingleColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridOneQuarterThreeQuarters, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridOneThirdTwoThirds, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridTwoEqualColumns, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridTwoThirdsOneThird, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridThreeQuartersOneQuarter, GovUkElementTypeAliases.GridTwoColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridThreeEqualColumns, GovUkElementTypeAliases.GridThreeColumnLayoutSettings)]
+        [InlineData(GovUkElementTypeAliases.GridFourEqualColumns, GovUkElementTypeAliases.GridFourColumnLayoutSettings)]
+        public void Layout_block_is_not_updated(string contentAlias, string settingsAlias)
+        {
+            // Arrange
+            var blockViewModel = CreateBlockView(contentAlias, settingsAlias, false);
+            ((OverridableBlockGridItem)blockViewModel.CurrentBlock)
+                .AddArea(UmbracoBlockGridFactory.CreateOverridableBlockGridArea([], "area"));
 
-			var interceptor = new TprDividerViewInterceptor();
+            var interceptor = new TprDividerViewInterceptor();
 
-			// Act
-			interceptor.InterceptBlockView(blockViewModel);
+            // Act
+            interceptor.InterceptBlockView(blockViewModel);
 
-			// Assert
-			Assert.That(blockViewModel.OpenGridRowAndColumn, Is.False);
-			Assert.That(blockViewModel.CloseGridRowAndColumn, Is.False);
-		}
+            // Assert
+            Assert.False(blockViewModel.OpenGridRowAndColumn);
+            Assert.False(blockViewModel.CloseGridRowAndColumn);
+        }
 
-		[TestCase(true)]
-		[TestCase(false)]
-		public void Grid_row_rendered_and_class_added_to_page_heading_if_missing(bool classWasAlreadyPresent)
-		{
-			// Arrange
-			var blockViewModel = CreateBlockView(GovUkElementTypeAliases.PageHeading, GovUkElementTypeAliases.PageHeadingSettings, classWasAlreadyPresent, classWasAlreadyPresent ? TprClassNames.Divider : null);
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Grid_row_rendered_and_class_added_to_page_heading_if_missing(bool classWasAlreadyPresent)
+        {
+            // Arrange
+            var blockViewModel = CreateBlockView(GovUkElementTypeAliases.PageHeading, GovUkElementTypeAliases.PageHeadingSettings, classWasAlreadyPresent, classWasAlreadyPresent ? TprClassNames.Divider : null);
 
-			var interceptor = new TprDividerViewInterceptor();
+            var interceptor = new TprDividerViewInterceptor();
 
-			// Act
-			interceptor.InterceptBlockView(blockViewModel);
+            // Act
+            interceptor.InterceptBlockView(blockViewModel);
 
-			// Assert
-			Assert.That(blockViewModel.RowClasses, Is.EqualTo($"{GovUkClassNames.Row} {TprClassNames.Divider}"));
-			Assert.That(blockViewModel.OpenGridRowAndColumn, Is.True);
-			Assert.That(blockViewModel.CloseGridRowAndColumn, Is.True);
-		}
+            // Assert
+            Assert.Equal($"{GovUkClassNames.Row} {TprClassNames.Divider}", blockViewModel.RowClasses);
+            Assert.True(blockViewModel.OpenGridRowAndColumn);
+            Assert.True(blockViewModel.CloseGridRowAndColumn);
+        }
 
-		[TestCase(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, true, true)]
-		[TestCase(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, true, false)]
-		[TestCase(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, false, false)]
+        [Theory]
+        [InlineData(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, true, true)]
+        [InlineData(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, true, false)]
+        [InlineData(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, false, false)]
 
-		[TestCase(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, true, true)]
-		[TestCase(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, true, false)]
-		[TestCase(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, false, false)]
+        [InlineData(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, true, true)]
+        [InlineData(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, true, false)]
+        [InlineData(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, false, false)]
 
-		[TestCase(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, true, true)]
-		[TestCase(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, true, false)]
-		[TestCase(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, false, false)]
+        [InlineData(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, true, true)]
+        [InlineData(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, true, false)]
+        [InlineData(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, false, false)]
 
-		[TestCase(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, true, true)]
-		[TestCase(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, true, false)]
-		[TestCase(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, false, false)]
+        [InlineData(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, true, true)]
+        [InlineData(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, true, false)]
+        [InlineData(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, false, false)]
 
-		[TestCase(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, false)]
-		[TestCase(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, false)]
+        [InlineData(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, false, false)]
 
-		[TestCase(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, false)]
-		[TestCase(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, false)]
+        [InlineData(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, false, false)]
 
-		[TestCase(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, false)]
-		[TestCase(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, false)]
+        [InlineData(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, false, false)]
 
-		[TestCase(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, false)]
-		[TestCase(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, false, false)]
-		public void If_component_includes_page_heading_grid_row_rendered_and_class_added_if_missing(string contentAlias, string settingsAlias, bool isFieldset, bool legendIsPageHeading, bool classWasAlreadyPresent)
-		{
-			// Arrange
-			var isPageHeadingProperty = isFieldset ? GovUkPropertyAliases.FieldsetLegendIsPageHeading : GovUkPropertyAliases.LabelIsPageHeading;
-			var dividerClass = isFieldset ? TprClassNames.DividerForFieldsetWithLegendAsPageHeading : TprClassNames.DividerForFormComponentWithLabelAsPageHeading;
+        [InlineData(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, false)]
+        [InlineData(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, false, false)]
+        public void If_component_includes_page_heading_grid_row_rendered_and_class_added_if_missing(string contentAlias, string settingsAlias, bool isFieldset, bool legendIsPageHeading, bool classWasAlreadyPresent)
+        {
+            // Arrange
+            var isPageHeadingProperty = isFieldset ? GovUkPropertyAliases.FieldsetLegendIsPageHeading : GovUkPropertyAliases.LabelIsPageHeading;
+            var dividerClass = isFieldset ? TprClassNames.DividerForFieldsetWithLegendAsPageHeading : TprClassNames.DividerForFormComponentWithLabelAsPageHeading;
 
-			var blockViewModel = CreateBlockView(contentAlias, settingsAlias, classWasAlreadyPresent, classWasAlreadyPresent ? dividerClass : null);
-			Mock.Get(blockViewModel.CurrentBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, legendIsPageHeading);
+            var blockViewModel = CreateBlockView(contentAlias, settingsAlias, classWasAlreadyPresent, classWasAlreadyPresent ? dividerClass : null);
+            Mock.Get(blockViewModel.CurrentBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, legendIsPageHeading);
 
-			var interceptor = new TprDividerViewInterceptor();
+            var interceptor = new TprDividerViewInterceptor();
 
-			// Act
-			interceptor.InterceptBlockView(blockViewModel);
+            // Act
+            interceptor.InterceptBlockView(blockViewModel);
 
-			// Assert
-			if (legendIsPageHeading)
-			{
-				Assert.That(blockViewModel.RowClasses, Is.EqualTo($"{GovUkClassNames.Row} {dividerClass}"));
-				Assert.That(blockViewModel.OpenGridRowAndColumn, Is.True);
-				Assert.That(blockViewModel.CloseGridRowAndColumn, Is.True);
-			}
-			else
-			{
-				Assert.That(blockViewModel.RowClasses, Is.EqualTo(GovUkClassNames.Row));
-				Assert.That(blockViewModel.OpenGridRowAndColumn, Is.False);
-				Assert.That(blockViewModel.CloseGridRowAndColumn, Is.False);
-			}
-		}
+            // Assert
+            if (legendIsPageHeading)
+            {
+                Assert.Equal($"{GovUkClassNames.Row} {dividerClass}", blockViewModel.RowClasses);
+                Assert.True(blockViewModel.OpenGridRowAndColumn);
+                Assert.True(blockViewModel.CloseGridRowAndColumn);
+            }
+            else
+            {
+                Assert.Equal(GovUkClassNames.Row, blockViewModel.RowClasses);
+                Assert.False(blockViewModel.OpenGridRowAndColumn);
+                Assert.False(blockViewModel.CloseGridRowAndColumn);
+            }
+        }
 
-		[TestCase(GovUkElementTypeAliases.PageHeading, GovUkElementTypeAliases.PageHeadingSettings, false, false, true)]
-		[TestCase(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, false, false)]
-		public void Block_following_component_where_class_is_added_sets_OpenGridRowAndColumn_true(string contentAlias, string settingsAlias, bool hasLegendAsHeading, bool hasLabelAsHeading, bool expected)
-		{
-			// Arrange
-			var isPageHeadingProperty = hasLegendAsHeading ? GovUkPropertyAliases.FieldsetLegendIsPageHeading : hasLabelAsHeading ? GovUkPropertyAliases.LabelIsPageHeading : null;
+        [Theory]
+        [InlineData(GovUkElementTypeAliases.PageHeading, GovUkElementTypeAliases.PageHeadingSettings, false, false, true)]
+        [InlineData(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, false, false)]
+        public void Block_following_component_where_class_is_added_sets_OpenGridRowAndColumn_true(string contentAlias, string settingsAlias, bool hasLegendAsHeading, bool hasLabelAsHeading, bool expected)
+        {
+            // Arrange
+            var isPageHeadingProperty = hasLegendAsHeading ? GovUkPropertyAliases.FieldsetLegendIsPageHeading : hasLabelAsHeading ? GovUkPropertyAliases.LabelIsPageHeading : null;
 
-			var blockViewModel = CreateBlockView("content", "settings", false);
-			blockViewModel.PreviousBlock = CreateBlock(contentAlias, settingsAlias);
-			if (isPageHeadingProperty is not null)
-			{
-				Mock.Get(blockViewModel.PreviousBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
-			}
+            var blockViewModel = CreateBlockView("content", "settings", false);
+            blockViewModel.PreviousBlock = CreateBlock(contentAlias, settingsAlias);
+            if (isPageHeadingProperty is not null)
+            {
+                Mock.Get(blockViewModel.PreviousBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
+            }
 
-			var interceptor = new TprDividerViewInterceptor();
+            var interceptor = new TprDividerViewInterceptor();
 
-			// Act
-			interceptor.InterceptBlockView(blockViewModel);
+            // Act
+            interceptor.InterceptBlockView(blockViewModel);
 
-			// Assert
-			Assert.That(blockViewModel.OpenGridRowAndColumn, Is.EqualTo(expected));
-		}
+            // Assert
+            Assert.Equal(expected, blockViewModel.OpenGridRowAndColumn);
+        }
 
-		[TestCase(GovUkElementTypeAliases.PageHeading, GovUkElementTypeAliases.PageHeadingSettings, false, false, true)]
-		[TestCase(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, false, true)]
-		[TestCase(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, false, false)]
-		[TestCase(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, true)]
-		[TestCase(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, false, false)]
-		public void Block_preceding_component_where_class_is_added_sets_CloseGridRowAndColumn_true(string contentAlias, string settingsAlias, bool hasLegendAsHeading, bool hasLabelAsHeading, bool expected)
-		{
-			// Arrange
-			var isPageHeadingProperty = hasLegendAsHeading ? GovUkPropertyAliases.FieldsetLegendIsPageHeading : hasLabelAsHeading ? GovUkPropertyAliases.LabelIsPageHeading : null;
+        [Theory]
+        [InlineData(GovUkElementTypeAliases.PageHeading, GovUkElementTypeAliases.PageHeadingSettings, false, false, true)]
+        [InlineData(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.CheckboxesSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.DateInputSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.FieldsetSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, true, false, true)]
+        [InlineData(GovUkElementTypeAliases.Radios, GovUkElementTypeAliases.RadiosSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.FileUploadSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.Select, GovUkElementTypeAliases.SelectSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextareaSettings, false, false, false)]
+        [InlineData(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, true, true)]
+        [InlineData(GovUkElementTypeAliases.TextInput, GovUkElementTypeAliases.TextInputSettings, false, false, false)]
+        public void Block_preceding_component_where_class_is_added_sets_CloseGridRowAndColumn_true(string contentAlias, string settingsAlias, bool hasLegendAsHeading, bool hasLabelAsHeading, bool expected)
+        {
+            // Arrange
+            var isPageHeadingProperty = hasLegendAsHeading ? GovUkPropertyAliases.FieldsetLegendIsPageHeading : hasLabelAsHeading ? GovUkPropertyAliases.LabelIsPageHeading : null;
 
-			var blockViewModel = CreateBlockView("content", "settings", false);
-			blockViewModel.NextBlock = CreateBlock(contentAlias, settingsAlias);
-			if (isPageHeadingProperty is not null)
-			{
-				Mock.Get(blockViewModel.NextBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
-			}
+            var blockViewModel = CreateBlockView("content", "settings", false);
+            blockViewModel.NextBlock = CreateBlock(contentAlias, settingsAlias);
+            if (isPageHeadingProperty is not null)
+            {
+                Mock.Get(blockViewModel.NextBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
+            }
 
-			var interceptor = new TprDividerViewInterceptor();
+            var interceptor = new TprDividerViewInterceptor();
 
-			// Act
-			interceptor.InterceptBlockView(blockViewModel);
+            // Act
+            interceptor.InterceptBlockView(blockViewModel);
 
-			// Assert
-			Assert.That(blockViewModel.CloseGridRowAndColumn, Is.EqualTo(expected));
-		}
+            // Assert
+            Assert.Equal(expected, blockViewModel.CloseGridRowAndColumn);
+        }
 
-		private static BlockViewModel CreateBlockView(string contentAlias, string settingsAlias, bool renderGridRowInitialValue, string? existingRowClasses = null)
-		{
-			var block = CreateBlock(contentAlias, settingsAlias, existingRowClasses);
-			var blockView = new BlockViewModel
-			{
-				CurrentBlock = block,
-				OpenGridRowAndColumn = renderGridRowInitialValue,
-				CloseGridRowAndColumn = renderGridRowInitialValue
-			};
-			if (existingRowClasses is not null) { blockView.RowClasses += $" {existingRowClasses}"; }
-			return blockView;
-		}
+        private static BlockViewModel CreateBlockView(string contentAlias, string settingsAlias, bool renderGridRowInitialValue, string? existingRowClasses = null)
+        {
+            var block = CreateBlock(contentAlias, settingsAlias, existingRowClasses);
+            var blockView = new BlockViewModel
+            {
+                CurrentBlock = block,
+                OpenGridRowAndColumn = renderGridRowInitialValue,
+                CloseGridRowAndColumn = renderGridRowInitialValue
+            };
+            if (existingRowClasses is not null) { blockView.RowClasses += $" {existingRowClasses}"; }
+            return blockView;
+        }
 
-		private static OverridableBlockGridItem CreateBlock(string contentAlias, string settingsAlias, string? existingRowClasses = null)
-		{
-			var settings = UmbracoBlockGridFactory.CreateContentOrSettings(settingsAlias);
-			if (existingRowClasses is not null) { settings.SetupUmbracoTextboxPropertyValue(GovUkPropertyAliases.CssClassesForRow, existingRowClasses); }
-			return UmbracoBlockGridFactory.CreateOverridableBlock(
-						UmbracoBlockGridFactory.CreateContentOrSettings(contentAlias).Object,
-						settings.Object
-					);
-		}
-	}
+        private static OverridableBlockGridItem CreateBlock(string contentAlias, string settingsAlias, string? existingRowClasses = null)
+        {
+            var settings = UmbracoBlockGridFactory.CreateContentOrSettings(settingsAlias);
+            if (existingRowClasses is not null) { settings.SetupUmbracoTextboxPropertyValue(GovUkPropertyAliases.CssClassesForRow, existingRowClasses); }
+            return UmbracoBlockGridFactory.CreateOverridableBlock(
+                        UmbracoBlockGridFactory.CreateContentOrSettings(contentAlias).Object,
+                        settings.Object
+                    );
+        }
+    }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/YouTubeVideoIdParserTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/YouTubeVideoIdParserTests.cs
@@ -2,31 +2,32 @@
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
 {
-    [TestFixture]
     public class YouTubeVideoIdParserTests
     {
-        [TestCase("https://www.youtube.com/embed/tTQiv1xKVM4")]
-        [TestCase("https://www.youtube.com/embed/tTQiv1xKVM4?utm_source=example")]
-        [TestCase("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4")]
-        [TestCase("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4?utm_source=example")]
-        [TestCase("https://www.youtube.com/watch?v=tTQiv1xKVM4")]
-        [TestCase("https://www.youtube.com/watch?v=tTQiv1xKVM4&utm_source=example")]
-        [TestCase("https://youtu.be/tTQiv1xKVM4")]
-        [TestCase("https://youtu.be/tTQiv1xKVM4?utm_source=example")]
+        [Theory]
+        [InlineData("https://www.youtube.com/embed/tTQiv1xKVM4")]
+        [InlineData("https://www.youtube.com/embed/tTQiv1xKVM4?utm_source=example")]
+        [InlineData("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4")]
+        [InlineData("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4?utm_source=example")]
+        [InlineData("https://www.youtube.com/watch?v=tTQiv1xKVM4")]
+        [InlineData("https://www.youtube.com/watch?v=tTQiv1xKVM4&utm_source=example")]
+        [InlineData("https://youtu.be/tTQiv1xKVM4")]
+        [InlineData("https://youtu.be/tTQiv1xKVM4?utm_source=example")]
         public void Valid_URL_returns_video_id(string originalUrl)
         {
             var normaliser = new YouTubeVideoIdParser();
             var result = normaliser.TryParseUrl(new Uri(originalUrl), out var videoId);
 
             Assert.True(result);
-            Assert.That(videoId, Is.EqualTo("tTQiv1xKVM4"));
+            Assert.Equal("tTQiv1xKVM4", videoId);
         }
 
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("not-a-url")]
-        [TestCase("https://www.youtube.com")]
-        [TestCase("https://example.org")]
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not-a-url")]
+        [InlineData("https://www.youtube.com")]
+        [InlineData("https://example.org")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2234:Pass system uri objects instead of strings", Justification = "Testing for invalid URLs")]
         public void Invalid_URL_returns_false(string? originalUrl)
         {

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,21 +10,26 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ThePensionsRegulator.Frontend.Umbraco\ThePensionsRegulator.Frontend.Umbraco.csproj" />
     <ProjectReference Include="..\ThePensionsRegulator.Umbraco.Testing\ThePensionsRegulator.Umbraco.Testing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Usings.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Usings.cs
@@ -1,1 +1,1 @@
-global using NUnit.Framework;
+global using Xunit;

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/xunit.runner.json
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "ReplaceUnderscoreWithSpace"
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatter.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatter.cs
@@ -49,7 +49,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters
             var html = value is IHtmlEncodedString encoded ? encoded.ToHtmlString() : value.ToString();
             var document = new HtmlDocument();
             document.LoadHtml(html);
-            var links = document.DocumentNode.SelectNodes("//a[@href]");
+            var links = document.DocumentNode.SelectNodes("//a[@href and @href!='' and normalize-space(@href) != ' ']");
             if (links != null)
             {
                 foreach (var link in links)


### PR DESCRIPTION
An empty href in a rich text area is quite hard to achieve, but we had one with a duplicated media item and it threw an exception and crashed the page. This PR fixes that by updating `HostNameInRichTextEditorPropertyValueFormatter.cs` to ignore empty hrefs, and providing tests to verify that.

Since I was working on those tests I also took the opportunity to update that test project to TPR's current standard of XUnit.