### PR TITLE
Introduce search category boosting to influence search results

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.0.3</Version>
+    <Version>9.0.4</Version>
   </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprSearchResultsSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprSearchResultsSettings.generated.cs
@@ -66,6 +66,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		public virtual string HeadingLevel => this.Value<string>(_publishedValueFallback, "headingLevel");
 
 		///<summary>
+		/// Search Boost Category: Prioritize results under the given topic/page
+		///</summary>
+		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "")]
+		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
+		[ImplementPropertyType("searchBoostingCategory")]
+		public virtual global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent SearchBoostingCategory => this.Value<global::Umbraco.Cms.Core.Models.PublishedContent.IPublishedContent>(_publishedValueFallback, "searchBoostingCategory");
+
+		///<summary>
 		/// CSS classes: Applied to the outermost HTML element of the component.
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "")]

--- a/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
@@ -67,6 +67,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp
 
             services.AddTransient<IGovUkBreadcrumbLinksService, BreadcrumbLinksServiceForExampleApp>();
             services.AddTransient<ITprSideNavigationLinksService, SideNavigationLinksServiceForExampleApp>();
+            services.AddTransient<ITprSearchResultsEndpointUrlProvider, TprQueryBasedSearchResultsEndpointUrlProvider>();
             services.AddTransient<IBlockViewInterceptor, SideNavigationBlockViewInterceptor>();
         }
 

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprsearchresultssettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/tprsearchresultssettings.config
@@ -55,6 +55,22 @@
       <ValidationRegExpMessage></ValidationRegExpMessage>
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
+    <GenericProperty>
+      <Key>b31d767a-baee-4b3e-8f3b-7e437ba3d82c</Key>
+      <Name>Search Boosting Category</Name>
+      <Alias>searchBoostingCategory</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Prioritize results under the given topic/page]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
   </GenericProperties>
   <Tabs>
     <Tab>

