### PR TITLE
Date inputs can be configured to show the year

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/DateInputViewModel.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/DateInputViewModel.cs
@@ -18,5 +18,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Models
         public DateOnly? Field3 { get; set; }
 
         public DateTime? Field4 { get; set; }
+
+        public DateTime? Field5 { get; set; }
     }
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/date-input.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/Content/date-input.config
@@ -42,6 +42,10 @@
         "settingsUdi": "umb://element/9816812394c54925af2efd66fa66fca5"
       },
       {
+        "contentUdi": "umb://element/bf56f58a19d8457094658255fd63325d",
+        "settingsUdi": "umb://element/e0f092e64f3e4ac1a99e69085ceebad4"
+      },
+      {
         "contentUdi": "umb://element/71510aa15acf49dbb202ee9c68758d9d",
         "settingsUdi": "umb://element/dcc8183ff9804a28b1219a2289868ff7"
       }
@@ -173,6 +177,19 @@
       },
       "legend": "This date input is read-only",
       "udi": "umb://element/d8851c79883b49a99ab0bed9a36f7653"
+    },
+    {
+      "contentTypeKey": "a3a58c3e-673f-4521-b9e7-4b6a667f06b4",
+      "fieldsetBlocks": "",
+      "hint": {
+        "markup": "<p>For example, 25 12</p>",
+        "blocks": {
+          "contentData": [],
+          "settingsData": []
+        }
+      },
+      "legend": "Enter the date of an annual event ",
+      "udi": "umb://element/bf56f58a19d8457094658255fd63325d"
     }
   ],
   "settingsData": [
@@ -193,6 +210,7 @@
       "modelProperty": "Field1",
       "readOnly": "0",
       "showDay": "1",
+      "showYear": "1",
       "udi": "umb://element/a7a5e274492f4c8898096d7200f80370"
     },
     {
@@ -212,6 +230,7 @@
       "modelProperty": "Field2",
       "readOnly": "0",
       "showDay": "1",
+      "showYear": "1",
       "udi": "umb://element/b769d3c82e0c42f7975e895c1caeb309"
     },
     {
@@ -263,7 +282,28 @@
       "modelProperty": "Field3",
       "readOnly": "0",
       "showDay": "0",
+      "showYear": "1",
       "udi": "umb://element/c5d3fea65d77489280484d51849cd5c6"
+    },
+    {
+      "columnSize": "",
+      "columnSizeFromDesktop": "",
+      "contentTypeKey": "308973a3-4525-445f-9bcd-bdf3d649abb6",
+      "cssClasses": "",
+      "cssClassesForColumn": "",
+      "cssClassesForRow": "",
+      "customError1": "",
+      "customError2": "",
+      "customError3": "",
+      "displayName": "",
+      "errorMessageRange": "",
+      "errorMessageRequired": "",
+      "legendIsPageHeading": "0",
+      "modelProperty": "Field4",
+      "readOnly": "1",
+      "showDay": "1",
+      "showYear": "1",
+      "udi": "umb://element/9816812394c54925af2efd66fa66fca5"
     },
     {
       "columnSize": "",
@@ -279,10 +319,11 @@
       "errorMessageRange": "",
       "errorMessageRequired": "",
       "legendIsPageHeading": "0",
-      "modelProperty": "Field4",
-      "readOnly": "1",
+      "modelProperty": "Field5",
+      "readOnly": "0",
       "showDay": "1",
-      "udi": "umb://element/9816812394c54925af2efd66fa66fca5"
+      "showYear": "0",
+      "udi": "umb://element/e0f092e64f3e4ac1a99e69085ceebad4"
     }
   ]
 }]]></Value>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukdateinputsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukdateinputsettings.config
