### PR TITLE
#240633 Adding accessible labels to document download links

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.8.3</Version>
+    <Version>8.8.4</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentContext.cs
@@ -1,10 +1,4 @@
 ﻿using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
 {

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
@@ -25,14 +25,9 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                 if (documentContext.Href.Contains('.')) { fileExtension = documentContext.Href.Split(".").Skip(1).ToArray()[0].ToString(); }
                 var isMediaLink = knownFileExtensions.Contains(fileExtension);
 
-                if (isMediaLink)
-                {
-                    output.TagName = $"a class=\"govuk-link\" href=\"{documentContext.Href}\" download";
-                }
-                else
-                {
-                    output.TagName = $"a class=\"govuk-link\" href=\"{documentContext.Href}\"";
-                }
+                output.TagName = $"a class=\"govuk-link\" href=\"{documentContext.Href}\"";
+
+                if (isMediaLink) { output.TagName += "download"; }
 
                 if (documentContext.Href.EndsWith(".pdf"))
                 {

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Razor.TagHelpers;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
@@ -14,11 +15,25 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             var documentContext = (TprDocumentContext)context.Items[typeof(TprDocumentsTagHelper)];
             documentContext.DocumentTitle = await output.GetChildContentAsync();
 
-            output.PreElement.SetHtmlContent("<dt>");
-            output.TagName = $"a class=\"govuk-link\" href=\"{documentContext.Href}\"";
-
             if (documentContext.Href != null)
             {
+                output.PreElement.SetHtmlContent("<dt>");
+
+                string[] knownFileExtensions = ["csv", "doc", "docx", "dotx", "odt", "pdf", "pptx", "rtf", "xlst", "xlsx"];
+                var fileExtension = string.Empty;
+
+                if (documentContext.Href.Contains('.')) { fileExtension = documentContext.Href.Split(".").Skip(1).ToArray()[0].ToString(); }
+                var isMediaLink = knownFileExtensions.Contains(fileExtension);
+
+                if (isMediaLink)
+                {
+                    output.TagName = $"a class=\"govuk-link\" href=\"{documentContext.Href}\" download";
+                }
+                else
+                {
+                    output.TagName = $"a class=\"govuk-link\" href=\"{documentContext.Href}\"";
+                }
+
                 if (documentContext.Href.EndsWith(".pdf"))
                 {
                     if (documentContext.Pages == "0")


### PR DESCRIPTION
In this PR:
- Added 'download' attribute to document download links within the list of documents component;
- Removed some redundant using statements in the list of documents context file.