### PR TITLE
Prevent long unbreakable words like URLs and filenames from overflowing

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-panel.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-panel.scss
@@ -1,11 +1,13 @@
-﻿/* 
-    If there is a fieldset level error we do not want to display an error message for the field, 
-    but without an error message the .govuk-select--error class will not be applied.
+﻿/* Prevent long unbreakable words like URLs and filenames from overflowing,
+   which would typically be white text on a white background.
 */
-.govuk-select[aria-invalid=true] {
-    @extend .govuk-select--error;
+.govuk-panel {
+    overflow-wrap: break-word;
 }
 
+/* Remove the bottom margin on the last content block element (eg a paragraph),
+   so that the padding of .govuk-panel creates even space all around.
+*/
 .govuk-panel__body > :last-child {
     margin-bottom: 0;
 }


### PR DESCRIPTION
This PR allows a long unbreakable word (such as a filename without spaces) to wrap with a Panel component, which is important as the text is white and typically overflows onto a white background if it doesn't wrap.

This screenshot shows it working for both heading and body content within a panel.

<img width="961" height="863" alt="Wrapping text" src="https://github.com/user-attachments/assets/1b6ad7fe-129b-4522-b22d-7b414aca834a" />

Fixes #374.

This PR also removes a duplicate style for select dropdowns. This is because `_govuk-panel.scss` was recently created by copying `_govuk-select.scss` and the existing style was not removed. It still exists in `_govuk-select.scss`.