### PR TITLE
Refactor footer code as ThePensionsRegulator.Frontend cannot depend on Umbraco

### DIFF
--- a/ThePensionsRegulator.Frontend.Umbraco/Models/UmbracoTprFooterLockupModel.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Models/UmbracoTprFooterLockupModel.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using GovUk.Frontend.Umbraco;
+using System;
 using System.Collections.Generic;
-using ThePensionsRegulator.Frontend.HtmlGeneration;
+using System.Linq;
 using ThePensionsRegulator.Frontend.Models;
 using ThePensionsRegulator.Umbraco.Blocks;
 using Umbraco.Cms.Core.Models;
@@ -17,11 +18,41 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Models
         public UmbracoTprFooterLockupModel(IPublishedContent settings)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+            ThreeColumnLinks = InitializeThreeColumnLinks();
         }
+
+        private IEnumerable<IEnumerable<TprFooterLink>> InitializeThreeColumnLinks()
+        {
+            var columns = new List<IEnumerable<TprFooterLink>>();
+            var columnBlock = _settings?.Value<OverridableBlockGridModel>(TprPropertyAliases.FooterLinks)?.FirstOrDefault(i => i.Content.ContentType.Alias == ElementTypeAliases.GridThreeEqualColumns);
+            if (columnBlock is null) { return columns; }
+
+            foreach (var links in columnBlock.Areas)
+            {
+                var column = new List<TprFooterLink>();
+                foreach (var link in links)
+                {
+                    var url = link.Content.Value<Link>("link")?.Url;
+                    var text = link.Content.Value<string>("text");
+
+                    if (!string.IsNullOrEmpty(url) && !string.IsNullOrWhiteSpace(text))
+                    {
+                        column.Add(new TprFooterLink
+                        {
+                            Url = url,
+                            Name = text
+                        });
+                    }
+                }
+                if (column.Any()) { columns.Add(column); }
+            }
+            return columns;
+        }
+
         public override string BackToTopText => string.IsNullOrEmpty(_settings.Value<string>("tprBackToTopText")) ? "Back to top" : _settings.Value<string>("tprBackToTopText")!;
         public override string? LogoAlternativeText => _settings.Value<string>("tprFooterLogoAlt");
         public override string? LogoHref => _settings.Value<Link>("tprFooterLogoHref")?.Url;
-        public override OverridableBlockGridModel? ThreeColumnLinks => _settings?.Value<OverridableBlockGridModel>("tprFooterThreeColumnLinks");
         public override string? Copyright => _settings.Value<string?>("tprFooterCopyright")?.Replace("{{year}}", DateTimeOffset.UtcNow.Year.ToString());
         public override string? FooterBarContent => _settings.Value<IHtmlEncodedString>("tprFooterContent")?.ToHtmlString();
     }

--- a/ThePensionsRegulator.Frontend.Umbraco/TprPropertyAliases.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/TprPropertyAliases.cs
@@ -15,6 +15,11 @@
         public const string DocumentNumberOfPages = "numberOfPages";
         public const string DocumentTitle = "documentTitle";
         public const string DocumentsBlockList = "documents";
+        public const string FooterContent = "tprFooterContent";
+        public const string FooterCopyright = "tprFooterCopyright";
+        public const string FooterLogoAltText = "tprFooterLogoAlt";
+        public const string FooterLogoHref = "tprFooterLogoHref";
+        public const string FooterLinks = "tprFooterThreeColumnLinks";
         public const string HeaderMenuAriaLabel = "tprHeaderMenuAriaLabel";
         public const string HeaderMenuItemAriaLabel = "tprHeaderMenuItemAriaLabel";
         public const string HeaderMenuLinkText = "linkText";
@@ -24,7 +29,7 @@
         public const string HeaderMenuToggleClosedText = "tprHeaderMenuToggleClosedText";
         public const string HeaderMenuToggleOpenText = "tprHeaderMenuToggleOpenText";
         public const string HeaderSearchAriaLabel = "tprHeaderAriaLabelText";
-        public const string HeaderSearchPlaceholderText = "tprHeaderSearchPlaceholderText";     
+        public const string HeaderSearchPlaceholderText = "tprHeaderSearchPlaceholderText";
         public const string ImageAltText = "altText";
         public const string ImageDecorative = "decorativeImage";
         public const string ImageSize = "imageSize";

--- a/ThePensionsRegulator.Frontend/Models/TprFooterLink.cs
+++ b/ThePensionsRegulator.Frontend/Models/TprFooterLink.cs
@@ -1,0 +1,8 @@
+﻿namespace ThePensionsRegulator.Frontend.Models
+{
+    public class TprFooterLink
+    {
+        public required string Name { get; set; }
+        public required string Url { get; set; }
+    }
+}

