### PR TITLE
Use standard GOV.UK grid elements to correct footer alignment #572

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRFooter.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/TPRFooter.cshtml
@@ -43,9 +43,9 @@
 <body class="govuk-template__body ">
     <partial name="GOVUK/BodyOpen" />
 
-    <header role="banner">
-        @if (useTPRstyles)
-        {
+    @if (useTPRstyles)
+    {
+        <header role="banner">
             <tpr-header-bar>
                 <tpr-header-bar-logo alt="@headerLogoAlt" href="@(settings?.Value<Link>("tprHeaderLogoHref")?.Url)" />
                 <tpr-header-bar-label>@(settings?.Value<string?>("tprHeaderLabel"))</tpr-header-bar-label>
@@ -58,100 +58,100 @@
                 <tpr-context-bar-context-2>@(settings?.Value<IHtmlEncodedString>("tprContext2"))</tpr-context-bar-context-2>
                 <tpr-context-bar-context-3>@(settings?.Value<IHtmlEncodedString>("tprContext3"))</tpr-context-bar-context-3>
             </tpr-context-bar>
+        </header>
 
+        <div class="tpr-main-wrapper">
             <div class="govuk-width-container">
                 <govuk-back-link href="@home?.Url()">@Umbraco.GetDictionaryValue("Back link")</govuk-back-link>
             </div>
-            <div class="govuk-width-container govuk-!-margin-top-5">
-                <partial name="GOVUK/BlockList" model="@Model.Description" />
-            </div>
-
-            <div class="govuk-width-container govuk-!-margin-top-5">
+            <main id="main" class="govuk-main-wrapper govuk-!-padding-bottom-0">
+                <div class="govuk-!-margin-top-5">
+                    <partial name="GOVUK/BlockList" model="@Model.Description" />
+                </div>
                 <partial name="GOVUK/BlockList" model="Model.FooterWithContent" />
-            </div>
-            <tpr-footer-bar>
-                <tpr-footer-bar-logo alt="@footerLogoAlt" href="@(settings?.Value<Link>("tprFooterLogoHref")?.Url)" />
-                <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
-                <tpr-footer-bar-content allow-html="true">
-                    @(settings?.Value<IHtmlEncodedString>("tprFooterContent"))
-                </tpr-footer-bar-content>
-            </tpr-footer-bar>
+            </main>
+        </div>
 
-            <div class="govuk-width-container govuk-!-margin-top-5">
-                <partial name="GOVUK/BlockList" model="Model.FooterWithoutContent" />
-            </div>
-            <tpr-footer-bar class="govuk-!-margin-top-5">
-                <tpr-footer-bar-logo alt="The Pensions Regulator logo" href="" />
-                <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
-            </tpr-footer-bar>
+        <tpr-footer-bar>
+            <tpr-footer-bar-logo alt="@footerLogoAlt" href="@(settings?.Value<Link>("tprFooterLogoHref")?.Url)" />
+            <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
+            <tpr-footer-bar-content allow-html="true">
+                @(settings?.Value<IHtmlEncodedString>("tprFooterContent"))
+            </tpr-footer-bar-content>
+        </tpr-footer-bar>
 
-            <div class="govuk-width-container govuk-!-margin-top-5">
-                <partial name="GOVUK/BlockList" model="Model.FooterWithThreeColumnLinks" />
-            </div>
-            <tpr-footer-bar class="govuk-!-margin-top-5" lang="@languageCode">
-                <tpr-footer-bar-logo alt="The Pensions Regulator logo" href="" />
-                <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
-                @if (column != null)
+        <div class="govuk-!-margin-top-5">
+            <partial name="GOVUK/BlockList" model="Model.FooterWithoutContent" />
+        </div>
+        <tpr-footer-bar>
+            <tpr-footer-bar-logo alt="The Pensions Regulator logo" href="" />
+            <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
+        </tpr-footer-bar>
+
+        <div class="govuk-!-margin-top-5">
+            <partial name="GOVUK/BlockList" model="Model.FooterWithThreeColumnLinks" />
+        </div>
+        <tpr-footer-bar lang="@languageCode">
+            <tpr-footer-bar-logo alt="The Pensions Regulator logo" href="" />
+            <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
+            @if (column != null)
+            {
+                @foreach (var item in column)
                 {
-                    @foreach (var item in column)
+                    foreach (var links in item.Areas)
                     {
-                        foreach (var links in item.Areas)
-                        {
-                            <tpr-footer-bar-three-column-links>
-                                @foreach (var link in links)
-                                {
-                                    var linkUrl = link.Content.Value<Link>("link");
-                                    var linkText = link.Content.Value<string>("text");
-                                    <tpr-footer-bar-three-column-link href="@linkUrl?.Url" link-text="@linkText" lang="en-gb"></tpr-footer-bar-three-column-link>
-                                }
-                            </tpr-footer-bar-three-column-links>
+                        <tpr-footer-bar-three-column-links>
+                            @foreach (var link in links)
+                            {
+                                var linkUrl = link.Content.Value<Link>("link");
+                                var linkText = link.Content.Value<string>("text");
+                                <tpr-footer-bar-three-column-link href="@linkUrl?.Url" link-text="@linkText" lang="en-gb"></tpr-footer-bar-three-column-link>
+                            }
+                        </tpr-footer-bar-three-column-links>
 
-                        }
                     }
                 }
+            }
 
-            </tpr-footer-bar>
+        </tpr-footer-bar>
 
-            <div class="govuk-width-container govuk-!-margin-top-5">
-                <partial name="GOVUK/BlockList" model="Model.FooterWithThreeColumnLinksAndContent" />
-            </div>
-            <tpr-footer-bar class="govuk-!-margin-top-5" lang="@languageCode">
-                <tpr-footer-bar-logo alt="The Pensions Regulator logo" href="" />
-                <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
-                @if (column != null)
+        <div class="govuk-!-margin-top-5">
+            <partial name="GOVUK/BlockList" model="Model.FooterWithThreeColumnLinksAndContent" />
+        </div>
+        <tpr-footer-bar lang="@languageCode">
+            <tpr-footer-bar-logo alt="The Pensions Regulator logo" href="" />
+            <tpr-footer-bar-copyright>@(settings?.Value<string>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString()))</tpr-footer-bar-copyright>
+            @if (column != null)
+            {
+                @foreach (var item in column)
                 {
-                    @foreach (var item in column)
+                    foreach (var links in item.Areas)
                     {
-                        foreach (var links in item.Areas)
-                        {
-                            <tpr-footer-bar-three-column-links>
-                                @foreach (var link in links)
-                                {
-                                    var linkUrl = link.Content.Value<Link>("link");
-                                    var linkText = link.Content.Value<string>("text");
-                                    <tpr-footer-bar-three-column-link href="@linkUrl?.Url" link-text="@linkText"></tpr-footer-bar-three-column-link>
-                                }
-                            </tpr-footer-bar-three-column-links>
+                        <tpr-footer-bar-three-column-links>
+                            @foreach (var link in links)
+                            {
+                                var linkUrl = link.Content.Value<Link>("link");
+                                var linkText = link.Content.Value<string>("text");
+                                <tpr-footer-bar-three-column-link href="@linkUrl?.Url" link-text="@linkText"></tpr-footer-bar-three-column-link>
+                            }
+                        </tpr-footer-bar-three-column-links>
 
-                        }
                     }
                 }
-                <tpr-footer-bar-content allow-html="true">
-                    @(settings?.Value<IHtmlEncodedString>("tprFooterContent"))
-                </tpr-footer-bar-content>
-            </tpr-footer-bar>
+            }
+            <tpr-footer-bar-content allow-html="true">
+                @(settings?.Value<IHtmlEncodedString>("tprFooterContent"))
+            </tpr-footer-bar-content>
+        </tpr-footer-bar>
 
-            <div class="govuk-width-container govuk-!-margin-top-5">
-                <partial name="GOVUK/BlockList" model="Model.FinalBlocks" />
-            </div>
-        }
-        else
-        {
-            <div class="govuk-width-container">
-                <partial name="GOVUK/BlockList" model="Model.GovukBlocks" />
-            </div>
-        }
-    </header>
+        <div class="govuk-!-margin-top-5">
+            <partial name="GOVUK/BlockList" model="Model.FinalBlocks" />
+        </div>
+    }
+    else
+    {
+        <partial name="GOVUK/BlockList" model="Model.GovukBlocks" />
+    }
     <tpr-back-to-top href="#main">@Umbraco.GetDictionaryValue("Back to top")</tpr-back-to-top>
     <partial name="GOVUK/BodyClosing" />
 

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
@@ -18,12 +18,16 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             tagBuilder.MergeCssClass("tpr-footer");
             tagBuilder.MergeAttribute("role", "contentinfo");
 
