### PR TITLE
Flag package rename #535

### DIFF
--- a/ThePensionsRegulator.Umbraco/NuGetReadme.md
+++ b/ThePensionsRegulator.Umbraco/NuGetReadme.md
@@ -1,5 +1,8 @@
 # ThePensionsRegulator.Umbraco
 
+> **WARNING**:
+> From v10.0.0 this package will be renamed to `ThePensionsRegulator.Umbraco.Core`
+
 Features for building applications in Umbraco, including filtering blocks and overriding property values in block lists.
 
 See the [documentation on Github](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions) for further details.


### PR DESCRIPTION
As part of the v17 upgrade I would like to rename `ThePensionsRegulator.Umbraco` to `ThePensionsRegulator.Umbraco.Core` as we have a lot of similarly-named projects and this would make the purpose of this one a little clearer, using the `.Core` convention that is common in the .NET world.

This PR just updates the NuGet readme so that, once that change is made, nuget.org will have a pointer to newer versions of the package.