### PR TITLE
Updated regex to include - (hypens) and added more unit tests.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>8.8.4</Version>
+    <Version>8.8.5</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/YouTubeVideoIdParserTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/YouTubeVideoIdParserTests.cs
@@ -5,21 +5,29 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
     public class YouTubeVideoIdParserTests
     {
         [Theory]
-        [InlineData("https://www.youtube.com/embed/tTQiv1xKVM4")]
-        [InlineData("https://www.youtube.com/embed/tTQiv1xKVM4?utm_source=example")]
-        [InlineData("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4")]
-        [InlineData("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4?utm_source=example")]
-        [InlineData("https://www.youtube.com/watch?v=tTQiv1xKVM4")]
-        [InlineData("https://www.youtube.com/watch?v=tTQiv1xKVM4&utm_source=example")]
-        [InlineData("https://youtu.be/tTQiv1xKVM4")]
-        [InlineData("https://youtu.be/tTQiv1xKVM4?utm_source=example")]
-        public void Valid_URL_returns_video_id(string originalUrl)
+        [InlineData("https://www.youtube.com/embed/tTQiv1xKVM4", "tTQiv1xKVM4")]
+        [InlineData("https://www.youtube.com/embed/tTQiv1xKVM4?utm_source=example", "tTQiv1xKVM4")]
+        [InlineData("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4", "tTQiv1xKVM4")]
+        [InlineData("https://www.youtube-nocookie.com/embed/tTQiv1xKVM4?utm_source=example", "tTQiv1xKVM4")]
+        [InlineData("https://www.youtube.com/watch?v=tTQiv1xKVM4", "tTQiv1xKVM4")]
+        [InlineData("https://www.youtube.com/watch?v=tTQiv1xKVM4&utm_source=example", "tTQiv1xKVM4")]
+        [InlineData("https://youtu.be/tTQiv1xKVM4", "tTQiv1xKVM4")]
+        [InlineData("https://youtu.be/tTQiv1xKVM4?utm_source=example", "tTQiv1xKVM4")]
+        [InlineData("https://www.youtube.com/embed/-w5YtMpS4J0", "-w5YtMpS4J0")]
+        [InlineData("https://www.youtube.com/embed/-w5YtMpS4J0?utm_source=example", "-w5YtMpS4J0")]
+        [InlineData("https://www.youtube-nocookie.com/embed/-w5YtMpS4J0", "-w5YtMpS4J0")]
+        [InlineData("https://www.youtube-nocookie.com/embed/-w5YtMpS4J0?utm_source=example", "-w5YtMpS4J0")]
+        [InlineData("https://www.youtube.com/watch?v=-w5YtMpS4J0", "-w5YtMpS4J0")]
+        [InlineData("https://www.youtube.com/watch?v=-w5YtMpS4J0&utm_source=example", "-w5YtMpS4J0")]
+        [InlineData("https://youtu.be/-w5YtMpS4J0", "-w5YtMpS4J0")]
+        [InlineData("https://youtu.be/-w5YtMpS4J0?utm_source=example", "-w5YtMpS4J0")]
+        public void Valid_URL_returns_video_id(string originalUrl, string expectedVideoId)
         {
             var normaliser = new YouTubeVideoIdParser();
             var result = normaliser.TryParseUrl(new Uri(originalUrl), out var videoId);
 
             Assert.True(result);
-            Assert.Equal("tTQiv1xKVM4", videoId);
+            Assert.Equal(expectedVideoId, videoId);
         }
 
         [Theory]

--- a/ThePensionsRegulator.Frontend.Umbraco/Services/YouTubeVideoIdParser.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Services/YouTubeVideoIdParser.cs
@@ -24,7 +24,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Services
                 return false;
             }
 
-            var match = Regex.Match(urlToParse, @"(\/embed\/|\/watch\?v=|youtu.be\/)(?<VideoId>[A-Z0-9_]+)", RegexOptions.IgnoreCase);
+            var match = Regex.Match(urlToParse, @"(\/embed\/|\/watch\?v=|youtu.be\/)(?<VideoId>[A-Z0-9_-]+)", RegexOptions.IgnoreCase);
             if (!match.Success)
             {
                 videoId = null;


### PR DESCRIPTION
Updated YouTube regex to include hyphens for the video id.

Added more tests for the new regex.

Bumped version to 8.8.5