### PR TITLE
A JS error prevented client-side validation from working

### DIFF
--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/UmbracoValidation.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/UmbracoValidation.cshtml
@@ -1,8 +1,11 @@
-﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper *, Smidge
-<environment names="Development">
-    <script src="govuk-frontend-validation" debug="true"></script>
-</environment>
-<environment names="Staging,Production">
-    <script src="govuk-frontend-validation"></script>
-</environment>
+﻿@using Microsoft.AspNetCore.Hosting
+@using Microsoft.Extensions.Hosting
+@inject Smidge.SmidgeHelper smidgeHelper
+@inject IWebHostEnvironment environment
+@{
+    var urls = await smidgeHelper.GenerateJsUrlsAsync("govuk-frontend-validation", environment.EnvironmentName.Equals(Environments.Development, StringComparison.OrdinalIgnoreCase));
+}
+@foreach (var url in urls)
+{
+    <script src="@url" type="module"></script>
+}


### PR DESCRIPTION
[govuk-validation.js](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/blob/develop/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js) now includes an `export` statement that requires it to be loaded with `<script type="module"></script>`.

The `Validation` partial view had been updated but the `UmbracoValidation` partial view, which uses Smidge, had not. This resulted in a console error. When validation failed the invalid field was focused but no error message appeared. This problem was visible throughout the Umbraco example app.

Smidge's tag helper doesn't support `type="module"`, so this PR gets the URLs Smidge would've rendered and puts them in a script tag. They all get  `type="module"` whether or not they need it, but this doesn't break anything.

Fixes #508.