### PR TITLE
Fix insufficient contrast on file upload when hovering over a focused or active component (.NET 8)

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-file-upload.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-file-upload.scss
@@ -17,6 +17,12 @@ $button-shadow-size: $govuk-border-width-form-element;
     background: $tpr-colour-white;
 }
 
+
+.govuk-file-upload-button:active:hover .govuk-file-upload-button__pseudo-button,
+.govuk-file-upload-button:focus:hover .govuk-file-upload-button__pseudo-button {
+    color: $tpr-colour-eclipse;
+}
+
 .govuk-file-upload:focus-within::file-selector-button,
 .govuk-file-upload:focus::file-selector-button,
 .govuk-file-upload-button:focus .govuk-file-upload-button__pseudo-button {
@@ -38,3 +44,4 @@ $button-shadow-size: $govuk-border-width-form-element;
     color: $govuk-button-text-colour;
     background-color: $tpr-colour-royal-blue;
 }
+


### PR DESCRIPTION
Fixes #591 for .NET 8 packages.

Before:

<img width="574" height="546" alt="image" src="https://github.com/user-attachments/assets/42b7dfa2-f629-4749-8850-8412eee11b8e" />

After:

<img width="597" height="635" alt="image" src="https://github.com/user-attachments/assets/6b8a253c-038b-4a6b-81d7-f8caae9fb640" />