### PR TITLE
ModelState.SetInitialValue() was not working for date inputs since the refactor for v9.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.0.4</Version>
+    <Version>9.0.5</Version>
   </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
@@ -24,24 +24,31 @@
     {
         if (ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry))
         {
-            var rawAttemptedDay = modelStateEntry!.GetModelStateForProperty("Day")?.AttemptedValue;
-            if (Int32.TryParse(rawAttemptedDay, out var parsedDay)) { attemptedDay = parsedDay; }
-            if (Int32.TryParse(modelStateEntry!.GetModelStateForProperty("Month")?.AttemptedValue, out var parsedMonth)) { attemptedMonth = parsedMonth; }
-            var rawAttemptedYear = modelStateEntry!.GetModelStateForProperty("Year")?.AttemptedValue;
-            if (Int32.TryParse(rawAttemptedYear, out var parsedYear)) { attemptedYear = parsedYear; }
-
-            // If an invalid integer is entered as a day or year, eg -1, .NET will parse the date successfully using 
-            // 1 for the day and the current year, which would then incorrectly be shown as the entered values, 
-            // so guard against that before parsing the date.
-            if (rawAttemptedDay is not null &&
-                rawAttemptedDay.Length <= 2 && 
-                attemptedDay >= 1 && attemptedDay <= 31 &&
-                rawAttemptedYear is not null && 
-                rawAttemptedYear.Length  == 4 && 
-                attemptedYear >= 1 && attemptedYear <= 9999 && 
-                DateOnly.TryParse(modelStateEntry?.AttemptedValue, out var date))
+            if (DateOnly.TryParse(modelStateEntry?.AttemptedValue, out var wholeDate))
             {
-                dateValue = date;
+                dateValue = wholeDate;
+            }
+            else
+            {
+                var rawAttemptedDay = modelStateEntry!.GetModelStateForProperty("Day")?.AttemptedValue;
+                if (Int32.TryParse(rawAttemptedDay, out var parsedDay)) { attemptedDay = parsedDay; }
+                if (Int32.TryParse(modelStateEntry!.GetModelStateForProperty("Month")?.AttemptedValue, out var parsedMonth)) { attemptedMonth = parsedMonth; }
+                var rawAttemptedYear = modelStateEntry!.GetModelStateForProperty("Year")?.AttemptedValue;
+                if (Int32.TryParse(rawAttemptedYear, out var parsedYear)) { attemptedYear = parsedYear; }
+
+                // If an invalid integer is entered as a day or year, eg -1, .NET will parse the date successfully using 
+                // 1 for the day and the current year, which would then incorrectly be shown as the entered values, 
+                // so guard against that before parsing the date.
+                if (rawAttemptedDay is not null &&
+                    rawAttemptedDay.Length <= 2 &&
+                    attemptedDay >= 1 && attemptedDay <= 31 &&
+                    rawAttemptedYear is not null &&
+                    rawAttemptedYear.Length == 4 &&
+                    attemptedYear >= 1 && attemptedYear <= 9999 &&
+                    DateOnly.TryParse(modelStateEntry?.AttemptedValue, out var dateInParts))
+                {
+                    dateValue = dateInParts;
+                }
             }
 
             if (modelStateEntry!.Errors.Any(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR))


### PR DESCRIPTION
When using `ModelState.SetInitialValue()` in a controller to pre-fill a date in a date input block, it is not working. That's because it sets the `AttemptedValue` for the date field as a whole, but the view only looks at the `AttemptedValue` in the three individual parts.

There was another branch of code in [the view before the v9.0.0 upgrade](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/blob/v8.9.0/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml) which is now restored, fixing this bug.

The code from line 33 to 51 shown in this PR is just indented due to the new if clause, not changed.

Fixes #554