### PR TITLE
Allow long unbreakable words to wrap within panel components #374

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-panel.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-panel.scss
@@ -1,0 +1,7 @@
+﻿/* This allows a long unbreakable word (such as a filename without spaces) to wrap,
+   which is important for this component as the text is white and typically overflows 
+   onto a white background if it doesn't wrap.
+*/
+.govuk-panel {
+    word-break: break-all;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
@@ -4,6 +4,7 @@ $govuk-new-organisation-colours: true; // Recommended in release notes for GOV.U
 @import "_govuk-checkboxes.scss";
 @import "_govuk-input.scss";
 @import "_govuk-pagination.scss";
+@import "_govuk-panel.scss";
 @import "_govuk-radios.scss";
 @import "_govuk-select.scss";
 @import "_govuk-textarea.scss";

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/success.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/success.config
@@ -26,6 +26,10 @@
         "settingsUdi": "umb://element/460db179fb784dd7a9860fa3cee45762"
       },
       {
+        "contentUdi": "umb://element/c654a9aad30c4cd7beb9b6f17b03a102",
+        "settingsUdi": "umb://element/88309f5cb27445deabd5eaa8da52db0c"
+      },
+      {
         "contentUdi": "umb://element/e4766636fda445c883e7a7d6b56c2ad4",
         "settingsUdi": "umb://element/0f97ed7fe9d84ab8bd3478332bdf48d9"
       }
@@ -34,9 +38,9 @@
   "contentData": [
     {
       "contentTypeKey": "6a472e93-8a46-4791-a387-bde834d619cf",
-      "panelHeading": "Success",
+      "panelHeading": "SuccessSuccessSuccessSuccessSuccessSuccess",
       "panelText": {
-        "markup": "<p>Use the <a href=\"https://design-system.service.gov.uk/components/panel/\">panel component</a> to display important information when a transaction has been completed.</p>",
+        "markup": "<p>Use the <a href=\"https://design-system.service.gov.uk/components/panel/\">panel component</a> to display important information when a transaction has been completed.</p>\n<p>SuccessSuccessSuccessSuccessSuccessSuccessSuccessSuccessSuccessSuccessSuccessSuccess</p>",
         "blocks": {
           "contentData": [],
           "settingsData": []
@@ -61,6 +65,17 @@
         }
       },
       "udi": "umb://element/e4766636fda445c883e7a7d6b56c2ad4"
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "text": {
+        "markup": "<p>The panel above has a dividing line added after it, when using TPR styles. This must be supported.</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "udi": "umb://element/c654a9aad30c4cd7beb9b6f17b03a102"
     }
   ],
   "settingsData": [
@@ -82,7 +97,7 @@
       "contentTypeKey": "46f4e57b-7357-44c0-bd4c-295b9edee4c1",
       "cssClasses": "",
       "cssClassesForColumn": "",
-      "cssClassesForRow": "",
+      "cssClassesForRow": "govuk-grid-row--tpr-divider",
       "headingLevel": [
         "Heading 2"
       ],
@@ -99,6 +114,14 @@
         "Heading 2"
       ],
       "udi": "umb://element/0f97ed7fe9d84ab8bd3478332bdf48d9"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "udi": "umb://element/88309f5cb27445deabd5eaa8da52db0c"
     }
   ]
 }]]></Value>

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -38,6 +38,7 @@
 @import "_govuk-checkboxes.scss";
 @import "_govuk-input.scss";
 @import "_govuk-pagination.scss";
+@import "_govuk-panel.scss";
 @import "_govuk-radios.scss";
 @import "_govuk-select.scss";
 @import "_govuk-textarea.scss";


### PR DESCRIPTION
This PR allows a long unbreakable word (such as a filename without spaces) to wrap with a Panel component, which is important as the text is white and typically overflows onto a white background if it doesn't wrap.

This screenshot shows it working for both heading and body content within a panel.

<img width="963" height="642" alt="Long words wrapping" src="https://github.com/user-attachments/assets/7d405c71-0bc6-4a0e-bc86-e58cb962f130" />

Fixes #374.