### PR TITLE
Prevent InvalidOperationException by ensuring current page is correct type 

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
@@ -16,6 +16,8 @@
     var requestCulture = Context.Features.Get<IRequestCultureFeature>();
     var currentLanguage = requestCulture!.RequestCulture.UICulture.Name;
     var twoLetterCode = requestCulture!.RequestCulture.UICulture.TwoLetterISOLanguageName;
+    var currentPage = @Model as IPublishedContent;
+    if (currentPage == null) { currentPage = Umbraco.AssignedContentItem; }
 }
 <!DOCTYPE html>
 <html lang="@twoLetterCode">
@@ -50,7 +52,7 @@
                 </div>
             }
         }
-        @if(Umbraco.AssignedContentItem.ContentType.Alias == "sideNavigation")
+        @if (currentPage.ContentType.Alias == "sideNavigation")
         {
             <div class="govuk-width-container">
                 <div class="govuk-grid-row">


### PR DESCRIPTION
Why: 
-When trying to navigate to a page such as `/success` an `InvalidOperationException` was thrown.  

In this PR:
-Ensure current page is correct type before accessing.