### PR TITLE
Fix summary link and summary card actions

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuksummarycardaction.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuksummarycardaction.config
@@ -43,7 +43,7 @@
       <Alias>text</Alias>
       <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
       <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
+      <Mandatory>true</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
       <SortOrder>1</SortOrder>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuksummarylistaction.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govuksummarylistaction.config
@@ -43,7 +43,7 @@
       <Alias>text</Alias>
       <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
       <Type>Umbraco.TextBox</Type>
-      <Mandatory>false</Mandatory>
+      <Mandatory>true</Mandatory>
       <Validation></Validation>
       <Description><![CDATA[]]></Description>
       <SortOrder>1</SortOrder>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryCard.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryCard.cshtml
@@ -28,7 +28,16 @@
             var link = action.Content.Value<Link>(PropertyAliases.SummaryCardActionLink);
             if (!string.IsNullOrEmpty(link?.Url))
             {
-                <govuk-summary-card-action href="@(link.Url)" visually-hidden-text="@cardTitle">@(action.Content.Value<string>(PropertyAliases.SummaryCardActionLinkText))</govuk-summary-card-action>
+                var openInNewTab = link.Target?.Equals("_blank") ?? false;
+                if (openInNewTab)
+                {
+                    var visuallyHidden = $"{Umbraco.GetDictionaryValueOrDefault(DictionaryConstants.OpensInNewTab, DictionaryConstants.OpensInNewTab)}";
+                    <govuk-summary-card-action href="@(link.Url)" visually-hidden-text="@visuallyHidden" target="_blank">@(action.Content.Value<string>(PropertyAliases.SummaryCardActionLinkText))</govuk-summary-card-action>
+                }
+                else
+                {
+                    <govuk-summary-card-action href="@(link.Url)">@(action.Content.Value<string>(PropertyAliases.SummaryCardActionLinkText))</govuk-summary-card-action>
+                }
             }
         }
         </govuk-summary-card-actions>
@@ -50,7 +59,17 @@
                                 var link = action.Content.Value<Link>(PropertyAliases.SummaryListActionLink);
                                 if (!string.IsNullOrEmpty(link?.Url))
                                 {
-                                    <govuk-summary-list-row-action href="@(link.Url)" visually-hidden-text="@(listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey))">@(action.Content.Value<string>(PropertyAliases.SummaryListActionLinkText))</govuk-summary-list-row-action>
+                                    var openInNewTab = link.Target?.Equals("_blank") ?? false;
+                                    if (openInNewTab)
+                                    {
+                                        var visuallyHidden = $"{listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey)} {Umbraco.GetDictionaryValueOrDefault(DictionaryConstants.OpensInNewTab, DictionaryConstants.OpensInNewTab)}";
+                                        <govuk-summary-list-row-action href="@(link.Url)" visually-hidden-text="@visuallyHidden" target="_blank">@(action.Content.Value<string>(PropertyAliases.SummaryListActionLinkText))</govuk-summary-list-row-action>
+                                    }
+                                    else
+                                    {
+                                        var visuallyHidden = listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey);
+                                        <govuk-summary-list-row-action href="@(link.Url)" visually-hidden-text="@visuallyHidden">@(action.Content.Value<string>(PropertyAliases.SummaryListActionLinkText))</govuk-summary-list-row-action>
+                                    }
                                 }
                             }
                         </govuk-summary-list-row-actions>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryList.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryList.cshtml
@@ -26,9 +26,20 @@
                     @foreach (var action in actions)
                     {
                         var link = action.Content.Value<Link>(PropertyAliases.SummaryListActionLink);
+
                         if (!string.IsNullOrEmpty(link?.Url))
                         {
-                            <govuk-summary-list-row-action href="@(link.Url)" visually-hidden-text="@(listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey))">@(action.Content.Value<string>(PropertyAliases.SummaryListActionLinkText))</govuk-summary-list-row-action>
+                            var openInNewTab = link.Target?.Equals("_blank") ?? false;
+                            if (openInNewTab)
+                            {
+                                var visuallyHidden = $"{listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey)} {Umbraco.GetDictionaryValueOrDefault(DictionaryConstants.OpensInNewTab, DictionaryConstants.OpensInNewTab)}";
+                                <govuk-summary-list-row-action href="@(link.Url)" visually-hidden-text="@visuallyHidden" target="_blank">@(action.Content.Value<string>(PropertyAliases.SummaryListActionLinkText))</govuk-summary-list-row-action>
+                            }
+                            else
+                            {
+                                var visuallyHidden = listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey);
+                                <govuk-summary-list-row-action href="@(link.Url)" visually-hidden-text="@visuallyHidden">@(action.Content.Value<string>(PropertyAliases.SummaryListActionLinkText))</govuk-summary-list-row-action>
+                            }
                         }
                     }
                     </govuk-summary-list-row-actions>


### PR DESCRIPTION
This PR fixes #519 - when you select the 'opens in new tab' option in Umbraco for a summary list item, the rendered HTML did not change. It also fixes the same issue for summary card actions.

It also fixes two issues noticed with summary cards during testing:
- the card title is no longer added to card actions as visually hidden text, since the tag helper from `govuk-frontend-aspnetcore` does this anyway and we were duplicating it
- the link text for summary list actions and summary card actions is now a required field, since no visible text is rendered if it's omitted