### PR TITLE
Date Input needs to handle DateTime as well as DateOnly types

### DIFF
--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
@@ -28,6 +28,10 @@
             {
                 dateValue = wholeDate;
             }
+            else if (DateTime.TryParse(modelStateEntry?.AttemptedValue, out var wholeDateTime))
+            {
+                dateValue = DateOnly.FromDateTime(wholeDateTime);
+            }
             else
             {
                 var rawAttemptedDay = modelStateEntry!.GetModelStateForProperty("Day")?.AttemptedValue;


### PR DESCRIPTION
When using _ModelState.SetInitialValue()_ in a controller to pre-fill a date in a date input block, it needs to be able to parse _DateTime_ as well as _DateOnly_ types.