### PR TITLE
Header menu improvements

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -217,12 +217,6 @@
             text-decoration: none;
             padding: 1rem;
         }
-
-        a:hover {
-            background: $tpr-colour-white;
-            text-decoration: underline;
-            color: $tpr-colour-black;
-        }
     }
 
     .tpr-header-menu__nav-menu-item {
@@ -295,6 +289,12 @@
         background-color: rgba(0,0,0,0.5);
         z-index: -1;
         cursor: pointer;
+    }
+
+    .tpr-header-menu__nav-menu-item:focus-within > a, .tpr-header-menu__nav-menu-item:hover > a /*.tpr-header-menu__nav-container a[aria-expanded="true"]*/ { //this is displaying without js
+        background: $tpr-colour-white;
+        text-decoration: underline;
+        color: $tpr-colour-black;
     }
 }
 

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -291,7 +291,7 @@
         cursor: pointer;
     }
 
-    .tpr-header-menu__nav-menu-item:focus-within > a, .tpr-header-menu__nav-menu-item:hover > a /*.tpr-header-menu__nav-container a[aria-expanded="true"]*/ { //this is displaying without js
+    .tpr-header-menu__nav-menu-item:focus-within > a, .tpr-header-menu__nav-menu-item:hover > a { 
         background: $tpr-colour-white;
         text-decoration: underline;
         color: $tpr-colour-black;

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -160,8 +160,9 @@ function keyboardToggleMobileMenu(e) {
 function desktopKeyboardNavigation(e) {
 
     const menuItem = e.currentTarget
+    const menuItemElements = document.querySelectorAll(".tpr-header-menu__nav-menu-item")
 
-    let menuItems = Array.from(document.querySelectorAll(".tpr-header-menu__nav-menu-item"));
+    let menuItems = Array.from(menuItemElements);
 
     let a = menuItem.querySelector('a');
 
@@ -177,7 +178,7 @@ function desktopKeyboardNavigation(e) {
         const newlyFocusedItem = e.target.closest(".tpr-header-menu__nav-menu-item");
         if (!newlyFocusedItem) return;
 
-        document.querySelectorAll(".tpr-header-menu__nav-menu-item").forEach(item => {
+        menuItemElements.forEach(item => {
             if (item !== newlyFocusedItem) {
                 const a = item.querySelector("a");
                 const sub = item.querySelector(".tpr-header-menu__nav-sub-menu");
@@ -192,20 +193,20 @@ function desktopKeyboardNavigation(e) {
     switch (e.key) {
         case "ArrowRight":
             e.preventDefault();
-            menuItems[(currentIndex + 1) % menuItems.length].querySelector('a')?.focus();
-            overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+            menuItems[(currentIndex + 1) % menuItems.length].querySelector('a')?.focus();         
             if (hasSubMenu) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
+                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
             }
             break;
         case "ArrowLeft":
             e.preventDefault();
             menuItems[(currentIndex - 1 + menuItems.length) % menuItems.length].querySelector('a')?.focus();
-            overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
             if (hasSubMenu) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
+                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
             }
             break;
         case "ArrowUp":
@@ -213,17 +214,17 @@ function desktopKeyboardNavigation(e) {
             if (hasSubMenu) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
-                menuItems[(currentIndex)].querySelector('a')?.focus();
+                a.focus();
+                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
             }
-            overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
             break;
         case "ArrowDown":
             e.preventDefault();
             if (hasSubMenu) {
                 subMenu.style.display = 'grid';
+                a.setAttribute("aria-expanded", "true");
                 subMenu.querySelector(".tpr-header-menu__nav-sub-menu-item").removeAttribute("style");
                 overlay?.classList.add("tpr-header-menu__nav-overlay--visible");
-                a.setAttribute("aria-expanded", "true");
             }
             break;
         case "Escape":

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -11,9 +11,12 @@ document.addEventListener("DOMContentLoaded", function () {
         const overlay = document.querySelectorAll(".tpr-header-menu__nav-overlay");
         const menuItems = document.querySelectorAll(".tpr-header-menu__nav-menu-item");
         const arrows = document.querySelectorAll(".tpr-mobile-menu__arrow");
+        const nav = document.querySelector(".tpr-header-menu__nav");
+
+        const isMobile = e.matches;
 
 
-        if (e.matches) {
+        if (isMobile) {
 
             toggles.forEach(t => t.removeAttribute("href"));
             toggles.forEach(t => t.addEventListener("click", toggleMobileMenu));
@@ -21,8 +24,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
             overlay.forEach(o => o.addEventListener("click", toggleMobileMenu));
 
-
             arrows.forEach(a => a.addEventListener("click", expandMobileMenuSubMenu))
+
+            nav.removeEventListener("focusin", restoreDefaultMenuState);
 
             menuItems.forEach(m => {
                 const subMenu = m.querySelector(".tpr-header-menu__nav-sub-menu");
@@ -39,6 +43,7 @@ document.addEventListener("DOMContentLoaded", function () {
             overlay?.forEach(o => o.classList.remove("tpr-header-menu__nav-overlay--visible"));
             toggles.forEach(t => t.removeEventListener("click", toggleMobileMenu))
             overlay.forEach(o => o.removeEventListener("click", toggleMobileMenu));
+            nav.addEventListener("focusin", restoreDefaultMenuState);
 
             arrows.forEach(a => a.removeEventListener("click", expandMobileMenuSubMenu))
 
@@ -53,7 +58,6 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
                 m.removeEventListener("keydown", mobileKeyboardNavigation)
                 m.addEventListener("keydown", desktopKeyboardNavigation)
-                overlay.forEach(o => o.addEventListener("click", removeOverlayOnClick));
             });
 
             removeActiveClasses()
@@ -128,17 +132,11 @@ function displayDesktopOverlayOnHover() {
                         a.setAttribute("aria-expanded", "false")
                     }
                 })
-
             );
         }
     });
 }
 
-function removeOverlayOnClick() {
-
-    const overlay = document.querySelector(".tpr-header-menu__nav-overlay");
-    overlay?.classList.remove("tpr-header-menu__nav-overlay--visible")
-}
 
 function keyboardToggleMobileMenu(e) {
 
@@ -172,28 +170,11 @@ function desktopKeyboardNavigation(e) {
     const currentIndex = menuItems.indexOf(menuItem);
 
     const overlay = document.querySelector(".tpr-header-menu__nav-overlay")
-    const nav = document.querySelector(".tpr-header-menu__nav");
-
-    nav.addEventListener("focusin", (e) => {
-        const newlyFocusedItem = e.target.closest(".tpr-header-menu__nav-menu-item");
-        if (!newlyFocusedItem) return;
-
-        menuItemElements.forEach(item => {
-            if (item !== newlyFocusedItem) {
-                const a = item.querySelector("a");
-                const sub = item.querySelector(".tpr-header-menu__nav-sub-menu");
-                if (sub) {
-                    sub.style.display = "none";
-                    a?.setAttribute("aria-expanded", "false");
-                }
-            }
-        });
-    });
-
+  
     switch (e.key) {
         case "ArrowRight":
             e.preventDefault();
-            menuItems[(currentIndex + 1) % menuItems.length].querySelector('a')?.focus();         
+            menuItems[(currentIndex + 1) % menuItems.length].querySelector('a')?.focus();
             if (hasSubMenu) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
@@ -256,6 +237,34 @@ function desktopKeyboardNavigation(e) {
             }, 0);
             break;
     }
+}
+
+function restoreDefaultMenuState(e) {
+
+    const menuItemElements = document.querySelectorAll(".tpr-header-menu__nav-menu-item")
+    const overlay = document.querySelector(".tpr-header-menu__nav-overlay")
+
+    const newlyFocusedItem = e.target.closest(".tpr-header-menu__nav-menu-item");
+    if (!newlyFocusedItem) return;
+
+    menuItemElements.forEach(item => {
+
+        const sub = item.querySelector(".tpr-header-menu__nav-sub-menu");
+
+        if (item !== newlyFocusedItem) {
+            const a = item.querySelector("a");
+            if (sub) {
+                sub.style.display = "none";
+                a?.setAttribute("aria-expanded", "false");             
+            }
+        }
+
+        const focusedTopLevelItem = newlyFocusedItem.querySelector("a");
+        if (e.target === focusedTopLevelItem) {
+            overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+            sub.style.display = "none";
+        }
+    });
 }
 
 function toggleMobileMenu() {

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -21,6 +21,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
             overlay.forEach(o => o.addEventListener("click", toggleMobileMenu));
 
+
             arrows.forEach(a => a.addEventListener("click", expandMobileMenuSubMenu))
 
             menuItems.forEach(m => {
@@ -36,9 +37,7 @@ document.addEventListener("DOMContentLoaded", function () {
         } else {
 
             overlay?.forEach(o => o.classList.remove("tpr-header-menu__nav-overlay--visible"));
-
             toggles.forEach(t => t.removeEventListener("click", toggleMobileMenu))
-
             overlay.forEach(o => o.removeEventListener("click", toggleMobileMenu));
 
             arrows.forEach(a => a.removeEventListener("click", expandMobileMenuSubMenu))
@@ -54,6 +53,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
                 m.removeEventListener("keydown", mobileKeyboardNavigation)
                 m.addEventListener("keydown", desktopKeyboardNavigation)
+                overlay.forEach(o => o.addEventListener("click", removeOverlayOnClick));
             });
 
             removeActiveClasses()
@@ -68,12 +68,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
 function highlightCurrentSection() {
 
-    let url = window.location.href.toString().split(window.location.host)[1];
+    let url = window.location.pathname;
 
     url = url.replace(/^\/[a-z]{2}\//i, '/');
     url = url.replace(/\/[a-z]{2}(?=\/|$)/gi, '');
 
-    let section = Array.from(url).filter(char => char !== '/').join('').replace("-", " ");
+    let section = url.split('/').slice(1, 2).join('').replace("-", " ");
 
     if (!section) {
         return;
@@ -134,6 +134,12 @@ function displayDesktopOverlayOnHover() {
     });
 }
 
+function removeOverlayOnClick() {
+
+    const overlay = document.querySelector(".tpr-header-menu__nav-overlay");
+    overlay?.classList.remove("tpr-header-menu__nav-overlay--visible")
+}
+
 function keyboardToggleMobileMenu(e) {
 
     switch (e.key) {
@@ -165,7 +171,23 @@ function desktopKeyboardNavigation(e) {
     const currentIndex = menuItems.indexOf(menuItem);
 
     const overlay = document.querySelector(".tpr-header-menu__nav-overlay")
+    const nav = document.querySelector(".tpr-header-menu__nav");
 
+    nav.addEventListener("focusin", (e) => {
+        const newlyFocusedItem = e.target.closest(".tpr-header-menu__nav-menu-item");
+        if (!newlyFocusedItem) return;
+
+        document.querySelectorAll(".tpr-header-menu__nav-menu-item").forEach(item => {
+            if (item !== newlyFocusedItem) {
+                const a = item.querySelector("a");
+                const sub = item.querySelector(".tpr-header-menu__nav-sub-menu");
+                if (sub) {
+                    sub.style.display = "none";
+                    a?.setAttribute("aria-expanded", "false");
+                }
+            }
+        });
+    });
 
     switch (e.key) {
         case "ArrowRight":
@@ -202,6 +224,14 @@ function desktopKeyboardNavigation(e) {
                 subMenu.querySelector(".tpr-header-menu__nav-sub-menu-item").removeAttribute("style");
                 overlay?.classList.add("tpr-header-menu__nav-overlay--visible");
                 a.setAttribute("aria-expanded", "true");
+            }
+            break;
+        case "Escape":
+            if (hasSubMenu) {
+                subMenu.style.display = 'none';
+                a.setAttribute("aria-expanded", "false");
+                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+                a.focus();
             }
             break;
         default:

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -170,7 +170,7 @@ function desktopKeyboardNavigation(e) {
     const currentIndex = menuItems.indexOf(menuItem);
 
     const overlay = document.querySelector(".tpr-header-menu__nav-overlay")
-  
+
     switch (e.key) {
         case "ArrowRight":
             e.preventDefault();
@@ -250,19 +250,22 @@ function restoreDefaultMenuState(e) {
     menuItemElements.forEach(item => {
 
         const sub = item.querySelector(".tpr-header-menu__nav-sub-menu");
+        const a = item.querySelector("a");
 
         if (item !== newlyFocusedItem) {
-            const a = item.querySelector("a");
             if (sub) {
                 sub.style.display = "none";
-                a?.setAttribute("aria-expanded", "false");             
+                a?.setAttribute("aria-expanded", "false");
             }
         }
 
         const focusedTopLevelItem = newlyFocusedItem.querySelector("a");
         if (e.target === focusedTopLevelItem) {
             overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
-            sub.style.display = "none";
+            if (sub) {
+                sub.style.display = "none";
+                a?.setAttribute("aria-expanded", "false");
+            }
         }
     });
 }


### PR DESCRIPTION
Why:

- When on a child page e.g `employers/new-employers` the current section was not being highlighted in the menu.
- When a sub menu was expanded the background did not update.
- Some previous functionality not supported.

In this PR:

- Update `highlightCurrentSection` function to retrieve correct part of URL.
- Added correct styling for when menu item is focused and hovered over.
- Added support to close the sub menu using the `Esc` key for keyboard navigation.
- Ensuring previous menu item state is returned to default when user tabs through entire sub menu.
- Able to close the overlay with click in desktop view. 