### PR TITLE
The side navigation example page has wanted extra spacing 

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Services/SideNavigationBlockViewInterceptor.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Services/SideNavigationBlockViewInterceptor.cs
@@ -1,0 +1,17 @@
+﻿using GovUk.Frontend.Umbraco.Blocks;
+using ThePensionsRegulator.Umbraco;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Services
+{
+    public class SideNavigationBlockViewInterceptor(IUmbracoPublishedContentAccessor _publishedContentAccessor) : IBlockViewInterceptor
+    {
+        public void InterceptBlockView(BlockViewModel blockViewModel)
+        {
+            if (_publishedContentAccessor.PublishedContent.ContentType.Alias == "sideNavigation")
+            {
+                blockViewModel.OpenWidthContainer = false;
+                blockViewModel.CloseWidthContainer = false;
+            }
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
@@ -1,3 +1,4 @@
+using GovUk.Frontend.Umbraco.Blocks;
 using GovUk.Frontend.Umbraco.ExampleApp.Middleware;
 using GovUk.Frontend.Umbraco.ExampleApp.Services;
 using GovUk.Frontend.Umbraco.Services;
@@ -66,6 +67,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp
 
             services.AddTransient<IGovUkBreadcrumbLinksService, BreadcrumbLinksServiceForExampleApp>();
             services.AddTransient<ITprSideNavigationLinksService, SideNavigationLinksServiceForExampleApp>();
+            services.AddTransient<IBlockViewInterceptor, SideNavigationBlockViewInterceptor>();
         }
 
         /// <summary>


### PR DESCRIPTION
Pages with side nav enabled currently have uneven spacing in mobile view (shown below). They also have unwanted extra spacing for the two columns hosting the block grid at some larger screen sizes.

<img width="616" height="1341" alt="Uneven spacing in mobile view" src="https://github.com/user-attachments/assets/df66cf89-423e-48e4-8fd5-25e6fd19a942" />

This is because the partial view that adds the side nav hard-codes a `<div class="govuk-width-container">`, which is necessary. However this is normally rendered by default, and so with the addition of the hard-coded one you get two. Part of the width container's function is to add some side margin to prevent content abutting the edge of the screen. With two width containers you have two lots of side margin, creating the unwanted extra spacing.

The `IBlockViewInterceptor` interface exists to allow the automatic rendering of width containers to be overridden. It was introduced to allow full-width boxes on landing pages to work, since these must break out of the width container and occupy the whole viewport.

This PR adds a new implementation of the same interface to also disable the automatic rendering of width containers when side nav is active. This uses the same test as `Views\_Layout.cshtml` when it's deciding whether to render the hard-coded width container. With automatic rendering disabled, only the hard-coded width container exists on a page with side nav and the spacing issue is resolved.

This doesn't include a version bump as it only affects the example app, not any published packages. [AB#243450](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/243450)