@@ -48,6 +48,22 @@
       <ValidationRegExpMessage></ValidationRegExpMessage>
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
+    <GenericProperty>
+      <Key>886b5aae-aad0-493c-aba8-15eb548cb019</Key>
+      <Name>Show the year field</Name>
+      <Alias>showYear</Alias>
+      <Definition>189de753-cac2-4307-868b-114832c68a07</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[If the year field is hidden the defaults to 1900.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="settings">Settings</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
   </GenericProperties>
   <Tabs>
     <Tab>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukdateinputsettings.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/ContentTypes/govukdateinputsettings.config
@@ -56,7 +56,7 @@
       <Type>Umbraco.TrueFalse</Type>
       <Mandatory>false</Mandatory>
       <Validation></Validation>
-      <Description><![CDATA[If the year field is hidden the defaults to 1900.]]></Description>
+      <Description><![CDATA[If the year field is hidden the year defaults to 1900.]]></Description>
       <SortOrder>5</SortOrder>
       <Tab Alias="settings">Settings</Tab>
       <Variations>Nothing</Variations>

--- a/GovUk.Frontend.Umbraco.Tests/HtmlGeneration/DateInputHtmlEnhancerTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/HtmlGeneration/DateInputHtmlEnhancerTests.cs
@@ -32,13 +32,13 @@ namespace GovUk.Frontend.Umbraco.Tests.HtmlGeneration
             </div>";
 
         [Test]
-        public void When_DayEnabled_Is_True_Html_Is_Unchanged()
+        public void When_DayEnabled_Is_True_And_YearEnabled_Is_True_Html_Is_Unchanged()
         {
             // Arrange
             var enhancer = new DateInputHtmlEnhancer();
 
             // Act
-            var result = enhancer.EnhanceHtml(DATE_INPUT_HTML, true);
+            var result = enhancer.EnhanceHtml(DATE_INPUT_HTML, true, true);
 
             // Assert
             Assert.That(result, Is.EqualTo(DATE_INPUT_HTML));
@@ -51,7 +51,7 @@ namespace GovUk.Frontend.Umbraco.Tests.HtmlGeneration
             var enhancer = new DateInputHtmlEnhancer();
 
             // Act
-            var result = enhancer.EnhanceHtml(DATE_INPUT_HTML, false);
+            var result = enhancer.EnhanceHtml(DATE_INPUT_HTML, false, true);
 
             // Assert
             var doc = new HtmlDocument();
@@ -61,6 +61,25 @@ namespace GovUk.Frontend.Umbraco.Tests.HtmlGeneration
             Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Day']"), Is.Null);
             Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Month']").Count, Is.EqualTo(1));
             Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Year']").Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void When_YearEnabled_Is_False_Year_Field_Is_Removed()
+        {
+            // Arrange
+            var enhancer = new DateInputHtmlEnhancer();
+
+            // Act
+            var result = enhancer.EnhanceHtml(DATE_INPUT_HTML, true, false);
+
+            // Assert
+            var doc = new HtmlDocument();
+            doc.LoadHtml(result);
+
+            Assert.That(doc.DocumentNode.SelectNodes("//div[@class='govuk-date-input__item']").Count, Is.EqualTo(2));
+            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Day']").Count, Is.EqualTo(1));
+            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Month']").Count, Is.EqualTo(1));
+            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Year']"), Is.Null);
         }
     }
 }

--- a/GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -178,6 +178,7 @@ namespace GovUk.Frontend.Umbraco.Tests.ModelBinding
                 UmbracoBlockGridFactory.CreateContentOrSettings("settings")
                     .SetupUmbracoTextboxPropertyValue(PropertyAliases.ModelProperty, nameof(ExampleModel.DateProperty))
                     .SetupUmbracoBooleanPropertyValue(PropertyAliases.DateInputShowDay, false)
+                    .SetupUmbracoBooleanPropertyValue(PropertyAliases.DateInputShowYear, true)
                     .Object
             );
             var grid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(block);
