### PR TITLE
Fixed bug where No results text remains displayed after clearing the form.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.0.2</Version>
+    <Version>9.0.3</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsInput.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsInput.cs
@@ -36,7 +36,6 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             errorTextParagraph.AddCssClass("govuk-error-message field-validation-error govuk-visually-hidden");
             errorTextParagraph.Attributes.Add("id", "tpr-search-results-error-text");
             errorTextParagraph.InnerHtml.AppendHtml(errorTextSpan);
-            errorTextParagraph.InnerHtml.Append("Enter a search term to find questions and answers");
 
             var input = new TagBuilder("input");
             input.Attributes.Add("type", "text");

--- a/ThePensionsRegulator.Frontend/__tests__/tpr-search-results.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-search-results.tests.js
@@ -1,7 +1,7 @@
 ﻿import '@testing-library/jest-dom';
 
 import { jest } from '@jest/globals';
-import { initialiseAccordion, searchButtonOnClick, resetSearchButtonOnClick, showMoreAnswersOnClick, setSearchResults, navigateToSearchButtonOnClick, removeNoResultsFound } from '../wwwroot/tpr/tpr-search-results';
+import { initialiseAccordion, searchButtonOnClick, resetButtonOnClick, showMoreAnswersOnClick, setSearchResults, navigateToSearchButtonOnClick, removeNoResultsFound, resetShowMoreAnswersButton, toggleErrorTextVisibility } from '../wwwroot/tpr/tpr-search-results';
 
 const setupBlankComponent = () => {
     document.body.innerHTML =
@@ -231,7 +231,7 @@ describe('removeNoResultsFound', () => {
     });
 });
 