+            var widthContainer = new TagBuilder("div");
+            widthContainer.MergeCssClass("govuk-width-container");
+            tagBuilder.InnerHtml.AppendHtml(widthContainer);
+
             var upperFooterContainer = new TagBuilder("div");
-            upperFooterContainer.MergeCssClass("tpr-footer__upper-footer-container");
-            tagBuilder.InnerHtml.AppendHtml(upperFooterContainer);
+            upperFooterContainer.MergeCssClass("govuk-grid-row");
+            widthContainer.InnerHtml.AppendHtml(upperFooterContainer);
 
             var logoContainer = new TagBuilder("div");
-            logoContainer.MergeCssClass("tpr-footer__footer-logo");
+            logoContainer.MergeCssClass("govuk-grid-column-one-quarter tpr-footer__footer-logo");
 
             var logoIsLinked = !string.IsNullOrEmpty(tprFooterBar.LogoHref);
             var logoElement = new TagBuilder(logoIsLinked ? "a" : "span");
@@ -43,27 +47,26 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             if (tprFooterBar.ThreeColumnLinks != null && tprFooterBar.ThreeColumnLinks?.Count > 0)
             {
-                var threeColumnLinks = new TagBuilder("div");
-                threeColumnLinks.AddCssClass("tpr-footer__three-column-links-container");
-                threeColumnLinks.MergeCssClass("govuk-body");
 
                 foreach (var column in tprFooterBar.ThreeColumnLinks)
                 {
-                    var ul = new TagBuilder("ul");
-                    if(column.Attributes != null) { ul.MergeAttributes(column.Attributes); }
-                    ul.AddCssClass("tpr-footer__three-column-links");
-
                     if (column.ThreeColumnFooterLinks != null && column.ThreeColumnFooterLinks.Count > 0)
                     {
+                        var linksColumn = new TagBuilder("div");
+                        linksColumn.AddCssClass("govuk-grid-column-one-quarter");
+
+                        var ul = new TagBuilder("ul");
+                        if (column.Attributes != null) { ul.MergeAttributes(column.Attributes); }
+                        ul.AddCssClass("govuk-list");
+                        ul.AddCssClass("tpr-footer__links");
+
                         foreach (var link in column.ThreeColumnFooterLinks)
                         {
                             var li = new TagBuilder("li");
-                            
-                            li.AddCssClass("tpr-footer__three-column-link");
 
                             var a = new TagBuilder("a");
                             a.AddCssClass("govuk-link");
-                          
+
                             if (link.LinkText != null)
                             {
                                 a.InnerHtml.Append(link.LinkText);
@@ -73,17 +76,19 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                                 a.Attributes.Add("href", link.LinkUrl);
                             }
 
-                            if (link.Attributes != null) { 
-                                a.MergeAttributes(link.Attributes); 
+                            if (link.Attributes != null)
+                            {
+                                a.MergeAttributes(link.Attributes);
                             }
-                            
+
                             li.InnerHtml.AppendHtml(a);
                             ul.InnerHtml.AppendHtml(li);
                         }
+
+                        linksColumn.InnerHtml.AppendHtml(ul);
+                        upperFooterContainer.InnerHtml.AppendHtml(linksColumn);
                     }
-                    threeColumnLinks.InnerHtml.AppendHtml(ul);
                 }
-                upperFooterContainer.InnerHtml.AppendHtml(threeColumnLinks);
             }
 
             var hasContent = (tprFooterBar.Content != null && !string.IsNullOrWhiteSpace(tprFooterBar.Content.ToString()));
@@ -102,9 +107,9 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 {
                     if (tprFooterBar.ContentAllowHtml)
                     {
-                                         
+
                         contentElement.InnerHtml.AppendHtml(tprFooterBar.Content!);
-                       
+
                     }
                     else
                     {
@@ -134,7 +139,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                     }
                     contentContainer.InnerHtml.AppendHtml(copyrightElement);
                 }
-                tagBuilder.InnerHtml.AppendHtml(contentContainer);
+                widthContainer.InnerHtml.AppendHtml(contentContainer);
             }
 
             return tagBuilder;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-footer.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-footer.scss