@@ -224,6 +225,68 @@ namespace GovUk.Frontend.Umbraco.Tests.ModelBinding
             Assert.AreEqual("2020", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
             Assert.AreEqual("4", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
             Assert.AreEqual(null, bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
+
+            Assert.AreEqual(0, bindingContext.ModelState.ErrorCount);
+        }
+
+        [Test]
+        public async Task BindModelAsync_DayAndMonth_AllComponentsProvided_PassesValuesToConverterAndBindsResult()
+        {
+            // Arrange
+            var modelType = typeof(ExampleModel);
+
+            var block = UmbracoBlockGridFactory.CreateOverridableBlock(
+                UmbracoBlockGridFactory.CreateContentOrSettings("content").Object,
+                UmbracoBlockGridFactory.CreateContentOrSettings("settings")
+                    .SetupUmbracoTextboxPropertyValue(PropertyAliases.ModelProperty, nameof(ExampleModel.DateProperty))
+                    .SetupUmbracoBooleanPropertyValue(PropertyAliases.DateInputShowDay, true)
+                    .SetupUmbracoBooleanPropertyValue(PropertyAliases.DateInputShowYear, false)
+                    .Object
+            );
+            var grid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(block);
+            _testContext.CurrentPage.SetupUmbracoBlockGridPropertyValue("blocks", grid);
+
+
+            ModelBindingContext bindingContext = new DefaultModelBindingContext()
+            {
+                ActionContext = CreateActionContext(),
+                ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForProperty(modelType, nameof(ExampleModel.DateProperty)),
+                ModelName = nameof(ExampleModel.DateProperty),
+                ModelState = new ModelStateDictionary(),
+                ValueProvider = new SimpleValueProvider()
+                {
+                    { $"{nameof(ExampleModel.DateProperty)}.Day", "25" },
+                    { $"{nameof(ExampleModel.DateProperty)}.Month", "12" }
+                }
+            };
+
+            var converterMock = new Mock<DateInputModelConverter>();
+
+            converterMock
+                .Protected()
+                .Setup<object>("ConvertToModelCore", ItExpr.IsAny<DateInputConvertToModelContext>())
+                .Returns(new DateOnly(1900, 12, 25))
+                .Verifiable();
+
+            var modelBinder = CreateModelBinder(converterMock.Object);
+
+            // Act
+            await modelBinder.BindModelAsync(bindingContext);
+
+            // Assert
+            converterMock.Verify();
+
+            Assert.True(bindingContext.Result.IsModelSet);
+
+            Assert.IsInstanceOf<DateOnly>(bindingContext.Result.Model);
+            var date = (DateOnly)bindingContext.Result.Model!;
+            Assert.AreEqual(1900, date.Year);
+            Assert.AreEqual(12, date.Month);
+            Assert.AreEqual(25, date.Day);
+
+            Assert.AreEqual(null, bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
+            Assert.AreEqual("12", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
+            Assert.AreEqual("25", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
 
             Assert.AreEqual(0, bindingContext.ModelState.ErrorCount);
         }

--- a/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkDateInputPreview.html
+++ b/GovUk.Frontend.Umbraco/App_Plugins/GOVUK/blocks/views/GovUkDateInputPreview.html
@@ -19,7 +19,7 @@
                         <input class="govuk-date-input__input govuk-input govuk-input--width-2" inputmode="numeric" type="text" />
                     </div>
                 </div>
-                <div class="govuk-date-input__item">
+                <div class="govuk-date-input__item" ng-if="block.settingsData.showYear==='1'">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label">Year</label>
                         <input class="govuk-date-input__input govuk-input govuk-input--width-4" inputmode="numeric" type="text" />

--- a/GovUk.Frontend.Umbraco/HtmlGeneration/DateInputHtmlEnhancer.cs
+++ b/GovUk.Frontend.Umbraco/HtmlGeneration/DateInputHtmlEnhancer.cs
@@ -4,19 +4,29 @@ namespace GovUk.Frontend.Umbraco.HtmlGeneration
 {
     public class DateInputHtmlEnhancer : IDateInputHtmlEnhancer
     {
-        public string EnhanceHtml(string html, bool dayEnabled)
+        public string EnhanceHtml(string html, bool dayEnabled, bool yearEnabled)
         {
-            if (dayEnabled) { return html; }
+            if (dayEnabled && yearEnabled) { return html; }
 
             var document = new HtmlDocument();
             document.LoadHtml(html);
 
-
-            var wrapperForDayInput = document.DocumentNode.SelectSingleNode($"//div[{WithClass("govuk-date-input__item")} and div[{WithClass(GovUkClassNames.FormGroup)} and input[{EndsWith("@id", ".Day")}]]]");
-
-            if (wrapperForDayInput is not null)
+            if (!dayEnabled)
             {
-                wrapperForDayInput.ParentNode.RemoveChild(wrapperForDayInput);
+                var wrapperForDayInput = document.DocumentNode.SelectSingleNode($"//div[{WithClass("govuk-date-input__item")} and div[{WithClass(GovUkClassNames.FormGroup)} and input[{EndsWith("@id", ".Day")}]]]");
+                if (wrapperForDayInput is not null)
+                {
+                    wrapperForDayInput.ParentNode.RemoveChild(wrapperForDayInput);
+                }
+            }
+
+            if (!yearEnabled)
+            {
+                var wrapperForYearInput = document.DocumentNode.SelectSingleNode($"//div[{WithClass("govuk-date-input__item")} and div[{WithClass(GovUkClassNames.FormGroup)} and input[{EndsWith("@id", ".Year")}]]]");
+                if (wrapperForYearInput is not null)
+                {
+                    wrapperForYearInput.ParentNode.RemoveChild(wrapperForYearInput);
+                }
             }
 
             return document.DocumentNode.OuterHtml;

--- a/GovUk.Frontend.Umbraco/HtmlGeneration/IDateInputHtmlEnhancer.cs
+++ b/GovUk.Frontend.Umbraco/HtmlGeneration/IDateInputHtmlEnhancer.cs
@@ -2,6 +2,6 @@
 {
     public interface IDateInputHtmlEnhancer
     {
-        string EnhanceHtml(string html, bool dayEnabled);
+        string EnhanceHtml(string html, bool dayEnabled, bool yearEnabled);
     }
 }

--- a/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
+++ b/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
@@ -260,8 +260,6 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
                     {
                         assumedYear = parsedYear;
                     }
-                    /*var assumedYear = yearIsValid ? parsedYear : 2000; */ 
-                    // Bug is here, the year could be valid because it has not been provided, which means parsedYear will be null
 
                     maxDaysInMonth = DateTime.DaysInMonth(assumedYear, parsedMonth);
                 }

--- a/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
+++ b/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
@@ -27,7 +27,8 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
         internal static DateInputItemTypes[] SupportedItemTypes { get; } =
         [
             DateInputItemTypes.DayMonthAndYear,
-            DateInputItemTypes.MonthAndYear
+            DateInputItemTypes.MonthAndYear,
+            DateInputItemTypes.DayAndMonth
         ];
 
         private readonly DateInputModelConverter _dateInputModelConverter;
@@ -65,6 +66,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
 
             var blockSettings = !string.IsNullOrEmpty(bindingContext.ModelMetadata.PropertyName) ? umbracoContext.PublishedRequest.PublishedContent.FindOverridableBlockModels(_publishedValueFallback).FindBlockByBoundProperty(bindingContext.ModelMetadata.PropertyName)?.Settings : null;
             var dayEnabled = blockSettings is not null ? blockSettings.Value<bool>(PropertyAliases.DateInputShowDay) : true;
+            var yearEnabled = blockSettings is not null ? blockSettings.Value<bool>(PropertyAliases.DateInputShowYear) : true;
 
             var dayModelName = $"{bindingContext.ModelName}.{DayComponentName}";
             var monthModelName = $"{bindingContext.ModelName}.{MonthComponentName}";
@@ -72,7 +74,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
 
             var dayValueProviderResult = dayEnabled ? bindingContext.ValueProvider.GetValue(dayModelName) : ValueProviderResult.None;
             var monthValueProviderResult = bindingContext.ValueProvider.GetValue(monthModelName);
-            var yearValueProviderResult = bindingContext.ValueProvider.GetValue(yearModelName);
+            var yearValueProviderResult = yearEnabled ? bindingContext.ValueProvider.GetValue(yearModelName) : ValueProviderResult.None;
 
             if ((dayValueProviderResult == ValueProviderResult.None || dayValueProviderResult.FirstValue == string.Empty) &&
                 (monthValueProviderResult == ValueProviderResult.None || monthValueProviderResult.FirstValue == string.Empty) &&
@@ -81,8 +83,20 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
                 return Task.CompletedTask;
             }
 
-            var itemTypes = dayEnabled ? DateInputItemTypes.DayMonthAndYear : DateInputItemTypes.MonthAndYear;
-
+            DateInputItemTypes itemTypes;
+            if (!dayEnabled)
+            {
+                itemTypes = DateInputItemTypes.MonthAndYear;
+            }
+            else if (!yearEnabled)
+            {
+                itemTypes = DateInputItemTypes.DayAndMonth;
+            }
+            else
+            {
+                itemTypes = DateInputItemTypes.DayMonthAndYear;
+            }
+            
             if (!SupportedItemTypes.Contains(itemTypes))
             {
                 // Weird combination of fields submitted; we're done
@@ -241,8 +255,15 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
                 // If we only have the month and not a year, we should assume the year could be a leap year.
                 if (monthIsValid)
                 {
-                    var y = yearIsValid ? parsedYear : 2000;  // 2000 is a leap year
-                    maxDaysInMonth = DateTime.DaysInMonth(y, parsedMonth);
+                    var assumedYear = 2000; // 2000 is a leap year
+                    if (yearIsValid && parsedYear != 0)
+                    {
+                        assumedYear = parsedYear;
+                    }
+                    /*var assumedYear = yearIsValid ? parsedYear : 2000; */ 
+                    // Bug is here, the year could be valid because it has not been provided, which means parsedYear will be null
+
+                    maxDaysInMonth = DateTime.DaysInMonth(assumedYear, parsedMonth);
                 }
 
                 if (string.IsNullOrEmpty(day))
@@ -258,7 +279,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
             dateParts = errors == DateInputParseErrors.None ? new(
                 expectDay ? parsedDay : 1,
                 expectMonth ? parsedMonth : null,
-                expectYear ? parsedYear : null) : default;
+                expectYear ? parsedYear : 1900) : default;
             return errors;
 
             bool TryParseDay(string value, out int result) => int.TryParse(value, out result);

--- a/GovUk.Frontend.Umbraco/PropertyAliases.cs
+++ b/GovUk.Frontend.Umbraco/PropertyAliases.cs
@@ -28,6 +28,7 @@
         public const string ColumnSize = "columnSize";
         public const string ColumnSizeFromDesktop = "columnSizeFromDesktop";
         public const string DateInputShowDay = "showDay";
+        public const string DateInputShowYear = "showYear";
         public const string DateInputFieldsetBlocks = "fieldsetBlocks";
         public const string DetailsSummary = "summary";
         public const string DecorativeImage = "decorativeImage";

--- a/GovUk.Frontend.Umbraco/TagHelpers/GovUKDateInputOptionsTagHelper.cs
+++ b/GovUk.Frontend.Umbraco/TagHelpers/GovUKDateInputOptionsTagHelper.cs
@@ -1,7 +1,5 @@
 ﻿using GovUk.Frontend.Umbraco.HtmlGeneration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
-using System.Threading.Tasks;
 
 namespace GovUk.Frontend.Umbraco.TagHelpers
 {
@@ -22,13 +20,24 @@ namespace GovUk.Frontend.Umbraco.TagHelpers
         [HtmlAttributeName("show-day")]
         public bool ShowDay { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets whether to the show the year field.
+        /// </summary>
+        [HtmlAttributeName("show-year")]
+        public bool ShowYear { get; set; } = true;
+
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
+            if (!ShowDay && !ShowYear)
+            {
+                throw new InvalidOperationException("At least one of 'show-day' or 'show-year' must be true.");
+            }
+
             // Grab the HTML that would've been rendered by the child tag helper.
             var html = (await output.GetChildContentAsync()).GetContent();
             output.SuppressOutput();
 
-            html = _htmlEnhancer.EnhanceHtml(html, ShowDay);
+            html = _htmlEnhancer.EnhanceHtml(html, ShowDay, ShowYear);
 
             // Output the child HTML with any modifications made
             output.Content.AppendHtml(html);

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
@@ -79,6 +79,7 @@
     }
     var readOnly = Model.Settings.Value<bool>(PropertyAliases.ReadOnly);
     var showDay = Model.Settings.Value<bool?>(PropertyAliases.DateInputShowDay) ?? true;
+    var showYear = Model.Settings.Value<bool?>(PropertyAliases.DateInputShowYear) ?? true;
 }
 <div class="@(GovUkClassNames.FormGroup)@(invalidClass)@(cssClass)">
     <govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
@@ -100,7 +101,7 @@
             {
                 if (readOnly)
                 {
-                    <govuk-date-input-options show-day="@showDay">
+                    <govuk-date-input-options show-day="@showDay" show-year="@showYear">
                         <govuk-date-input name-prefix="@modelPropertyName" id="@modelPropertyName" value="@dateValue">
                             @if (hasHint)
                             {
@@ -118,7 +119,7 @@
                 }
                 else
                 {
-                    <govuk-date-input-options show-day="@showDay">
+                    <govuk-date-input-options show-day="@showDay" show-year="@showYear">
                         <govuk-date-input name-prefix="@modelPropertyName" id="@modelPropertyName" value="@dateValue">
                             @if (hasHint)
                             {
@@ -139,7 +140,7 @@
             {
                 if (readOnly)
                 {
-                    <govuk-date-input-options show-day="@showDay">
+                    <govuk-date-input-options show-day="@showDay" show-year="@showYear">
                         <govuk-date-input name-prefix="@modelPropertyName" id="@modelPropertyName">
                             @if (hasHint)
                             {
@@ -157,7 +158,7 @@
                 }
                 else
                 {
-                    <govuk-date-input-options show-day="@showDay">
+                    <govuk-date-input-options show-day="@showDay" show-year="@showYear">
                         <govuk-date-input name-prefix="@modelPropertyName" id="@modelPropertyName">
                             @if (hasHint)
                             {


### PR DESCRIPTION
Adds a tag helper and Umbraco configuration to hide the 'year' input box as part of a date input. This extends the work already done to hide the 'day' field. 

Includes some changes to the model binder, as there were a few bugs for when a year was not provided.

Defaults the year to 1900 after discussions with the team. I could provide a way to configure the default year, but that could come as an enhancement of this work.