-describe('resetSearchButtonOnClick', () => {
+describe('resetButtonOnClick', () => {
     beforeEach(() => {
         // Ensure a clean fetch mock for each test
         global.fetch = undefined;
@@ -259,7 +259,7 @@ describe('resetSearchButtonOnClick', () => {
 
         expect(document.querySelectorAll('.govuk-accordion__section').length).toBe(initialPopular.length);
 
-        await resetSearchButtonOnClick();
+        await resetButtonOnClick();
 
         expect(input.value).toBe('');
 
@@ -276,14 +276,43 @@ describe('resetSearchButtonOnClick', () => {
 
         // DOM without input
         document.body.innerHTML = `
-            <aside class="tpr-search-results">
-                <form class="tpr-search-results__form">
-                    <div class="govuk-form-group"></div>
-                </form>
-                <a id="tpr-search-results-show-more-questions" class="govuk-link">Show more questions</a>
-            </aside>
-        `;
+        <aside class="tpr-search-results">
+            <form class="tpr-search-results__form">
+                <div class="govuk-form-group"></div>
+            </form>
+            <a id="tpr-search-results-show-more-questions" class="govuk-link">Show more questions</a>
+        </aside>`;
 
-        await expect(resetSearchButtonOnClick()).resolves.not.toThrow();
+        await expect(resetButtonOnClick()).resolves.not.toThrow();
+    });
+
+    it('resets show more answers view', async () => {
+        setupBlankComponent();
+
+        resetShowMoreAnswersButton();
+
+        const showMoreButton = document.getElementById('tpr-search-results-show-more-questions');
+        expect(showMoreButton).toHaveTextContent('Show more questions');
+        expect(showMoreButton).not.toHaveClass('govuk-visually-hidden');
+    });
+
+    it('resets the form to remove error text and error classes on elements', async () => {
+        document.body.innerHTML = `
+	    <form class="tpr-search-results__form">
+		    <div class="govuk-form-group govuk-form-group--error">
+			    <label class="govuk-label govuk-visually-hidden" for="tpr-search-results-ask-input">Search Q&amp;As</label>
+			    <p class="govuk-error-message field-validation-error" id="tpr-search-results-error-text">
+				    <span class="govuk-visually-hidden">Error:</span>Enter a search term to find questions and answers</p>
+			    <div class="tpr-search-results__input-group">
+				    <input aria-describedby="tpr-search-results-error-text" class="govuk-input govuk-input--error" id="tpr-search-results-ask-input" required="" type="text">
+				</div>
+			</div>
+		</form>`;
+
+        toggleErrorTextVisibility();
+
+        expect(document.querySelector('.govuk-form-group')).not.toHaveClass('govuk-form-group--error');
+        expect(document.getElementById('tpr-search-results-error-text')).toHaveClass('govuk-visually-hidden');
+        expect(document.getElementById('tpr-search-results-ask-input')).not.toHaveClass('govuk-input--error');
     });
 });

--- a/ThePensionsRegulator.Frontend/__tests__/tpr-search-results.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-search-results.tests.js
@@ -11,7 +11,7 @@ const setupBlankComponent = () => {
 		        <div class="govuk-form-group">
 			        <label class="govuk-label govuk-visually-hidden" for="tpr-search-results-ask-input">Search Q&amp;As</label>
 			        <p class="govuk-error-message field-validation-error govuk-visually-hidden" id="tpr-search-results-error-text">
-				        <span class="govuk-visually-hidden">Error:</span>Enter a search term to find questions and answers
+				        <span class="govuk-visually-hidden">Error:</span>
 			        </p>
 			        <div class="tpr-search-results__input-group">
 				        <input aria-describedby="tpr-search-results-error-text" class="govuk-input" id="tpr-search-results-ask-input" required="" type="text">
@@ -101,11 +101,34 @@ describe('initialise accordion', () => {
         expect(mockEvent.preventDefault).toHaveBeenCalled();
         expect(document.querySelector('.govuk-form-group')).toHaveClass('govuk-form-group--error');
         expect(document.getElementById('tpr-search-results-error-text')).not.toHaveClass('govuk-visually-hidden');
+        expect(document.getElementById('tpr-search-results-error-text')).toHaveTextContent('Please enter a question or phrase.');
         expect(searchInput.value).toBe('');
         expect(searchInput).toHaveClass('govuk-input--error');
     });
 
-    it('should show "No results found" if search returns no results', async () => {
+    it('should show error state if search terms characters are 2 or less', async () => {
+        global.fetch = jest.fn().mockResolvedValueOnce({
+            json: async () => {
+                return { results: [] };
+            }
+        });
+
+        setupBlankComponent();
+
+        const searchInput = document.getElementById("tpr-search-results-ask-input");
+        searchInput.value = "hi";
+
+        const mockEvent = { preventDefault: jest.fn() };
+        await searchButtonOnClick(mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(document.querySelector('.govuk-form-group')).toHaveClass('govuk-form-group--error');
+        expect(document.getElementById('tpr-search-results-error-text')).not.toHaveClass('govuk-visually-hidden');
+        expect(document.getElementById('tpr-search-results-error-text')).toHaveTextContent('Your question must be 2 characters or more.');
+        expect(searchInput).toHaveClass('govuk-input--error');
+    });
+
+    it('should show error message if search returns no results', async () => {
         global.fetch = jest.fn().mockResolvedValueOnce({
             json: async () => {
                 return { results: [] };
@@ -120,9 +143,11 @@ describe('initialise accordion', () => {
         const mockEvent = { preventDefault: jest.fn() };
         await searchButtonOnClick(mockEvent);
 
-        var result = document.body.querySelector('.tpr-search-results__no-results-found');
+        expect(document.querySelector('.govuk-form-group')).toHaveClass('govuk-form-group--error');
+        expect(document.getElementById('tpr-search-results-error-text')).not.toHaveClass('govuk-visually-hidden');
+        expect(document.getElementById('tpr-search-results-error-text')).toHaveTextContent('Your question returned no results, please try again.');
+        expect(document.getElementById('tpr-search-results-ask-input')).toHaveClass('govuk-input--error');
 
-        expect(result).toHaveTextContent('No results found');
         expect(mockEvent.preventDefault).toHaveBeenCalled();
     });
 
@@ -268,7 +293,6 @@ describe('resetButtonOnClick', () => {
 
         const showMoreButton = document.getElementById('tpr-search-results-show-more-questions');
         expect(showMoreButton).toHaveTextContent('Show more questions');
-        expect(showMoreButton).not.toHaveClass('govuk-visually-hidden');
     });
 
     it('handles missing input element without throwing', async () => {

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
@@ -27,13 +27,15 @@ async function fetchJson(url) {
 async function initialiseAccordion() {
     let results = [];
 
+    toggleErrorTextVisibility(false);
+
     try {
         results = await fetchJson(`${popularContentApiUrl}`);
     } catch (error) {
         console.error("Failed to fetch most popular content:", error);
     }
 
-    showMoreQuestions = false;
+    results = results || [];
 
     if (results.length === 0) {
         createNoResultsFoundHeading();
@@ -47,7 +49,7 @@ async function initialiseAccordion() {
         });
 
         createAccordion(accordionSections);
-
+        resetShowMoreAnswersButton();
         toggleShowMoreButton(results.length <= INITIAL_VISIBLE_RESULTS);
     }
 }
@@ -108,7 +110,7 @@ async function fetchContentById(contentId) {
     }
 }
 
-async function toggleErrorTextVisibility(showErrorText) {
+async function toggleErrorTextVisibility(showErrorText, errorTextContent = '') {
     const errorText = document.getElementById("tpr-search-results-error-text");
     const formGroup = document.querySelector('.tpr-search-results__form .govuk-form-group');
     const searchInput = getSearchInput();
@@ -116,15 +118,22 @@ async function toggleErrorTextVisibility(showErrorText) {
     if (errorText != null && searchInput != null && formGroup != null) {
         if (showErrorText) {
             errorText.classList.remove("govuk-visually-hidden");
+            errorText.textContent = errorTextContent;
             searchInput.classList.add("govuk-input--error");
             formGroup.classList.add("govuk-form-group--error");
-
         } else {
             errorText.classList.add("govuk-visually-hidden");
             searchInput.classList.remove("govuk-input--error");
             formGroup.classList.remove("govuk-form-group--error");
         }
     }
+}
+
+function setErrorText(errorMessage, value = '') {
+    const searchInput = getSearchInput();
+    searchInput.value = value;
+    navigateToSearchInput(false);
+    toggleErrorTextVisibility(true, errorMessage);
 }
 
 async function searchButtonOnClick(event) {
@@ -135,16 +144,18 @@ async function searchButtonOnClick(event) {
         return;
     }
 
-    const searchValue = searchInput.value;
-
-    toggleErrorTextVisibility(false);
-
-    if (!searchValue || searchValue.trim() === '') {
-        searchInput.value = '';
-        navigateToSearchInput(false);
-        toggleErrorTextVisibility(true);
+    const searchValue = searchInput.value?.trim() || '';
+    if (!searchValue) {
+        setErrorText('Please enter a question or phrase.');
         return;
     }
+
+    if (searchValue.length < 3) {
+        setErrorText('Your question must be 2 characters or more.', searchValue);
+        return;
+    }
+
+    toggleErrorTextVisibility(false);
 
     let searchUrl = new URL(searchContentApiUrl, window.location.origin);
     searchUrl.searchParams.set('searchTerm', searchValue);
@@ -162,7 +173,8 @@ async function searchButtonOnClick(event) {
     removeAccordion("search-results-accordion");
 
     if (results.length === 0) {
-        createNoResultsFoundHeading();
+        setErrorText('Your question returned no results, please try again.', searchValue);
+        toggleShowMoreButton(true);
     } else {
         removeNoResultsFound();
 
@@ -196,9 +208,6 @@ async function resetButtonOnClick() {
 
     removeAccordion("search-results-accordion");
     await initialiseAccordion();
-    resetShowMoreAnswersButton();
-    removeNoResultsFound();
-    toggleErrorTextVisibility(false);
     navigateToSearchInput(false);
 }
 
@@ -254,6 +263,8 @@ function createNoResultsFoundHeading() {
         const searchBlock = document.getElementsByClassName("tpr-search-results__form")[0];
         searchBlock.after(noResultsHeading);
     }
+
+    showMoreQuestions = false;
 
     toggleShowMoreButton(true);
 }

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
@@ -114,7 +114,6 @@ async function toggleErrorTextVisibility(showErrorText) {
     const searchInput = getSearchInput();
 
     if (errorText != null && searchInput != null && formGroup != null) {
-
         if (showErrorText) {
             errorText.classList.remove("govuk-visually-hidden");
             searchInput.classList.add("govuk-input--error");
@@ -189,15 +188,17 @@ async function searchButtonOnClick(event) {
     }
 }
 
-async function resetSearchButtonOnClick() {
+async function resetButtonOnClick() {
     const searchInput = getSearchInput();
     if (searchInput != null) {
         searchInput.value = '';
     }
-    toggleErrorTextVisibility(false);
+
     removeAccordion("search-results-accordion");
     await initialiseAccordion();
     resetShowMoreAnswersButton();
+    removeNoResultsFound();
+    toggleErrorTextVisibility(false);
     navigateToSearchInput(false);
 }
 
@@ -305,7 +306,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     searchButton.addEventListener("click", searchButtonOnClick);
-    resetButton.addEventListener("click", resetSearchButtonOnClick);
+    resetButton.addEventListener("click", resetButtonOnClick);
     showMoreButton.addEventListener("click", showMoreAnswersOnClick);
 
     const searchAside = document.getElementsByClassName("tpr-search-results")[0];
@@ -342,4 +343,4 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 });
 
-export { initialiseAccordion, searchButtonOnClick, resetSearchButtonOnClick, showMoreAnswersOnClick, setSearchResults, navigateToSearchButtonOnClick, removeNoResultsFound }
+export { initialiseAccordion, searchButtonOnClick, resetButtonOnClick, showMoreAnswersOnClick, setSearchResults, navigateToSearchButtonOnClick, removeNoResultsFound, resetShowMoreAnswersButton, toggleErrorTextVisibility }


### PR DESCRIPTION
When using the TPR search results component, if a search returned no results, then clear button clicked, it does not clear the 'No results found' message.

<img width="1213" height="758" alt="image" src="https://github.com/user-attachments/assets/d7093cb9-ae6b-4fb4-b0e3-81bda53f49e9" />


**Error validation messaging has also been updated as per the content team requirements**

<img width="843" height="878" alt="image" src="https://github.com/user-attachments/assets/831428a8-9594-487c-a29f-065844bb55b0" />

