### PR TITLE
Fix accessibility issues with side nav component 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.0.11</Version>
+    <Version>9.0.12</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend/Models/TprSideNavigationViewModel.cs
+++ b/ThePensionsRegulator.Frontend/Models/TprSideNavigationViewModel.cs
@@ -6,6 +6,10 @@ namespace ThePensionsRegulator.Frontend.Models
     {
         public required TprSideNavigationLink TitleLink { get; set; }
         public string AriaNavigationLabel { get; set; } = "Pages in this section";
+        public string ExpandItemLabel { get; set; } = "Expand {0}";
+        public string CollapseItemLabel { get; set; } = "Collapse {0}";
+        public string ExpandedItemLabel { get; set; } = "{0} is expanded";
+        public string CollapsedItemLabel { get; set; } = "{0} is collapsed";
         public List<TprSideNavigationLink> NavigationLinks { get; set; } = new();
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-side-navigation.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-side-navigation.scss
@@ -14,7 +14,7 @@ $side-nav-selection-border-size: govuk-spacing(1);
 }
 
 a.tpr-side-nav__desktop-link {
-    display: block;
+    display: none;
 }
 
 .tpr-side-nav li {
@@ -26,7 +26,7 @@ a.tpr-side-nav__desktop-link {
 }
 
 .tpr-side-nav__mobile-expand-toggle {
-    display: none;
+    display: block;
     color: $tpr-colour-royal-blue;
     border: none;
     background-color: transparent;
@@ -40,29 +40,24 @@ a.tpr-side-nav__desktop-link {
 }
 
 .tpr-side-nav__mobile-expand-toggle__arrow {
-    content: url(../../ThePensionsRegulator.Frontend/tpr/tpr-arrow-down.svg);
-    max-height: 25px;
-    max-width: 25px;
     float: inline-end;
 }
 
-.tpr-side-nav a {
+.tpr-side-nav .govuk-link {
+    font-weight: normal;
+}
+
+.tpr-side-nav a:not(.tpr-side-nav__mobile-expand-toggle):not(.tpr-side-nav__desktop-link) {
     text-decoration: none;
     padding: govuk-spacing(1);
     padding-left: $side-nav-indentation-space;
     display: inline-block;
     position: relative;
-
-    &.govuk-link--no-visited-state {
-        font-weight: normal;
-        font-family: "Open Sans", Arial, sans-serif;
-    }
 }
 .tpr-side-nav a.tpr-side-nav__desktop-link {
     padding-left: govuk-spacing(1);
 }
 
-// Root ul only
 .tpr-side-nav > ul {
     margin: $side-nav-indentation-space ($side-nav-indentation-space * -1);
 }
@@ -72,8 +67,12 @@ ul.tpr-side-nav__list {
     padding-inline-start: 0;
     display:none;
 }
-ul[data-level = "1"]{
-    display:block;
+
+.tpr-side-nav__list[data-level = "1"]{
+    display:none;
+}
+.tpr-side-nav__list--expanded[data-level = "1"] {
+    display: block;
 }
 
 .tpr-side-nav__list ul {
@@ -92,16 +91,13 @@ ul[data-level = "1"]{
     display: flex;
 }
 
-.tpr-side-nav__list-item__arrow {
-    content: url(../../ThePensionsRegulator.Frontend/tpr/tpr-arrow-down.svg);
-    max-height: 25px;
-    max-width: 25px;
+.tpr-side-nav__list-item-arrow {
     float: inline-end;
     padding: 0.2em;
     cursor: pointer;
 }
 
-.tpr-side-nav__arrow--up {
+.tpr-side-nav__list-item-arrow--up {
     transform: rotate(180deg);
 }
 
@@ -141,16 +137,16 @@ li.tpr-side-nav__list-item--expanded {
     border-color: transparent;
 }
 
-@include govuk-media-query($until:tablet) {
-    ul[data-level = "1"] {
-        display: none;
+@include govuk-media-query($from:tablet) {
+    .tpr-side-nav__list[data-level = "1"] {
+        display: block;
     }
 
     a.tpr-side-nav__desktop-link {
-        display: none;
+        display: block;
     }
 
-    button.tpr-side-nav__mobile-expand-toggle {
-        display: block;
+    .tpr-side-nav__mobile-expand-toggle {
+        display: none;
     }
 }

--- a/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
@@ -1,41 +1,51 @@
+@using System.Web
 @using ThePensionsRegulator.Frontend
 @using ThePensionsRegulator.Frontend.Models
 @model TprSideNavigationViewModel
-<nav class="tpr-side-nav" aria-label="@Model.AriaNavigationLabel">
+@{
+    var query = HttpUtility.ParseQueryString(Context.Request.QueryString.ToString());
+    var isMobileExpanded = query["tpr-side-nav"] == "expand";
+    query["tpr-side-nav"] = "expand";
+    var expandMobileUrl = Context.Request.Path + "?" + query;
+
+    var id = "tpr-side-nav__" + Guid.NewGuid().ToString().Substring(0,8);
+}
+<nav class="tpr-side-nav" id="@id" aria-label="@Model.AriaNavigationLabel" data-expand-text="@Model.ExpandItemLabel" data-collapse-text="@Model.CollapseItemLabel">
     @{
         var level = 1;
         if (Model.TitleLink is not null)
         {
             <h2 class="govuk-heading-m">
-                <button aria-expanded="false" type="button" class="govuk-link--no-visited-state tpr-side-nav__mobile-expand-toggle">
+                <a href="@expandMobileUrl" class="govuk-link govuk-link--no-visited-state tpr-side-nav__mobile-expand-toggle">
                     @Model.TitleLink.Name
-                    <img alt="tpr-arrow-image" class="tpr-side-nav__mobile-expand-toggle__arrow" />
-                </button>
-                <a class="govuk-link--no-visited-state tpr-side-nav__desktop-link" href="@Model.TitleLink.Url">@Model.TitleLink.Name</a>
+                    <img src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-arrow-down.svg" width="25" height="25" alt="@(string.Format(isMobileExpanded ? Model.CollapseItemLabel : Model.ExpandItemLabel, string.Empty))" class="tpr-side-nav__mobile-expand-toggle__arrow" />
+                </a>
+                <a class="govuk-link govuk-link--no-visited-state tpr-side-nav__desktop-link" href="@Model.TitleLink.Url">@Model.TitleLink.Name</a>
             </h2>
         }
-        RenderNavListLayer(Model.NavigationLinks, level);
+        await RenderNavListLayer(Model.NavigationLinks, level, isMobileExpanded ? "tpr-side-nav__list--expanded" : null);
     }
 </nav>
 @{
-    void RenderNavListLayer(List<TprSideNavigationLink> navigationLinks, int level)
+    async Task RenderNavListLayer(List<TprSideNavigationLink> navigationLinks, int level, string? listClass)
     {
-        <ul class="tpr-side-nav__list" data-level="@level">
+        <ul class="tpr-side-nav__list @listClass" id="@(id)__list" data-level="@level">
             @foreach (var child in navigationLinks)
             {
-                <li @(child.IsCurrentPage && !child.IsExpanded ? "class=tpr-side-nav__list-item--active" : string.Empty) @(child.IsExpanded && !child.IsCurrentPage ? "class=tpr-side-nav__list-item--expanded" : string.Empty) @Html.Raw(child.IsCurrentPage && child.IsExpanded ? "class='tpr-side-nav__list-item--active tpr-side-nav__list-item--expanded'" : string.Empty)>
+                var childId = $"{id}-{Guid.NewGuid().ToString().Substring(0, 8)}";
+                <li id="@childId" @(child.IsCurrentPage && !child.IsExpanded ? "class=tpr-side-nav__list-item--active" : string.Empty) @(child.IsExpanded && !child.IsCurrentPage ? "class=tpr-side-nav__list-item--expanded" : string.Empty) @Html.Raw(child.IsCurrentPage && child.IsExpanded ? "class='tpr-side-nav__list-item--active tpr-side-nav__list-item--expanded'" : string.Empty)>
                     <div class="tpr-side-nav__list-item-wrapper">
-                        <a class="govuk-link--no-visited-state" @(child.IsCurrentPage ? "aria-current=page" : string.Empty) href="@child.Url">@child.Name</a>
+                        <a class="govuk-link govuk-link--no-visited-state" @(child.IsCurrentPage ? "aria-current=page" : string.Empty) href="@child.Url">@child.Name</a>
                         @if (child.Children is not null && child.Children.Any())
                         {
-                            <button type="button" class="tpr-side-nav__list-item__expand-toggle" aria-expanded="@child.IsExpanded">
-                                <img alt="tpr-arrow-image" class="tpr-side-nav__list-item__arrow @(child.IsExpanded ? "tpr-side-nav__arrow--up" : "")" />
-                            </button>
+                            var arrowNoJsAlternative = string.Format(child.IsExpanded ? Model.ExpandedItemLabel : Model.CollapsedItemLabel, child.Name);
+                            var arrowClass = child.IsExpanded ? "tpr-side-nav__list-item-arrow tpr-side-nav__list-item-arrow--up" : "tpr-side-nav__list-item-arrow";
+                            <img src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-arrow-down.svg" width="25" height="25" alt="@arrowNoJsAlternative" class="@arrowClass" />
                         }
                     </div>
                     @if (child.Children is not null && child.Children.Any())
                     {
-                        RenderNavListLayer(child.Children, ++level);
+                        await RenderNavListLayer(child.Children, ++level, null);
                     }
                 </li>
             }

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-side-navigation.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-side-navigation.js
@@ -1,62 +1,100 @@
 ﻿
 document.addEventListener("DOMContentLoaded", function () {
-    var buttonToggle = document.getElementsByClassName("tpr-side-nav__mobile-expand-toggle");
-    if (buttonToggle.length === 0) {
+    var sideNav = document.querySelector(".tpr-side-nav");
+    if (!sideNav) {
         return;
     }
-    // mobile menu expand/collapse handling
-    buttonToggle[0].addEventListener("click", expandOrCollapseMobileNav);
+
+    const id = sideNav.getAttribute("id") || "tpr-side-nav";
+    const expand = sideNav.getAttribute("data-expand-text") || "Expand {0}";
+    const collapse = sideNav.getAttribute("data-collapse-text") || "Collapse {0}";
+
+    var noJsMobileLink = document.getElementsByClassName("tpr-side-nav__mobile-expand-toggle");
+
+    const mobileToggle = document.createElement("button");
+    mobileToggle.type = "button";
+    mobileToggle.classList.add("govuk-link");
+    mobileToggle.classList.add("govuk-link--no-visited-state");
+    mobileToggle.classList.add("tpr-side-nav__mobile-expand-toggle");
+    mobileToggle.setAttribute("aria-expanded", "false");
+    mobileToggle.setAttribute("aria-controls", id + "__list");
+    while (noJsMobileLink[0].firstChild) {
+        mobileToggle.appendChild(noJsMobileLink[0].firstChild);
+    }
+    mobileToggle.addEventListener("click", expandOrCollapseMobileNav);
+    noJsMobileLink[0].parentNode.replaceChild(mobileToggle, noJsMobileLink[0]);
+
    
     // list item expand/collapse handling
-    var sideNavListItemToggle = document.getElementsByClassName("tpr-side-nav__list-item__expand-toggle");
-    for (var i = 0; i < sideNavListItemToggle.length; i++) {
-        sideNavListItemToggle[i].addEventListener("click", expandOrCollapseListItem);
+    var sideNavListItemToggles = document.getElementsByClassName("tpr-side-nav__list-item-arrow");
+    for (var i = 0; i < sideNavListItemToggles.length; i++) {
+        const img = sideNavListItemToggles[i];
+        const isExpanded = img.classList.contains("tpr-side-nav__list-item-arrow--up");
+        img.setAttribute("alt", (isExpanded ? collapse : expand).replace("{0}", img.closest(".tpr-side-nav__list-item-wrapper").querySelector("a").textContent.trim()));
+        const itemToggle = document.createElement("button");
+        itemToggle.type = "button";
+        itemToggle.setAttribute("aria-controls", img.closest("li").id);
+        itemToggle.classList.add("tpr-side-nav__list-item__expand-toggle");
+        itemToggle.setAttribute("aria-expanded", isExpanded);
+        itemToggle.addEventListener("click", expandOrCollapseListItem);
+        img.parentNode.insertBefore(itemToggle, img);
+        itemToggle.appendChild(img);
     }
-});
-function expandOrCollapseMobileNav() {
-    let firstLevelNav = this.closest("nav").querySelector("ul");
-    if (firstLevelNav.style.display == 'block') {
-        firstLevelNav.style.display = 'none';
-        this.querySelector("img").classList.remove("tpr-side-nav__arrow--up");
-    }
-    else {
-        firstLevelNav.style.display = 'block';
-        this.querySelector("img").classList.add("tpr-side-nav__arrow--up");
-    }
-}
-function expandOrCollapseListItem(e) {
-    var el = this.firstElementChild;
-    if (el.classList.contains("tpr-side-nav__arrow--up")) {
-        collapseListItem(el);
-    }
-    else {
-        expandListItem(el);
-    }
-}
-function expandListItem(liArrow) {
-    //check for open branches outside this path and close them first
-    clearExpandedBranches(liArrow);
-    liArrow.classList.add("tpr-side-nav__arrow--up");
-    liArrow.closest("li").classList.add("tpr-side-nav__list-item--expanded");
-    
-}
-function collapseListItem(liArrow) {
-    liArrow.classList.remove("tpr-side-nav__arrow--up");
-    liArrow.closest("li").classList.remove("tpr-side-nav__list-item--expanded");
-}
-function clearExpandedBranches(el) {
-    if (el.closest("li").classList.contains("tpr-side-nav__list-item--expanded")) {
-        return;
-    }
-    let parent = el.closest("ul");
-    if (parent.dataset.level > 1 && parent.closest("li").classList.contains("tpr-side-nav__list-item--expanded")) {
-        return;
-    }
-    for(let node of el.closest("ul[data-level='1']").children){
-        node.classList.remove("tpr-side-nav__list-item--expanded");
-        let nodeArrow = node.querySelector("img.tpr-side-nav__list-item__arrow");
-        if (nodeArrow != null) {
-            nodeArrow.classList.remove("tpr-side-nav__arrow--up");
+
+    function expandOrCollapseMobileNav() {
+        let button = this.closest("button");
+        let firstLevelNav = button.closest("nav").querySelector("ul");
+        if (firstLevelNav.classList.contains("tpr-side-nav__list--expanded")) {
+            firstLevelNav.classList.remove("tpr-side-nav__list--expanded");
+            const img = button.querySelector("img");
+            img.classList.remove("tpr-side-nav__list-item-arrow--up");
+            img.setAttribute("alt", expand.replace("{0}", ""));
+            button.setAttribute("aria-expanded", "false");
+        }
+        else {
+            firstLevelNav.classList.add("tpr-side-nav__list--expanded");
+            const img = button.querySelector("img");
+            img.classList.add("tpr-side-nav__list-item-arrow--up");
+            img.setAttribute("alt", collapse.replace("{0}", ""));
+            button.setAttribute("aria-expanded", "true");
         }
     }
-}
+    function expandOrCollapseListItem(e) {
+        const button = e.target.closest("button");
+        if (button.getAttribute("aria-expanded") === "true") {
+            collapseListItem(button);
+        }
+        else {
+            expandListItem(button);
+        }
+    }
+    function expandListItem(button) {
+        //check for open branches outside this path and close them first
+        clearExpandedBranches(button);
+        button.setAttribute("aria-expanded", "true");
+        button.firstElementChild.classList.add("tpr-side-nav__list-item-arrow--up");
+        button.closest("li").classList.add("tpr-side-nav__list-item--expanded");
+    }
+
+    function collapseListItem(button) {
+        button.setAttribute("aria-expanded", "false");
+        button.firstElementChild.classList.remove("tpr-side-nav__list-item-arrow--up");
+        button.closest("li").classList.remove("tpr-side-nav__list-item--expanded");
+    }
+    function clearExpandedBranches(el) {
+        if (el.closest("li").classList.contains("tpr-side-nav__list-item--expanded")) {
+            return;
+        }
+        let parent = el.closest("ul");
+        if (parent.dataset.level > 1 && parent.closest("li").classList.contains("tpr-side-nav__list-item--expanded")) {
+            return;
+        }
+        for(let node of el.closest("ul[data-level='1']").children){
+            node.classList.remove("tpr-side-nav__list-item--expanded");
+            const toggle = node.querySelector(".tpr-side-nav__list-item__expand-toggle");
+            if (toggle) { toggle.setAttribute("aria-expanded", "false"); }
+            let nodeArrow = node.querySelector(".tpr-side-nav__list-item-arrow");
+            if (nodeArrow) { nodeArrow.classList.remove("tpr-side-nav__list-item-arrow--up"); }
+        }
+    }
+});


### PR DESCRIPTION
The side nav component has number of accessibility issues, which are fixed in this PR:

- a link (actually a button) is shown in mobile view with no JS, but it doesn't do anything
- arrow images have unhelpful alternative text like `tpr-arrow-image`
- `aria-controls` is not set
- `aria-expanded` is not set after initial load
- when expanding or collapsing a menu, there is no audible feedback of any change in NVDA

To fix these issues:

- The default mobile view for no JS is now a link with a query string parameter. If the link is followed the page is re-rendered with the menu expanded. JS converts the link to a button to retain previous JS behaviour.
- Arrow images now have alternative text that explains whether an item is expanded (no JS) or whether the arrow will expand or collapse it (with JS)
- `aria-controls` is set, with ids added to elements to make that possible
- `aria-expanded` is set, resulting in audible feedback of changes by NVDA

In addition this PR also fixes:

- the mobile toggle button is displayed in Arial (now changed to Open Sans)
- none of the links have the correct `.govuk-link` class (now fixed)

Fixes #576

## Out of scope

There are also issues with localisation and lack of JS test coverage, but this PR is focussed on accessibility.