--- a/ThePensionsRegulator.Frontend/Models/TprFooterLockupModel.cs
+++ b/ThePensionsRegulator.Frontend/Models/TprFooterLockupModel.cs
@@ -1,5 +1,5 @@
-﻿using ThePensionsRegulator.Frontend.HtmlGeneration;
-using ThePensionsRegulator.Umbraco.Blocks;
+﻿using System.Collections.Generic;
+using ThePensionsRegulator.Frontend.HtmlGeneration;
 
 namespace ThePensionsRegulator.Frontend.Models
 {
@@ -13,7 +13,7 @@ namespace ThePensionsRegulator.Frontend.Models
         public virtual string? LanguageCode { get; init; }
         public virtual string? LogoAlternativeText { get; init; } = ComponentGenerator.FooterLogoDefaultAlt;
         public virtual string? LogoHref { get; init; } = ComponentGenerator.FooterLogoDefaultHref;
-        public virtual OverridableBlockGridModel? ThreeColumnLinks { get; init; }
+        public virtual IEnumerable<IEnumerable<TprFooterLink>> ThreeColumnLinks { get; init; } = [];
         public virtual string? Copyright { get; init; }
         public virtual string? FooterBarContent { get; init; }
     }

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -289,7 +289,6 @@
 	
 	<ItemGroup>
 	  <ProjectReference Include="..\GovUk.Frontend.AspNetCore.Extensions\GovUk.Frontend.AspNetCore.Extensions.csproj" />
-	  <ProjectReference Include="..\ThePensionsRegulator.Umbraco\ThePensionsRegulator.Umbraco.csproj" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRFooterLockup.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRFooterLockup.cshtml
@@ -1,7 +1,6 @@
 ﻿@using System.Globalization
 @using ThePensionsRegulator.Frontend.HtmlGeneration;
 @using ThePensionsRegulator.Frontend.Models;
-@using Umbraco.Cms.Core.Models
 @model TprFooterLockupModel
 @addTagHelper *, ThePensionsRegulator.Frontend
 @{
@@ -10,7 +9,6 @@
     var languageCode = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
     var footerLogoAlt = Model.LogoAlternativeText;
     if (string.IsNullOrEmpty(footerLogoAlt) && !string.IsNullOrEmpty(Model.LogoHref)) { footerLogoAlt = ComponentGenerator.FooterLogoDefaultAlt; }
-    var threeColumnLinks = @Model.ThreeColumnLinks;
 }
 @if (Model.ShowBackToTop)
 {
@@ -21,25 +19,16 @@
     <tpr-footer-bar class="@Model.FooterBarClass" lang="@languageCode">
         <tpr-footer-bar-logo alt="@footerLogoAlt" href="@Model.LogoHref" />
 
-        @if (@Model.ThreeColumnLinks != null)
+        @if (Model.ThreeColumnLinks is not null)
         {
-            var column = threeColumnLinks?.Where(i => i.Content.ContentType.Alias == "govukGridThreeEqualColumns");
-            @if (column != null)
+            foreach (var column in Model.ThreeColumnLinks)
             {
-                @foreach (var item in column)
+                <tpr-footer-bar-three-column-links>
+                @foreach (var link in column)
                 {
-                    foreach (var links in item.Areas)
-                    {
-                        <tpr-footer-bar-three-column-links>
-                            @foreach (var link in links)
-                            {
-                                var linkUrl = link.Content.Value<Link>("link");
-                                var linkText = link.Content.Value<string>("text");
-                                <tpr-footer-bar-three-column-link href="@linkUrl?.Url" link-text="@linkText"></tpr-footer-bar-three-column-link>
-                            }
-                        </tpr-footer-bar-three-column-links>
-                    }
+                    <tpr-footer-bar-three-column-link href="@link.Url" link-text="@link.Name" />
                 }
+                </tpr-footer-bar-three-column-links>
             }
         }
         <tpr-footer-bar-copyright>@Model.Copyright</tpr-footer-bar-copyright>


### PR DESCRIPTION
A recent change has added a reference from `ThePensionsRegulator.Frontend` to `ThePensionsRegulator.Umbraco`, and therefore a dependency on Umbraco itself.

`ThePensionsRegulator.Frontend` has the implementation of our TPR design system for non-Umbraco apps, so it _cannot_ depend upon Umbraco. This dependency needs to be removed.

This PR moves the code that used the reference out of the view and into an initializer for the Umbraco version of the footer model.

Fixes #581