### PR TITLE
Search results styling broke global styling for buttons 

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
@@ -17,7 +17,7 @@
     flex: 1 1 100%;
 }
 
-.govuk-button-group {
+.tpr-search-results .govuk-button-group {
     display: flex;
     flex-direction: column;
     flex: 1 1 100%;
@@ -28,16 +28,19 @@
         flex-wrap: nowrap;
     }
 
-    .govuk-button-group {
-        flex-direction: row;
-        gap: 0.5rem;
-        flex: 0 0 auto;
-        align-items: center;
-        margin: 0;
-    }
+    .tpr-search-results {
 
-    .govuk-button-group .govuk-button {
-        margin: 0;
+        .govuk-button-group {
+            flex-direction: row;
+            gap: 0.5rem;
+            flex: 0 0 auto;
+            align-items: center;
+            margin: 0;
+        }
+
+        .govuk-button-group .govuk-button {
+            margin: 0;
+        }
     }
 }
 


### PR DESCRIPTION
Every component has standard spacing that follows it. Buttons have lost theirs. 

<img width="1285" height="609" alt="Image" src="https://github.com/user-attachments/assets/0e2dfdf4-c8ec-4865-8d56-a244af8f0847" />

This was because styles that were intended only to affect the search results component were actually global styles. These are now correctly scoped.

<img width="1341" height="621" alt="image" src="https://github.com/user-attachments/assets/1675b3be-3aef-44fd-934b-91858258f9f4" />

Fixes #570 