--- a/ThePensionsRegulator.Frontend.Umbraco/Models/TprSearchResultEndpoints.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Models/TprSearchResultEndpoints.cs
@@ -1,0 +1,10 @@
+﻿namespace ThePensionsRegulator.Frontend.Umbraco.Models
+{
+    public class TprSearchResultEndpoints
+    {
+        public required string PopularContentApiUrl { get; set; }
+        public required string ContentByIdApiUrl { get; set; }
+        public required string ContentSearchApiUrl { get; set; }
+
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/Services/TprSearchResultsEndpointUrlProvider.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Services/TprSearchResultsEndpointUrlProvider.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using ThePensionsRegulator.Frontend.Umbraco.Models;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Services
+{
+    public interface ITprSearchResultsEndpointUrlProvider
+    {
+        TprSearchResultEndpoints GetSearchResultsEndpoints(Guid? searchBoostingCategory);
+    }
+
+    public class TprQueryBasedSearchResultsEndpointUrlProvider : ITprSearchResultsEndpointUrlProvider
+    {
+        private readonly IConfigurationSection _searchResultsSection;
+
+        public TprQueryBasedSearchResultsEndpointUrlProvider(IConfiguration configuration)
+        {
+            _searchResultsSection = configuration.GetSection("SearchResultsApiEndpoints");
+        }
+        public TprSearchResultEndpoints GetSearchResultsEndpoints(Guid? searchBoostingCategory)
+        {
+            var endpoints = new TprSearchResultEndpoints
+            {
+                ContentByIdApiUrl = _searchResultsSection["ContentByIdUrl"] ?? string.Empty,
+                ContentSearchApiUrl = _searchResultsSection["SearchContentUrl"] ?? string.Empty,
+                PopularContentApiUrl = _searchResultsSection["PopularContentUrl"] ?? string.Empty
+            };
+            if (searchBoostingCategory.HasValue)
+            {
+                string searchBoostingCategoryParam = $"?{TprPropertyAliases.SearchBoostingCategory}={searchBoostingCategory.Value}";
+                endpoints.ContentSearchApiUrl += searchBoostingCategoryParam;
+                endpoints.PopularContentApiUrl += searchBoostingCategoryParam;
+            }
+            return endpoints;
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/TprPropertyAliases.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/TprPropertyAliases.cs
@@ -23,6 +23,7 @@
         public const string SearchResultsFooterLinks = "footerlinks";
         public const string SearchResultsHeadingClass = "headingClass";
         public const string SearchResultsHeadingLevel = "headingLevel";
+        public const string SearchBoostingCategory = "searchBoostingCategory";
         public const string SectionCards = "cards";
         public const string SectionCardsNavigationAriaLabel = "navigationAriaLabel";
         public const string SectionCardsTitleHeadingLevel = "cardTitlesHeadingLevel";

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSearchResults.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSearchResults.cshtml
@@ -1,19 +1,22 @@
 ﻿@using ThePensionsRegulator.Frontend.Umbraco
+@using ThePensionsRegulator.Frontend.Umbraco.Services
 @using Umbraco.Cms.Core.Models
+@using Umbraco.Cms.Core.Models.PublishedContent
 @using Umbraco.Cms.Web.Common
 @using Microsoft.Extensions.Configuration
 @using GovUkPropertyAliases = GovUk.Frontend.Umbraco.PropertyAliases
-@inject IConfiguration configuration
+@inject ITprSearchResultsEndpointUrlProvider endpointUrlsProvider
 @addTagHelper *, ThePensionsRegulator.Frontend
 
 @{
-    var searchResultsSection = configuration.GetSection("SearchResultsApiEndpoints");
 
     var heading = Model.Content.Value<string>(TprPropertyAliases.SearchResultsHeading);
     var links = Model.Content.Value<IEnumerable<Link>>(TprPropertyAliases.SearchResultsFooterLinks);
 
     var cssClasses = Model.Settings.Value<string>(GovUkPropertyAliases.CssClasses);
     var headingClass = Model.Settings.Value<string?>(TprPropertyAliases.SearchResultsHeadingClass);
+    var searchBoostingCategory = Model.Settings.Value<IPublishedContent>(TprPropertyAliases.SearchBoostingCategory);
+    var endpoints = endpointUrlsProvider.GetSearchResultsEndpoints(searchBoostingCategory?.Key);
 
     if (string.IsNullOrEmpty(headingClass))
     {
@@ -29,7 +32,7 @@
     }
 }
 
-<tpr-search-results class="@cssClasses" content-by-id-url=@searchResultsSection["ContentByIdUrl"] search-content-url=@searchResultsSection["SearchContentUrl"] popular-content-url=@searchResultsSection["PopularContentUrl"]>
+<tpr-search-results class="@cssClasses" content-by-id-url=@endpoints.ContentByIdApiUrl search-content-url=@endpoints.ContentSearchApiUrl popular-content-url=@endpoints.PopularContentApiUrl>
     <tpr-search-results-input heading-level=@numericHeadingLevel govuk-heading-class=@headingClass>@heading</tpr-search-results-input>
     <tpr-search-results-footer-links>
         @foreach(var link in links)

--- a/docs/components/tpr-search-results.md
+++ b/docs/components/tpr-search-results.md
@@ -148,3 +148,22 @@ These are configured via the `appsettings.json` under a section named  `Search
     "PopularContentUrl": "/SearchResultsData/popularContentExample.json"
 }
 ```
+#### Search results relevance and popular results
+A new setting has been introduced for this component to boost search results under a particular content section.
+
+This can be controlled using the endpoint urls exposed in appsettings.json by implementing the ITprSearchResultsEndpointUrlProvider interface.
+```csharp 
+public interface ITprSearchResultsEndpointUrlProvider
+{
+    TprSearchResultEndpoints GetSearchResultsEndpoints(Guid? searchBoostingCategory);
+}
+```
+
+As part of this project a concrete implementation based on query string values is provided to append the search category page identifier to the popular content and search content api endpoints.
+
+The provider ensures the category identifier is appended at the end of the relevant endpoints as illustrated below:
+```html
+<aside class=" tpr-search-results" data-content-by-id-url="/SearchResultsData/" data-popular-content-url="/SearchResultsData/popularContentExample.json?searchBoostingCategory=5e682cbe-b867-491a-955f-3382446d5663" data-search-content-url="/SearchResultsData/searchResults.json?searchBoostingCategory=5e682cbe-b867-491a-955f-3382446d5663">
+.....
+</aside>  
+```


### PR DESCRIPTION
- Introduce search results component setting to boost search results based on a given search category

<img width="1410" height="162" alt="image" src="https://github.com/user-attachments/assets/bd009064-ac21-450d-b716-116da9b35b60" />

- Introduce search results endpoint url provider abstraction and query string based implementation to handle search category boosting

```html 
<aside class=" tpr-search-results" data-content-by-id-url="/SearchResultsData/" data-popular-content-url="/SearchResultsData/popularContentExample.json?searchBoostingCategory=5e682cbe-b867-491a-955f-3382446d5663" data-search-content-url="/SearchResultsData/searchResults.json?searchBoostingCategory=5e682cbe-b867-491a-955f-3382446d5663">
.....
</aside> 
```