@@ -2,28 +2,13 @@
 @import 'govuk/base';
 @import 'govuk/helpers/_focused';
 
-// Like .govuk-width-container but without the margins because they're handled according to TPR brand by padding on .tpr-footer
-@mixin tpr-footer-width-container {
-    max-width: $govuk-page-width;
-    margin: auto;
-}
-
 .tpr-footer {
     background: $tpr-colour-whisper;
     border-top: govuk-px-to-rem(6) solid $tpr-colour-steel;
-    padding: govuk-px-to-rem(40) govuk-px-to-rem(20) 0;
-}
-
-@include govuk-media-query($from: desktop) {
-
-    .tpr-footer__upper-footer-container {
-        display: grid;
-        grid-template-columns: 1fr 4fr;
-    }
+    padding: govuk-px-to-rem(40) 0 0;
 }
 
 .tpr-footer__footer-logo {
-    @include tpr-footer-width-container;
     padding-bottom: govuk-px-to-rem(20);
 }
 
@@ -32,43 +17,16 @@
     height: govuk-px-to-rem(47);
 }
 
-.tpr-footer__three-column-links-container {
-    display: flex;
-    flex-direction: column;
-    gap: govuk-px-to-rem(20);
+.tpr-footer__links { 
+    @include govuk-responsive-margin(8, "bottom");
 }
 
-.tpr-footer__three-column-links {
-    display: flex;
-    flex-direction: column;
-    gap: govuk-px-to-rem(10);
-    list-style-type: none;
-}
-
-@include govuk-media-query($from: tablet) {
-    .tpr-footer__three-column-links-container {
-        flex-direction: row;
-        gap: 3rem;
-        justify-content: center;
-    }
-}
-
-.tpr-footer__three-column-link {
-    padding: 0.5rem;
-}
-
-.tpr-footer__three-column-link > a:visited {
-    color: $tpr-colour-steel;
-    margin-bottom: govuk-px-to-rem(20);
-}
-
-.tpr-footer__three-column-link > a:focus {
-    color: $tpr-colour-eclipse;
+.tpr-footer__links > li {
+    @include govuk-responsive-margin(4, "bottom");
 }
 
 // Wrapper around .tpr-footer__content and .tpr-footer__copyright allowing them to be positioned using flexbox at tablet & above
 .tpr-footer__content-container {
-    @include tpr-footer-width-container;
     border-top: govuk-px-to-rem(1) solid $tpr-colour-very-light-grey;
     padding-top: govuk-px-to-rem(22);
 }
@@ -86,11 +44,14 @@
 }
 
 .tpr-footer__content > a:link,
-.tpr-footer__content > a:visited {
+.tpr-footer__content > a:visited,
+.tpr-footer__links a:link,
+.tpr-footer__links a:visited {
     color: $tpr-colour-steel;
     margin-bottom: govuk-px-to-rem(20);
 }
 
+.tpr-footer__links a:focus,
 .tpr-footer__content > a:focus {
     color: $tpr-colour-eclipse;
 }
@@ -101,14 +62,8 @@
 }
 
 @include govuk-media-query($from: tablet) {
-    .tpr-footer {
-        padding-left: govuk-px-to-rem(30);
-        padding-right: govuk-px-to-rem(30);
-    }
-
     .tpr-footer__footer-logo {
         padding-bottom: govuk-px-to-rem(60);
-        margin-left: -2rem;
     }
 
     .tpr-footer__content-container {
@@ -123,12 +78,5 @@
     .tpr-footer__content > a {
         margin-bottom: 0;
         margin-right: govuk-px-to-rem(29);
-    }
-}
-
-@include govuk-media-query($from: desktop) {
-    .tpr-footer {
-        padding-left: govuk-px-to-rem(85);
-        padding-right: govuk-px-to-rem(85);
     }
 }


### PR DESCRIPTION
Recent changes to the footer have broken the alignment both horizontally and vertically:

<img width="980" height="492" alt="Image" src="https://github.com/user-attachments/assets/10198f55-bc4e-4383-87ce-64157e7c6231" />

Links in the three columns appear almost right-aligned within their containers:

<img width="532" height="296" alt="image" src="https://github.com/user-attachments/assets/38074b66-6e48-43e9-bd3c-e369c7700ff0" />

The example page also had structural problems resulting in misleading output. The footer was inside the header and there were multiple nested elements using `.govuk-width-container`.

Before recent changes it looked like this:

<img width="1573" height="414" alt="Image" src="https://github.com/user-attachments/assets/66b7d152-24c2-4f3e-815c-354efbbc3ac9" />

This PR restructures the footer to use standard GOV.UK grid elements, meaning it will line up with not just the main content but also any elements arranged within the main content using the standard GOV.UK grid. Specifically:

- the content of the footer is now contained by a standard `.govuk-width-container`
- the columns of links use `govuk-grid-column-one-quarter` rather than their own separate grid
- standard GOV.UK classes are used where available, eg `govuk-list` on the lists of links

The result is a footer which is correctly aligned with the content:

<img width="719" height="341" alt="image" src="https://github.com/user-attachments/assets/3d25a0ae-d762-45f9-8f0f-68ecde3aafc7" />

Fixes #572.