### PR TITLE
Add .govuk-panel to the list of exclusions from removing bottom padding

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-panel.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-panel.scss
@@ -1,0 +1,11 @@
+﻿/* 
+    If there is a fieldset level error we do not want to display an error message for the field, 
+    but without an error message the .govuk-select--error class will not be applied.
+*/
+.govuk-select[aria-invalid=true] {
+    @extend .govuk-select--error;
+}
+
+.govuk-panel__body > :last-child {
+    margin-bottom: 0;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
@@ -4,6 +4,7 @@ $govuk-new-organisation-colours: true; // Recommended in release notes for GOV.U
 @import "_govuk-checkboxes.scss";
 @import "_govuk-input.scss";
 @import "_govuk-pagination.scss";
+@import "_govuk-panel.scss";
 @import "_govuk-radios.scss";
 @import "_govuk-select.scss";
 @import "_govuk-textarea.scss";

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/success.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/success.config
@@ -26,6 +26,10 @@
         "settingsUdi": "umb://element/460db179fb784dd7a9860fa3cee45762"
       },
       {
+        "contentUdi": "umb://element/c654a9aad30c4cd7beb9b6f17b03a102",
+        "settingsUdi": "umb://element/88309f5cb27445deabd5eaa8da52db0c"
+      },
+      {
         "contentUdi": "umb://element/e4766636fda445c883e7a7d6b56c2ad4",
         "settingsUdi": "umb://element/0f97ed7fe9d84ab8bd3478332bdf48d9"
       }
@@ -61,6 +65,17 @@
         }
       },
       "udi": "umb://element/e4766636fda445c883e7a7d6b56c2ad4"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The panel above has a dividing line added after it, when using TPR styles. This must be supported.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/c654a9aad30c4cd7beb9b6f17b03a102"
     }
   ],
   "settingsData": [
@@ -82,7 +97,7 @@
       "contentTypeKey": "46f4e57b-7357-44c0-bd4c-295b9edee4c1",
       "cssClasses": "",
       "cssClassesForColumn": "",
-      "cssClassesForRow": "",
+      "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "headingLevel": [
         "Heading 2"
       ],
@@ -99,6 +114,14 @@
         "Heading 2"
       ],
       "udi": "umb://element/0f97ed7fe9d84ab8bd3478332bdf48d9"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/88309f5cb27445deabd5eaa8da52db0c"
     }
   ]
 }]]></Value>

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
@@ -71,14 +71,14 @@
 
 // .govuk-grid-row--tpr-divider and .tpr-box both apply padding-bottom, so remove any bottom padding or
 //  margin from the last element inside either one so that we get one spacer, not the combination of both.
-.govuk-grid-row--tpr-divider > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-.govuk-grid-row--tpr-divider > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-.tpr-box > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button), 
-.tpr-box > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .tpr-section-cards),
-.tpr-box.govuk-grid-row > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button), 
-.tpr-box.govuk-grid-row > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-.tpr-box > .govuk-grid-row > .govuk-grid-column:last-child > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-.tpr-box--full-width > .govuk-width-container > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.govuk-button) {
+.govuk-grid-row--tpr-divider > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+.govuk-grid-row--tpr-divider > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+.tpr-box > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel), 
+.tpr-box > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .tpr-section-cards, .govuk-panel),
+.tpr-box.govuk-grid-row > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel), 
+.tpr-box.govuk-grid-row > .govuk-grid-column > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+.tpr-box > .govuk-grid-row > .govuk-grid-column:last-child > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+.tpr-box--full-width > .govuk-width-container > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.govuk-button, .govuk-panel) {
     padding-bottom: 0;
     margin-bottom: 0;
 }
@@ -104,12 +104,12 @@
 }
 
 @include govuk-media-query($from: tablet) {
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-quarter > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-third > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-half > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-two-thirds > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-three-quarters > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-full > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button) {
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-quarter > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-third > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-half > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-two-thirds > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-three-quarters > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-full > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel) {
         padding-bottom: 0;
         margin-bottom: 0;
     }
@@ -134,12 +134,12 @@
 }
 
 @include govuk-media-query($from: desktop) {
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-quarter-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-third-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-half-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-two-thirds-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-three-quarters-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button),
-    .tpr-box > .govuk-grid-row > .govuk-grid-column-full-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button) {
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-quarter-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-third-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-one-half-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-two-thirds-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-three-quarters-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel),
+    .tpr-box > .govuk-grid-row > .govuk-grid-column-full-from-desktop > .govuk-grid-row:last-child > .govuk-grid-column > :last-child:not(.tpr-box, .tpr-box > .govuk-grid-column, .govuk-button, .govuk-panel) {
         padding-bottom: 0;
         margin-bottom: 0;
     }

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -38,6 +38,7 @@
 @import "_govuk-checkboxes.scss";
 @import "_govuk-input.scss";
 @import "_govuk-pagination.scss";
+@import "_govuk-panel.scss";
 @import "_govuk-radios.scss";
 @import "_govuk-select.scss";
 @import "_govuk-textarea.scss";


### PR DESCRIPTION
It's a box that always needs its bottom padding. This is a problem already solved for other elements. `.govuk-panel` just needed to be added to the list.

The panel page in Umbraco is updated with an example.

This PR also removes additional spacing when multiple paragraphs are used inside `.govuk-panel__body`. The bottom margin of the last paragraph was combining with the bottom padding of the panel to produce a larger-than-normal space. Now only the gutter is used, making spacing even all around the panel.

Fixes #431