### PR TITLE
All menu items being highlighted as current section when at root

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.0.9</Version>
+    <Version>9.0.10</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -30,8 +30,8 @@ document.addEventListener("DOMContentLoaded", function () {
                     a.setAttribute("aria-expanded", false);
                     subMenu.style.display = "none";
                 }
-                    m.removeEventListener("keydown", desktopKeyboardNavigation)
-                    m.addEventListener("keydown", mobileKeyboardNavigation)
+                m.removeEventListener("keydown", desktopKeyboardNavigation)
+                m.addEventListener("keydown", mobileKeyboardNavigation)
             });
         } else {
 
@@ -75,6 +75,10 @@ function highlightCurrentSection() {
 
     let section = Array.from(url).filter(char => char !== '/').join('').replace("-", " ");
 
+    if (!section) {
+        return;
+    }
+
     const translations = {
         "cyflogwyr": "employers",
         "amdanom ni": "about us",
@@ -92,7 +96,6 @@ function highlightCurrentSection() {
 
             anchor.classList.toggle("tpr-header-menu__nav-menu-item--active")
         }
-
     });
 }
 
@@ -102,7 +105,7 @@ function displayDesktopOverlayOnHover() {
 
     document.querySelectorAll(".tpr-header-menu__nav-menu-item").forEach((item) => {
         const a = item.querySelector('a');
-        var subMenu = item.querySelector(".tpr-header-menu__nav-sub-menu"); 
+        var subMenu = item.querySelector(".tpr-header-menu__nav-sub-menu");
         if (subMenu != null) {
 
             ["mouseenter"].forEach((evt) =>
@@ -131,7 +134,7 @@ function displayDesktopOverlayOnHover() {
     });
 }
 
-function keyboardToggleMobileMenu(e){
+function keyboardToggleMobileMenu(e) {
 
     switch (e.key) {
 
@@ -196,7 +199,7 @@ function desktopKeyboardNavigation(e) {
             e.preventDefault();
             if (hasSubMenu) {
                 subMenu.style.display = 'grid';
-                subMenu.querySelector(".tpr-header-menu__nav-sub-menu-item").removeAttribute("style"); 
+                subMenu.querySelector(".tpr-header-menu__nav-sub-menu-item").removeAttribute("style");
                 overlay?.classList.add("tpr-header-menu__nav-overlay--visible");
                 a.setAttribute("aria-expanded", "true");
             }


### PR DESCRIPTION
Why:

- When at the root all menu items were being highlighted as current section.

In this PR:

- Updated to avoid setting current section styling if at the root.
- Minor formatting updates.