### PR TITLE
Refactor GOV.UK backoffice views

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKBlockGrid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKBlockGrid.config
@@ -420,7 +420,7 @@
       "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
       "view": "~/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html",
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
-      "label": "{{label}} (Select)",
+      "label": "",
       "editorSize": "medium",
       "inlineEditing": false,
       "forceHideContentEditorInOverlay": false,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKBlockList.config
@@ -213,7 +213,7 @@
       "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
       "view": "~/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html",
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
-      "label": "{{label}} (Select)",
+      "label": "",
       "editorSize": "medium",
       "forceHideContentEditorInOverlay": false
     },

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKFieldsetBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKFieldsetBlockList.config
@@ -137,7 +137,7 @@
       "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
       "view": "~/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html",
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
-      "label": "{{label}} (Select)",
+      "label": "",
       "editorSize": "medium",
       "forceHideContentEditorInOverlay": false
     },

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKGridColumnBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKGridColumnBlockList.config
@@ -161,7 +161,7 @@
       "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
       "view": "~/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html",
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
-      "label": "{{label}} (Select)",
+      "label": "",
       "editorSize": "medium",
       "forceHideContentEditorInOverlay": false
     },

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKGridRowBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/GOVUKGridRowBlockList.config
@@ -168,7 +168,7 @@
       "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
       "view": "~/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html",
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
-      "label": "{{label}} (Select)",
+      "label": "",
       "editorSize": "medium",
       "forceHideContentEditorInOverlay": false
     },

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBlockGrid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBlockGrid.config
@@ -437,7 +437,7 @@
       "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
       "view": "~/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html",
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
-      "label": "{{label}} (Select)",
+      "label": "",
       "editorSize": "medium",
       "inlineEditing": false,
       "forceHideContentEditorInOverlay": false,

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBlockList.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBlockList.config
@@ -221,7 +221,7 @@
       "settingsElementTypeKey": "b4bca409-19d8-460d-9155-6b84fc90e820",
       "view": "~/App_Plugins/GOVUK/blocks/views/GovUkSelectPreview.html",
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
-      "label": "{{label}} (Select)",
+      "label": "",
       "editorSize": "medium",
       "forceHideContentEditorInOverlay": false
     },

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/accordion-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/accordion-helper.ts
@@ -1,7 +1,7 @@
 ﻿import { html, TemplateResult } from '@umbraco-cms/backoffice/external/lit';
-import { IBlockListItem } from '../interfaces/IBlockListItem';
+import { UmbBlockDataModel } from '@umbraco-cms/backoffice/block';
 
-export function renderAccordionSection(heading: string | undefined, summary: string | undefined, blocks: Array<IBlockListItem> | null | undefined = []): TemplateResult {
+export function renderAccordionSection(heading: string | undefined, summary: string | undefined, blocks: Array<UmbBlockDataModel> | null | undefined = []): TemplateResult {
         let blocksText = "No blocks.";    
         if (blocks?.length === 1) { blocksText = "1 block." }
         if ((blocks?.length || 0) > 1) { blocksText = `${blocks?.length} blocks.` }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/checkboxes-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/checkboxes-helper.ts
@@ -1,5 +1,5 @@
 ﻿import { html, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
-import { IBlockListItem } from "../interfaces/IBlockListItem";
+import { UmbBlockDataModel } from "@umbraco-cms/backoffice/block";
 import { disableLinks } from '../helpers/html-helper';
 
 export function renderCheckboxesDivider(text:string | undefined): TemplateResult {
@@ -10,7 +10,7 @@ export function renderCheckbox(
     label: string | undefined,
     value: string | undefined,
     hintHtml: string | undefined,
-    conditionalBlocks: Array<IBlockListItem> | null | undefined = []
+    conditionalBlocks: Array<UmbBlockDataModel> | null | undefined = []
 ): TemplateResult {
 
     let conditionalBlocksText = "No conditional blocks.";

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/checkboxes-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/checkboxes-helper.ts
@@ -1,5 +1,6 @@
 ﻿import { html, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { IBlockListItem } from "../interfaces/IBlockListItem";
+import { disableLinks } from '../helpers/html-helper';
 
 export function renderCheckboxesDivider(text:string | undefined): TemplateResult {
     return html`<div class="govuk-checkboxes__divider">${text || 'or'}</div>`;
@@ -8,7 +9,7 @@ export function renderCheckboxesDivider(text:string | undefined): TemplateResult
 export function renderCheckbox(
     label: string | undefined,
     value: string | undefined,
-    hint: string | undefined,
+    hintHtml: string | undefined,
     conditionalBlocks: Array<IBlockListItem> | null | undefined = []
 ): TemplateResult {
 
@@ -19,7 +20,7 @@ export function renderCheckbox(
     return html`<div class="govuk-checkboxes__item">
                     <input class="govuk-checkboxes__input" type="checkbox" value="${value}">
                     <label class="govuk-checkboxes__label govuk-label">${label}</label>
-                    ${hint ? html`<div class="govuk-checkboxes__hint govuk-hint">${unsafeHTML(hint)}</div>` : null}
+                    ${hintHtml ? html`<div class="govuk-checkboxes__hint govuk-hint">${unsafeHTML(disableLinks(hintHtml))}</div>` : null}
                 </div>
                 <div class="govuk-checkboxes__conditional">
                     <div class="govuk-form-group">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/html-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/html-helper.ts
@@ -1,0 +1,24 @@
+export function disableLinks(html: string | undefined): string | undefined {
+    if (!html) return html;
+
+    // Replace <a ...href="...">...</a> with <span class="govuk-link" ...>...</span> (removes href and changes tag)
+    // so that links in backoffice previews are not clickable but still styled as links.
+    return html
+        .replace(
+            /<a\b([^>]*)\bhref\s*=\s*(['"])[^'"]*\2([^>]*)>/gi,
+            (_match, preAttrs, _quote, postAttrs) => {
+                // Ensure class="govuk-link" is present
+                let attrs = `${preAttrs}${postAttrs}`;
+                if (/class\s*=/.test(attrs)) {
+                    // Add govuk-link to existing class attribute
+                    attrs = attrs.replace(/class\s*=\s*(['"])([^'"]*)\1/, (_match, quote, classes) =>
+                        `class=${quote}${classes} govuk-link${quote}`
+                    );
+                } else {
+                    attrs += ' class="govuk-link"';
+                }
+                return `<span${attrs}>`;
+            }
+        )
+        .replace(/<\/a>/gi, '</span>');
+}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/radios-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/radios-helper.ts
@@ -1,5 +1,6 @@
 ﻿import { html, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { IBlockListItem } from "../interfaces/IBlockListItem";
+import { disableLinks } from '../helpers/html-helper';
 
 export function renderRadiosDivider(text:string | undefined): TemplateResult {
     return html`<div class="govuk-radios__divider">${text || 'or'}</div>`;
@@ -20,7 +21,7 @@ export function renderRadioButton(
     return html`<div class="govuk-radios__item">
                     <input class="govuk-radios__input" type="radio" value="${value}">
                     <label class="govuk-radios__label govuk-label">${label}</label>
-                    ${hintHtml ? html`<div class="govuk-radios__hint govuk-hint">${unsafeHTML(hintHtml)}</div>` : null}
+                    ${hintHtml ? html`<div class="govuk-radios__hint govuk-hint">${unsafeHTML(disableLinks(hintHtml))}</div>` : null}
                 </div>
                 ${renderConditionalBlocks ? html`<div class="govuk-radios__conditional">
                     <div class="govuk-form-group">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/radios-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/radios-helper.ts
@@ -1,5 +1,5 @@
 ﻿import { html, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
-import { IBlockListItem } from "../interfaces/IBlockListItem";
+import { UmbBlockDataModel } from "@umbraco-cms/backoffice/block";
 import { disableLinks } from '../helpers/html-helper';
 
 export function renderRadiosDivider(text:string | undefined): TemplateResult {
@@ -10,7 +10,7 @@ export function renderRadioButton(
     label: string | undefined,
     value: string | undefined,
     hintHtml: string | undefined,
-    conditionalBlocks: Array<IBlockListItem> | null | undefined = [],
+    conditionalBlocks: Array<UmbBlockDataModel> | null | undefined = [],
     renderConditionalBlocks: boolean,
 ): TemplateResult {
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/summary-list-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/summary-list-helper.ts
@@ -1,22 +1,23 @@
 ﻿import { html, repeat, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
-import { IBlockListItem } from '../interfaces/IBlockListItem';
+import { UmbBlockDataModel, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
-export function renderSummaryList(listItems: Array<IBlockListItem> | [], cssClasses: string | undefined = undefined): TemplateResult {
+export function renderSummaryList(listItems: Array<UmbBlockDataModel> | [], cssClasses: string | undefined = undefined): TemplateResult {
         return html`
             <dl class="govuk-summary-list ${cssClasses}">
                 ${repeat(listItems || [],
                     (block) => block.key,
                     (block) => {
-                        const itemKey = block.values.find(props => props.alias == "itemKey")?.value;
-                        const itemValue = block.values.find(props => props.alias == "itemValue")?.value?.markup;
-                        const actions = block.values.find(props => props.alias == "actions")?.value?.contentData;
+                        const itemKey = (block.values.find(props => props.alias == "itemKey")?.value as string)?.toString();
+                        const itemValue = (block.values.find(props => props.alias == "itemValue")?.value as UmbPropertyEditorRteValueType)?.markup;
+                        const actions = (block.values.find(props => props.alias == "actions")?.value as UmbBlockValueDataPropertiesBaseType)?.contentData;
                         return renderSummaryListItem(itemKey, itemValue, actions);
                     })}
             </dl>`;
 }
 
-export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml: string | undefined, actions: Array<IBlockListItem> | null | undefined):  TemplateResult {
+export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml: string | undefined, actions: Array<UmbBlockDataModel> | null | undefined):  TemplateResult {
     return html`
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">${itemKey}</dt>
@@ -25,10 +26,13 @@ export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml
                 <dd class="govuk-summary-list__actions">
                     <ul class="govuk-summary-list__actions-list">
                     ${repeat(actions || [],
-                        (action: IBlockListItem) => action.key,
-                        (action: IBlockListItem) => html`<li class="govuk-summary-list__actions-list-item">
-                            ${renderSummaryListAction(action.values.find(props => props.alias == "text")?.value)}
-                        </li>`
+                        (action: UmbBlockDataModel) => action.key,
+                        (action: UmbBlockDataModel) => {
+                            const text = (action.values.find(props => props.alias == "text")?.value as string);
+                            return html`<li class="govuk-summary-list__actions-list-item">
+                                ${renderSummaryListAction(text)}
+                                </li>`
+                            }
                     )}
                     </ul>
                 </dd>` : null}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/summary-list-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/summary-list-helper.ts
@@ -1,5 +1,6 @@
 ﻿import { html, repeat, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { IBlockListItem } from '../interfaces/IBlockListItem';
+import { disableLinks } from '../helpers/html-helper';
 
 export function renderSummaryList(listItems: Array<IBlockListItem> | [], cssClasses: string | undefined = undefined): TemplateResult {
         return html`
@@ -19,7 +20,7 @@ export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml
     return html`
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">${itemKey}</dt>
-            <dd class="govuk-summary-list__value">${unsafeHTML(itemValueHtml || '')}</dd>
+            <dd class="govuk-summary-list__value">${unsafeHTML(disableLinks(itemValueHtml) || '')}</dd>
             ${actions ? html`
                 <dd class="govuk-summary-list__actions">
                     <ul class="govuk-summary-list__actions-list">
@@ -35,5 +36,5 @@ export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml
 }
 
 export function renderSummaryListAction(text: string | undefined): TemplateResult {
-    return  html`<a class="govuk-link" href="javascript:return false">${text}</a>`;
+    return  html`<span class="govuk-link">${text}</span>`;
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/task-list-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/task-list-helper.ts
@@ -1,4 +1,5 @@
 ﻿import { html, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
+import { disableLinks } from '../helpers/html-helper';
 
 function toKebabCase(str: string): string {
     return "govuk-task-list__status--" + str
@@ -18,7 +19,7 @@ export function renderTask(
     const children = html`
         <div class="govuk-task-list__name-and-hint">
             <span class="govuk-task-list__link govuk-link" href="javascript:return false">${taskName}</span>
-            ${hintHtml ? html`<div class="govuk-task-list__hint">${unsafeHTML(hintHtml)}</div>` : null}
+            ${hintHtml ? html`<div class="govuk-task-list__hint">${unsafeHTML(disableLinks(hintHtml))}</div>` : null}
         </div>
         ${status ? html`<div class="govuk-task-list__status ${toKebabCase(String(status))}">
             <strong class="govuk-tag">${status}</strong>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IBlockListItem.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IBlockListItem.ts
@@ -1,7 +1,0 @@
-import { IUmbracoProperty } from "./IUmbracoProperty";
-
-export interface IBlockListItem {
-    key: string;
-    contentTypeKey: string;
-    values: Array<IUmbracoProperty>;
-}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IBlockListProperty.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IBlockListProperty.ts
@@ -1,6 +1,0 @@
-import { IBlockListItem } from "./IBlockListItem";
-
-export interface IBlockListProperty {
-    contentData: Array<IBlockListItem>;
-    settingsData: Array<IBlockListItem>;
-}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IRichTextProperty.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IRichTextProperty.ts
@@ -1,3 +1,0 @@
-export interface IRichTextProperty {
-    markup: string;
-}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IUmbracoProperty.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/interfaces/IUmbracoProperty.ts
@@ -1,5 +1,0 @@
-export interface IUmbracoProperty {
-    editorAlias: string;
-    alias: string;
-    value: any;
-}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 import { renderAccordionSection } from '../helpers/accordion-helper';
@@ -25,12 +25,15 @@ export class GovUkAccordionSectionView extends UmbElementMixin(LitElement) imple
     @property({ attribute: false })
     settings?: IGovUkAccordionSectionSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ renderAccordionSection(this.content?.heading, this.content?.summary, this?.content?.blocks?.contentData) }
-        </div>`;
+        </a>`;
     }
 }
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
@@ -1,14 +1,13 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
 import { renderAccordionSection } from '../helpers/accordion-helper';
 
 interface IGovUkAccordionSectionContent extends UmbBlockDataType {
     heading: string;
     summary: string;
-    blocks: IBlockListProperty | null;
+    blocks: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkAccordionSectionSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
@@ -1,13 +1,11 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
-import { IBlockListItem } from '../interfaces/IBlockListItem';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType, UmbBlockDataModel } from '@umbraco-cms/backoffice/block';
 import { renderAccordionSection } from '../helpers/accordion-helper';
 
 interface IGovUkAccordionContent extends UmbBlockDataType {
-    sections: IBlockListProperty | null;
+    sections: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkAccordionSettings extends UmbBlockDataType {
@@ -34,11 +32,11 @@ export class GovUkAccordionView extends UmbElementMixin(LitElement) implements U
             ${ this.content?.sections?.contentData ? html`
                 <div class="govuk-accordion">
                     ${repeat(this.content.sections.contentData,
-                        (section: IBlockListItem) => section.key,
-                        (section: IBlockListItem) => {
-                            const heading = section?.values.find(props => props.alias == "heading")?.value;
-                            const summary = section?.values.find(props => props.alias == "summary")?.value;
-                            const blocks = section?.values.find(props => props.alias == "blocks")?.value?.contentData;
+                        (section: UmbBlockDataModel) => section.key,
+                        (section: UmbBlockDataModel) => {
+                            const heading = (section?.values.find(props => props.alias == "heading")?.value as string);
+                            const summary = (section?.values.find(props => props.alias == "summary")?.value as string);
+                            const blocks = (section?.values.find(props => props.alias == "blocks")?.value as UmbBlockValueDataPropertiesBaseType)?.contentData;
                             return renderAccordionSection(heading, summary, blocks);
                         }
                     )}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 import { IBlockListItem } from '../interfaces/IBlockListItem';
@@ -24,10 +24,13 @@ export class GovUkAccordionView extends UmbElementMixin(LitElement) implements U
     @property({ attribute: false })
     settings?: IGovUkAccordionSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.sections?.contentData ? html`
                 <div class="govuk-accordion">
                     ${repeat(this.content.sections.contentData,
@@ -42,7 +45,7 @@ export class GovUkAccordionView extends UmbElementMixin(LitElement) implements U
                 </div>` : 
                 html`<p class="backoffice-additional-blocks">Accordion with no sections.</p>`
             }
-        </div>`;
+        </a>`;
     }
 }
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
@@ -1,11 +1,10 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
 
 interface IGovUkButtonGroupContent extends UmbBlockDataType {
-    buttons: IBlockListProperty | null;
+    buttons: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkButtonGroupSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 
@@ -22,6 +22,9 @@ export class GovUkButtonGroupView extends UmbElementMixin(LitElement) implements
     @property({ attribute: false })
     settings?: IGovUkButtonGroupSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -32,10 +35,10 @@ export class GovUkButtonGroupView extends UmbElementMixin(LitElement) implements
         if ((this.content?.buttons?.contentData?.length || 0) > 1) { blocks = `${this.content?.buttons?.contentData?.length} blocks.` }
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view ${ this.settings?.cssClasses}">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view ${ this.settings?.cssClasses}">
             <h2 class="govuk-heading-s">Button group</h2>
             <p class="backoffice-additional-blocks">${ blocks }</p>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 interface IGovUkButtonContent extends UmbBlockDataType {
     text: string;
@@ -21,6 +21,9 @@ export class GovUkButtonView extends UmbElementMixin(LitElement) implements UmbB
     @property({ attribute: false })
     settings?: IGovUkButtonSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -37,11 +40,11 @@ export class GovUkButtonView extends UmbElementMixin(LitElement) implements UmbB
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="${ blockViewClass }">
                 <button class="govuk-button ${ buttonClass} ${this.settings?.cssClasses}" type="button">${this.content?.text }</button>
             </div>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-caption.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-caption.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 interface IGovUkCaptionContent extends UmbBlockDataType {
     caption: string;
@@ -20,6 +20,9 @@ export class GovUkCaptionView extends UmbElementMixin(LitElement) implements Umb
     @property({ attribute: false })
     settings?: IGovUkCaptionSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -27,7 +30,9 @@ export class GovUkCaptionView extends UmbElementMixin(LitElement) implements Umb
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-caption-l backoffice-block-view ${ this.settings?.cssClasses }">${ this.content?.caption }</div>
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
+            <div class="govuk-caption-l ${ this.settings?.cssClasses}">${this.content?.caption }</div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
@@ -1,9 +1,10 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
 import { IBlockListProperty } from "../interfaces/IBlockListProperty";
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkCheckboxContent extends UmbBlockDataType {
     label: string;
@@ -26,6 +27,9 @@ export class GovUkCheckboxView extends UmbElementMixin(LitElement) implements Um
     @property({ attribute: false })
     settings?: IGovUkCheckboxSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -38,12 +42,12 @@ export class GovUkCheckboxView extends UmbElementMixin(LitElement) implements Um
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-form-group backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <div class="govuk-checkboxes ${ this.settings?.cssClasses}">
                 <div class="govuk-checkboxes__item">
                     <input class="govuk-checkboxes__input" type="checkbox" value="${this.content?.value}" />
                     <label class="govuk-checkboxes__label govuk-label">${this.content?.label}</label>
-                    ${this.content?.hint?.markup ? html`<div class="govuk-checkboxes__hint govuk-hint">${unsafeHTML(this.content?.hint?.markup)}</div>` : null}
+                    ${this.content?.hint?.markup ? html`<div class="govuk-checkboxes__hint govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
                 </div>
                 <div class="govuk-checkboxes__conditional">
                     <div class="govuk-form-group">
@@ -51,7 +55,7 @@ export class GovUkCheckboxView extends UmbElementMixin(LitElement) implements Um
                     </div> 
                 </div>
             </div>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
@@ -1,16 +1,15 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
-import { IBlockListProperty } from "../interfaces/IBlockListProperty";
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkCheckboxContent extends UmbBlockDataType {
     label: string;
     value: string;
-    hint: IRichTextProperty;
-    conditionalBlocks: IBlockListProperty;
+    hint: UmbPropertyEditorRteValueType;
+    conditionalBlocks: UmbBlockValueDataPropertiesBaseType;
 }
 
 interface IGovUkCheckboxSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes-divider.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes-divider.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderCheckboxesDivider } from '../helpers/checkboxes-helper';
 interface IGovUkCheckboxesDividerContent extends UmbBlockDataType {
@@ -13,6 +13,9 @@ export class GovUkCheckboxesDividerView extends UmbElementMixin(LitElement) impl
     @property({ attribute: false })
     content?: IGovUkCheckboxesDividerContent;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -20,9 +23,9 @@ export class GovUkCheckboxesDividerView extends UmbElementMixin(LitElement) impl
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderCheckboxesDivider(this.content?.text) }
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
@@ -1,18 +1,17 @@
 import { html, customElement, LitElement, property, unsafeHTML, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
-import { IBlockListProperty } from "../interfaces/IBlockListProperty";
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderCheckboxesDivider, renderCheckbox } from '../helpers/checkboxes-helper';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkCheckboxesContent extends UmbBlockDataType {
     legend: string;
-    hint: IRichTextProperty;
-    fieldsetBlocks: IBlockListProperty;
-    checkboxes: IBlockListProperty;
+    hint: UmbPropertyEditorRteValueType;
+    fieldsetBlocks: UmbBlockValueDataPropertiesBaseType;
+    checkboxes: UmbBlockValueDataPropertiesBaseType;
 }
 
 interface IGovUkCheckboxesSettings extends UmbBlockDataType {
@@ -71,13 +70,13 @@ export class GovUkCheckboxesView extends UmbElementMixin(LitElement) implements 
                             (checkbox) => {
                                 const govukCheckboxesDivider = "ee99c671-93dc-4d08-9933-e61e50dc234a";
                                 if (checkbox.contentTypeKey === govukCheckboxesDivider) {
-                                    const text = checkbox?.values.find(props => props.alias == "text")?.value;
+                                    const text = (checkbox?.values.find(props => props.alias == "text")?.value as string);
                                     return renderCheckboxesDivider(text);
                                 } else {
-                                    const label = checkbox?.values.find(props => props.alias == "label")?.value;
-                                    const value = checkbox?.values.find(props => props.alias == "value")?.value;
-                                    const hint = checkbox?.values.find(props => props.alias == "hint")?.value;
-                                    const conditionalBlocks = checkbox?.values.find(props => props.alias == "conditionalBlocks")?.value;
+                                    const label = (checkbox?.values.find(props => props.alias == "label")?.value as string);
+                                    const value = (checkbox?.values.find(props => props.alias == "value")?.value as string);
+                                    const hint = (checkbox?.values.find(props => props.alias == "hint")?.value as UmbPropertyEditorRteValueType);
+                                    const conditionalBlocks = (checkbox?.values.find(props => props.alias == "conditionalBlocks")?.value as UmbBlockValueDataPropertiesBaseType);
                                     return renderCheckbox(label, value, hint?.markup, conditionalBlocks?.contentData)
                                 }
                             }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
@@ -1,11 +1,12 @@
 import { html, customElement, LitElement, property, unsafeHTML, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
 import { IBlockListProperty } from "../interfaces/IBlockListProperty";
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderCheckboxesDivider, renderCheckbox } from '../helpers/checkboxes-helper';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkCheckboxesContent extends UmbBlockDataType {
     legend: string;
@@ -27,6 +28,9 @@ export class GovUkCheckboxesView extends UmbElementMixin(LitElement) implements 
 
     @property({ attribute: false })
     settings?: IGovUkCheckboxesSettings;
+
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
 
     @state()
     _nodeName?: string;
@@ -55,12 +59,12 @@ export class GovUkCheckboxesView extends UmbElementMixin(LitElement) implements 
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-form-group backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <fieldset class="govuk-fieldset govuk-checkboxes__fieldset ${ this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend }</legend>
                 <div class="govuk-form-group">
                     <p class="backoffice-additional-blocks">${blocksText}</p>
-                    ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(this.content?.hint?.markup)}</div>` : null}
+                    ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
                     <div class="govuk-checkboxes">
                         ${repeat(this.content?.checkboxes?.contentData || [],
                             (checkbox) => checkbox.key,
@@ -81,7 +85,7 @@ export class GovUkCheckboxesView extends UmbElementMixin(LitElement) implements 
                     </div>
                 </div>
             </fieldset>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
@@ -1,16 +1,15 @@
 import { html, customElement, LitElement, property, unsafeHTML, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
-import { IBlockListProperty } from "../interfaces/IBlockListProperty";
+import { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkDateInputContent extends UmbBlockDataType {
-    fieldsetBlocks: IBlockListProperty;
+    fieldsetBlocks: UmbBlockValueDataPropertiesBaseType;
     legend: string;
-    hint: IRichTextProperty;
+    hint: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkDateInputSettings extends UmbBlockDataType {
@@ -54,7 +53,7 @@ export class GovUkDateInputView extends UmbElementMixin(LitElement) implements U
     override render() {
 
         let blocksText = "No blocks.";
-        if (this.content?.fieldsetBlocks?.contentData.length === 1) { blocksText = "1 block." }
+        if (this.content?.fieldsetBlocks?.contentData?.length === 1) { blocksText = "1 block." }
         if ((this.content?.fieldsetBlocks?.contentData?.length || 0) > 1) { blocksText = `${this.content?.fieldsetBlocks?.contentData.length} blocks.` }
 
         const legend = (this.content?.legend || "").replace("{{name}}", this._nodeName || "");

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
@@ -1,10 +1,11 @@
 import { html, customElement, LitElement, property, unsafeHTML, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
 import { IBlockListProperty } from "../interfaces/IBlockListProperty";
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkDateInputContent extends UmbBlockDataType {
     fieldsetBlocks: IBlockListProperty;
@@ -29,6 +30,9 @@ export class GovUkDateInputView extends UmbElementMixin(LitElement) implements U
 
     @property({ attribute: false })
     settings?: IGovUkDateInputSettings;
+
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
 
     @state()
     _nodeName?: string;
@@ -58,12 +62,12 @@ export class GovUkDateInputView extends UmbElementMixin(LitElement) implements U
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-form-group backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <fieldset class="govuk-fieldset govuk-date-input__fieldset ${ this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend }</legend>
                 <p class="backoffice-additional-blocks">${blocksText}</p>
                 <div class="govuk-form-group">
-                    ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(this.content?.hint?.markup)}</div>` : null}
+                    ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
                     <div class="govuk-date-input">
                         ${this.settings?.showDay !== false ? html`<div class="govuk-date-input__item">
                             <div class="govuk-form-group">
@@ -92,7 +96,7 @@ export class GovUkDateInputView extends UmbElementMixin(LitElement) implements U
                     </div>
                 </div>
             </fieldset>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-details.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-details.ts
@@ -2,12 +2,12 @@ import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkDetailsContent extends UmbBlockDataType {
     summary: string;
-    text: IRichTextProperty;
+    text: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkDetailsSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-details.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-details.ts
@@ -1,8 +1,9 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkDetailsContent extends UmbBlockDataType {
     summary: string;
@@ -23,6 +24,9 @@ export class GovUkDetailsView extends UmbElementMixin(LitElement) implements Umb
     @property({ attribute: false })
     settings?: IGovUkDetailsSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -30,10 +34,12 @@ export class GovUkDetailsView extends UmbElementMixin(LitElement) implements Umb
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <details class="govuk-details backoffice-block-view ${ this.settings?.cssClasses}">
-            <summary class="govuk-details__summary"><span class="govuk-details__summary-text">${ this.content?.summary }</span></summary>
-            ${ unsafeHTML(this.content?.text.markup) }
-        </details>
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
+            <details class="govuk-details ${ this.settings?.cssClasses}">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text">${ this.content?.summary }</span></summary>
+                ${ unsafeHTML(disableLinks(this.content?.text.markup)) }
+            </details>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-message.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-message.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 interface IGovUkErrorMessageContent extends UmbBlockDataType {
     error: string;
@@ -20,6 +20,9 @@ export class GovUkErrorMessageView extends UmbElementMixin(LitElement) implement
     @property({ attribute: false })
     settings?: IGovUkErrorMessageSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -27,7 +30,9 @@ export class GovUkErrorMessageView extends UmbElementMixin(LitElement) implement
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <p class="govuk-error-message backoffice-block-view ${ this.settings?.cssClasses }">${ this.content?.error }</p>
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
+            <p class="govuk-error-message ${ this.settings?.cssClasses}">${this.content?.error }</p>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-summary.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-summary.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 interface IGovUkErrorSummaryContent extends UmbBlockDataType {
     title: string;
@@ -20,6 +20,9 @@ export class GovUkErrorSummaryView extends UmbElementMixin(LitElement) implement
     @property({ attribute: false })
     settings?: IGovUkErrorSummarySettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -27,14 +30,14 @@ export class GovUkErrorSummaryView extends UmbElementMixin(LitElement) implement
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="govuk-error-summary">
                 <h2 class="govuk-error-summary__title">${ this.content?.title || "There is a problem" }</h2>
                 <div class="govuk-error-summary__body">
-                    <ul class="govuk-error-summary__list govuk-list"><li><a href="javascript:return false">Example error message</a></li></ul>
+                    <ul class="govuk-error-summary__list govuk-list"><li><span class="govuk-link">Example error message</span></li></ul>
                 </div>
             </div>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
@@ -1,13 +1,12 @@
 import { html, customElement, LitElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 
 interface IGovUkFieldsetContent extends UmbBlockDataType {
     legend: string;
-    blocks: IBlockListProperty | null;
+    blocks: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkFieldsetSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
@@ -24,6 +24,9 @@ export class GovUkFieldsetView extends UmbElementMixin(LitElement) implements Um
 
     @property({ attribute: false })
     settings?: IGovUkFieldsetSettings;
+
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
     
     @state()
     _nodeName?: string;
@@ -52,12 +55,12 @@ export class GovUkFieldsetView extends UmbElementMixin(LitElement) implements Um
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <fieldset class="govuk-fieldset ${ this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${ this.settings?.legendIsPageHeading ? html `<h1 class="govuk-fieldset__heading">${ legend }</h1>`: legend }</legend>
                 <p class="backoffice-additional-blocks">${ blocks }</p>
             </fieldset>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-file-upload.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-file-upload.ts
@@ -1,9 +1,10 @@
 import { html, customElement, LitElement, property, state, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
+import { disableLinks } from '../helpers/html-helper';
 interface IGovUkFileUploadContent extends UmbBlockDataType {
     label: string;
     hint: IRichTextProperty;
@@ -23,6 +24,9 @@ export class GovUkFileUploadView extends UmbElementMixin(LitElement) implements 
 
     @property({ attribute: false })
     settings?: IGovUkFileUploadSettings;
+
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
 
     @state()
     _nodeName?: string;
@@ -49,13 +53,13 @@ export class GovUkFileUploadView extends UmbElementMixin(LitElement) implements 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
 
-        <div class="govuk-form-group backoffice-block-view ${ this.settings?.cssClasses }">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${ this.settings?.cssClasses }">
             ${this.settings?.labelIsPageHeading ?
                 html`<h1 class="govuk-label-wrapper">
                     <label class="govuk-label govuk-label--l" id="${uniqueId}-label">${label}</label>
                 </h1>` :
                 html`<label class="govuk-label" id="${uniqueId}-label">${label}</label>`}
-            ${this.content?.hint?.markup ? html`<div class="govuk-hint" id="${uniqueId}-hint">${unsafeHTML(this.content?.hint?.markup)}</div>` : null}
+            ${this.content?.hint?.markup ? html`<div class="govuk-hint" id="${uniqueId}-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
             <div class="govuk-drop-zone">
                 <button class="govuk-file-upload-button govuk-file-upload-button--empty" type="button" id="${uniqueId}" onclick="javascript:return false" aria-labelledby="${uniqueId}-label ${uniqueId}-comma ${uniqueId}-hint">
                     <span class="govuk-body govuk-file-upload-button__status">No file chosen</span>
@@ -66,7 +70,7 @@ export class GovUkFileUploadView extends UmbElementMixin(LitElement) implements 
                     </span>
                 </button>
             </div>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-file-upload.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-file-upload.ts
@@ -2,12 +2,12 @@ import { html, customElement, LitElement, property, state, unsafeHTML } from '@u
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { disableLinks } from '../helpers/html-helper';
 interface IGovUkFileUploadContent extends UmbBlockDataType {
     label: string;
-    hint: IRichTextProperty;
+    hint: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkFileUploadSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-inset-text.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-inset-text.ts
@@ -1,8 +1,9 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkInsetTextContent extends UmbBlockDataType {
     text: IRichTextProperty;
@@ -22,6 +23,9 @@ export class GovUkInsetTextView extends UmbElementMixin(LitElement) implements U
     @property({ attribute: false })
     settings?: IGovUkInsetTextSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -29,7 +33,7 @@ export class GovUkInsetTextView extends UmbElementMixin(LitElement) implements U
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-inset-text backoffice-block-view ${ this.settings?.cssClasses}">${unsafeHTML(this.content?.text.markup) }</div>
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-inset-text backoffice-block-view ${ this.settings?.cssClasses}">${unsafeHTML(disableLinks(this.content?.text.markup)) }</a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-inset-text.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-inset-text.ts
@@ -2,11 +2,11 @@ import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkInsetTextContent extends UmbBlockDataType {
-    text: IRichTextProperty;
+    text: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkInsetTextSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link-as-button.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link-as-button.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 interface IGovUkLinkAsButtonContent extends UmbBlockDataType {
     text: string;
@@ -22,6 +22,9 @@ export class GovUkLinkAsButtonView extends UmbElementMixin(LitElement) implement
     @property({ attribute: false })
     settings?: IGovUkLinkAsButtonSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -36,30 +39,21 @@ export class GovUkLinkAsButtonView extends UmbElementMixin(LitElement) implement
             blockViewClass = "backoffice-block-view-inverse";
         }
 
-        if (this.settings?.isStartButton) {
-            return html`
-            <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-            <div class="backoffice-block-view">
+        return html`<link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+            <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
                 <div class="${ blockViewClass }">
-                    <a href="javascript:return false" role="button" draggable="false" class="govuk-button govuk-button--start ${buttonClass} ${this.settings?.cssClasses}">
-                      ${this.content?.text }
-                      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-                        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-                      </svg>
-                    </a>
+                ${ this.settings?.isStartButton ?
+                    html`<span role="button" draggable="false" class="govuk-button govuk-button--start ${buttonClass} ${this.settings?.cssClasses}">
+                          ${this.content?.text }
+                          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+                            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+                          </svg>
+                        </span>` :
+                    html`<span class="govuk-button ${buttonClass} ${this.settings?.cssClasses}" role="button">${this.content?.text}</span>` }
                 </div>
-            </div>`;
-        }
-        else {
-            return html`
-            <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-            <div class="backoffice-block-view">
-                <div class="${ blockViewClass }">
-                    <a href="javascript:return false" class="govuk-button ${buttonClass} ${this.settings?.cssClasses}" role="button">${this.content?.text}</a>
-                </div>
-            </div>`;
-        }
+            </a>`;
     }
 }
+
 
 export default GovUkLinkAsButtonView;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 interface IGovUkLinkContent extends UmbBlockDataType {
     text: string;
@@ -20,6 +20,9 @@ export class GovUkLinkView extends UmbElementMixin(LitElement) implements UmbBlo
     @property({ attribute: false })
     settings?: IGovUkLinkSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -27,9 +30,9 @@ export class GovUkLinkView extends UmbElementMixin(LitElement) implements UmbBlo
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
-            <a href="javascript:return false" class="govuk-link ${this.settings?.cssClasses}">${this.content?.text}</a>
-        </div>`;
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
+            <span class="govuk-link ${this.settings?.cssClasses}">${this.content?.text}</a>
+        </a>`;
     }
 }
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
@@ -1,15 +1,14 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkNotificationBannerContent extends UmbBlockDataType {
-    heading: IRichTextProperty;
-    text: IRichTextProperty;
-    blocks: IBlockListProperty | null;
+    heading: UmbPropertyEditorRteValueType;
+    text: UmbPropertyEditorRteValueType;
+    blocks: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkNotificationBannerSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
@@ -1,9 +1,10 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkNotificationBannerContent extends UmbBlockDataType {
     heading: IRichTextProperty;
@@ -27,6 +28,9 @@ export class GovUkNotificationBannerView extends UmbElementMixin(LitElement) imp
     @property({ attribute: false })
     settings?: IGovUkNotificationBannerSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -43,7 +47,7 @@ export class GovUkNotificationBannerView extends UmbElementMixin(LitElement) imp
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="${bannerClass} ${ this.settings?.cssClasses }">
                 <div class="govuk-notification-banner__header">
                     ${ this.settings?.title ? html`<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">${this.settings?.title}</h2>` : null }
@@ -51,12 +55,12 @@ export class GovUkNotificationBannerView extends UmbElementMixin(LitElement) imp
                     ${ this.settings?.type === 'Success' && !(this.settings?.title) ? html`<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>` : null }
                 </div>
                 <div class="govuk-notification-banner__content" aria-hidden="true">
-                    <h3 class="govuk-notification-banner__heading">${ html`${unsafeHTML(this.content?.heading.markup) }` }</h3>
-                    ${ this.content?.text?.markup ? html`<p class="govuk-body">${unsafeHTML(this.content.text.markup) }</p>` : null }
+                    <h3 class="govuk-notification-banner__heading">${ html`${unsafeHTML(disableLinks(this.content?.heading.markup)) }` }</h3>
+                    ${ this.content?.text?.markup ? html`<p class="govuk-body">${unsafeHTML(disableLinks(this.content.text.markup)) }</p>` : null }
                     <p class="backoffice-additional-blocks">${ blocks }</p>
                 </div>
             </div>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-page-heading.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-page-heading.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property,state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 
@@ -22,6 +22,9 @@ export class GovUkPageHeadingView extends UmbElementMixin(LitElement) implements
     @property({ attribute: false })
     settings?: IGovUkPageHeadingSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     @state()
     _nodeName?: string;
 
@@ -42,8 +45,9 @@ export class GovUkPageHeadingView extends UmbElementMixin(LitElement) implements
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <h1 class="govuk-heading-l backoffice-block-view ${ this.settings?.cssClasses }">${this.content?.text ? this.content.text : this._nodeName }</h1>
-        `;
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
+            <h1 class="govuk-heading-l ${ this.settings?.cssClasses}">${this.content?.text ? this.content.text : this._nodeName }</h1>
+        </a>`;
     }
 }
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-pagination.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-pagination.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 
 interface IGovUkPaginationContent extends UmbBlockDataType {
@@ -21,6 +21,9 @@ export class GovUkPaginationView extends UmbElementMixin(LitElement) implements 
     @property({ attribute: false })
     settings?: IGovUkPaginationSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -28,18 +31,19 @@ export class GovUkPaginationView extends UmbElementMixin(LitElement) implements 
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <nav class="govuk-pagination--block govuk-pagination backoffice-block-view ${ this.settings?.cssClasses}">
-            <div class="govuk-pagination__next">
-                <span class="govuk-link govuk-pagination__link">
-                    <svg class="govuk-pagination__icon govuk-pagination__icon--next" focusable="false" height="13" viewBox="0 0 15 13" width="15" xmlns="http://www.w3.org/2000/svg">
-                        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-                    </svg> 
-                    <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
-                    <span class="govuk-pagination__link-label">${ this.settings?.nextPageLabel || '{{page}} of {{total}}' }</span>
-                 </span>
-            </div>
-        </nav>
-        `;
+        <a href="${this.config?.editSettingsPath ?? ''}" class="backoffice-block-view">
+            <nav class="govuk-pagination--block govuk-pagination ${ this.settings?.cssClasses}">
+                <div class="govuk-pagination__next">
+                    <span class="govuk-link govuk-pagination__link">
+                        <svg class="govuk-pagination__icon govuk-pagination__icon--next" focusable="false" height="13" viewBox="0 0 15 13" width="15" xmlns="http://www.w3.org/2000/svg">
+                            <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                        </svg> 
+                        <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+                        <span class="govuk-pagination__link-label">${ this.settings?.nextPageLabel || '{{page}} of {{total}}' }</span>
+                     </span>
+                </div>
+            </nav>
+        </a>`;
     }
 }
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-panel.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-panel.ts
@@ -2,12 +2,12 @@ import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkPanelContent extends UmbBlockDataType {
     panelHeading: string;
-    panelText: IRichTextProperty;
+    panelText: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkPanelSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-panel.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-panel.ts
@@ -1,8 +1,9 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkPanelContent extends UmbBlockDataType {
     panelHeading: string;
@@ -23,6 +24,9 @@ export class GovUkPanelView extends UmbElementMixin(LitElement) implements UmbBl
     @property({ attribute: false })
     settings?: IGovUkPanelSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -30,11 +34,10 @@ export class GovUkPanelView extends UmbElementMixin(LitElement) implements UmbBl
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-panel--confirmation govuk-panel backoffice-block-view ${ this.settings?.cssClasses}">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-panel--confirmation govuk-panel backoffice-block-view ${ this.settings?.cssClasses}">
             ${this?.content?.panelHeading ? html`<h1 class="govuk-panel__title">${ this.content?.panelHeading }</h1>` : null }
-            ${this.content?.panelText.markup ? html`<div class="govuk-panel__body">${ unsafeHTML(this.content?.panelText.markup) }</div>` : null }
-        </div>
-        <div class="govuk-caption-l backoffice-block-view">${ this.content?.caption }</div>
+            ${this.content?.panelText.markup ? html`<div class="govuk-panel__body">${ unsafeHTML(disableLinks(this.content?.panelText.markup)) }</div>` : null }
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
 import { IBlockListProperty } from "../interfaces/IBlockListProperty";
@@ -25,6 +25,9 @@ export class GovUkRadioView extends UmbElementMixin(LitElement) implements UmbBl
 
     @property({ attribute: false })
     settings?: IGovUkRadioSettings;
+
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
     constructor() {
         super();
     }
@@ -32,9 +35,9 @@ export class GovUkRadioView extends UmbElementMixin(LitElement) implements UmbBl
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderRadioButton(this.content?.label, this.content?.value, this.content?.hint?.markup, this.content?.conditionalBlocks?.contentData, true) }
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
@@ -1,14 +1,13 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
-import { IBlockListProperty } from "../interfaces/IBlockListProperty";
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { renderRadioButton } from '../helpers/radios-helper';
 
 interface IGovUkRadioContent extends UmbBlockDataType {
-    conditionalBlocks: IBlockListProperty;
-    hint: IRichTextProperty;
+    conditionalBlocks: UmbBlockValueDataPropertiesBaseType;
+    hint: UmbPropertyEditorRteValueType;
     label: string;
     value: string;
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios-divider.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios-divider.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderRadiosDivider } from '../helpers/radios-helper';
 interface IGovUkRadiosDividerContent extends UmbBlockDataType {
@@ -13,6 +13,9 @@ export class GovUkRadiosDividerView extends UmbElementMixin(LitElement) implemen
     @property({ attribute: false })
     content?: IGovUkRadiosDividerContent;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -20,9 +23,9 @@ export class GovUkRadiosDividerView extends UmbElementMixin(LitElement) implemen
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderRadiosDivider(this.content?.text) }
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
@@ -1,11 +1,12 @@
 import { html, customElement, LitElement, property, state, unsafeHTML, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
 import { IBlockListProperty } from "../interfaces/IBlockListProperty";
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderRadiosDivider, renderRadioButton } from '../helpers/radios-helper';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkRadiosContent extends UmbBlockDataType {
     fieldsetBlocks: IBlockListProperty;
@@ -29,6 +30,9 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
 
     @property({ attribute: false })
     settings?: IGovUkRadiosSettings;
+
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
 
     @state()
     _nodeName?: string;
@@ -59,12 +63,12 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-form-group backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <fieldset class="govuk-fieldset govuk-radios__fieldset ${ this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend }</legend>
                 <p class="backoffice-additional-blocks">${blocksText}</p>
                 <div class="govuk-form-group">
-                    ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(this.content?.hint?.markup)}</div>` : null}
+                    ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
                     <div class="govuk-radios ${horizontalLayout ? "govuk-radios--inline" : null}">
                         ${ repeat(this.content?.radioButtons?.contentData || [],
                             (radio) => radio.key,
@@ -85,7 +89,7 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
                     </div>
                 </div>
             </fieldset>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
@@ -1,18 +1,17 @@
 import { html, customElement, LitElement, property, state, unsafeHTML, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
-import { IBlockListProperty } from "../interfaces/IBlockListProperty";
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderRadiosDivider, renderRadioButton } from '../helpers/radios-helper';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkRadiosContent extends UmbBlockDataType {
-    fieldsetBlocks: IBlockListProperty;
-    radioButtons: IBlockListProperty;
+    fieldsetBlocks: UmbBlockValueDataPropertiesBaseType;
+    radioButtons: UmbBlockValueDataPropertiesBaseType;
     legend: string;
-    hint: IRichTextProperty;
+    hint: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkRadiosSettings extends UmbBlockDataType {
@@ -75,13 +74,13 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
                             (radio) => {
                                 const govukRadiosDivider = "5bbc1a49-49b7-4119-b6ad-c113226d92e0";
                                 if (radio.contentTypeKey === govukRadiosDivider) {
-                                    const text = radio?.values.find(props => props.alias == "text")?.value;
+                                    const text = (radio?.values.find(props => props.alias == "text")?.value as string);
                                     return renderRadiosDivider(text);
                                 } else {
-                                    const label = radio?.values.find(props => props.alias == "label")?.value;
-                                    const value = radio?.values.find(props => props.alias == "value")?.value;
-                                    const hint = radio?.values.find(props => props.alias == "hint")?.value;
-                                    const conditionalBlocks = radio?.values.find(props => props.alias == "conditionalBlocks")?.value;
+                                    const label = (radio?.values.find(props => props.alias == "label")?.value as string);
+                                    const value = (radio?.values.find(props => props.alias == "value")?.value as string);
+                                    const hint = (radio?.values.find(props => props.alias == "hint")?.value as UmbPropertyEditorRteValueType);
+                                    const conditionalBlocks = (radio?.values.find(props => props.alias == "conditionalBlocks")?.value as UmbBlockValueDataPropertiesBaseType);
                                     return renderRadioButton(label, value, hint?.markup, conditionalBlocks?.contentData, !horizontalLayout)
                                 }
                             }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
@@ -1,15 +1,14 @@
 import { html, customElement, LitElement, property, repeat, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkSelectContent extends UmbBlockDataType {
     label: string;
-    hint: IRichTextProperty;
-    options: IBlockListProperty | null;
+    hint: UmbPropertyEditorRteValueType;
+    options: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkSelectSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
@@ -1,9 +1,10 @@
 import { html, customElement, LitElement, property, repeat, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkSelectContent extends UmbBlockDataType {
     label: string;
@@ -26,6 +27,9 @@ export class GovUkSelectView extends UmbElementMixin(LitElement) implements UmbB
     @property({ attribute: false })
     settings?: IGovUkSelectSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -33,13 +37,13 @@ export class GovUkSelectView extends UmbElementMixin(LitElement) implements UmbB
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-form-group backoffice-block-view ${ this.settings?.cssClasses }">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${ this.settings?.cssClasses }">
             ${ this.settings?.labelIsPageHeading ?
             html`<h1 class="govuk-label-wrapper">
                     <label class="govuk-label govuk-label--l">${this.content?.label}</label>
                 </h1>` :
             html`<label class="govuk-label">${this.content?.label}</label>` }            
-            ${ this.content?.hint.markup ? html`<div class="govuk-hint">${ unsafeHTML(this.content?.hint.markup)}</div>` : null }
+            ${ this.content?.hint.markup ? html`<div class="govuk-hint">${ unsafeHTML(disableLinks(this.content?.hint.markup))}</div>` : null }
             <select class="govuk-select">
                 ${ this?.content?.options?.contentData ? repeat(this.content?.options?.contentData,
                     (opt) => opt.key,
@@ -51,7 +55,7 @@ export class GovUkSelectView extends UmbElementMixin(LitElement) implements UmbB
                     }
                 ) : null }
             </select>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 import { renderSummaryList } from '../helpers/summary-list-helper';
@@ -25,6 +25,9 @@ export class GovUkSummaryCardView extends UmbElementMixin(LitElement) implements
     @property({ attribute: false })
     settings?: IGovUkSummaryCardSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -32,7 +35,7 @@ export class GovUkSummaryCardView extends UmbElementMixin(LitElement) implements
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="govuk-summary-card ${ this.settings?.cssClasses}">
                 <div class="govuk-summary-card__title-wrapper"><h2 class="govuk-summary-card__title">${this.content?.cardTitle}</h2>
                     ${this.content?.cardActions?.contentData ? html`<div class="govuk-summary-card__actions">
@@ -47,7 +50,7 @@ export class GovUkSummaryCardView extends UmbElementMixin(LitElement) implements
                     html`<div class="govuk-summary-card__content">${ renderSummaryList(this.content?.summaryListItems?.contentData || []) }</div>` :
                     html`<p class="backoffice-additional-blocks">Summary card with no list items.</p>` }
             </div>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
@@ -1,14 +1,13 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
 import { renderSummaryList } from '../helpers/summary-list-helper';
 
 interface IGovUkSummaryCardContent extends UmbBlockDataType {
     cardTitle: string;
-    cardActions: IBlockListProperty | null;
-    summaryListItems: IBlockListProperty | null;
+    cardActions: UmbBlockValueDataPropertiesBaseType | null;
+    summaryListItems: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkSummaryCardSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-action.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-action.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderSummaryListAction } from '../helpers/summary-list-helper';
 
@@ -14,6 +14,8 @@ export class GovUkSummaryListActionView extends UmbElementMixin(LitElement) impl
     @property({ attribute: false })
     content?: IGovUkSummaryListActionContent;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
     constructor() {
         super();
     }
@@ -21,9 +23,9 @@ export class GovUkSummaryListActionView extends UmbElementMixin(LitElement) impl
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderSummaryListAction(this.content?.text)}
-        </div>`;
+        </a>`;
     }
 }
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
@@ -1,15 +1,14 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
 import { renderSummaryListItem } from '../helpers/summary-list-helper';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 
 interface IGovUkSummaryListItemContent extends UmbBlockDataType {
     itemKey: string;
-    itemValue: IRichTextProperty;
-    actions: IBlockListProperty | null;
+    itemValue: UmbPropertyEditorRteValueType;
+    actions: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkSummaryListItemSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderSummaryListItem } from '../helpers/summary-list-helper';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
@@ -26,6 +26,9 @@ export class GovUkSummaryListItemView extends UmbElementMixin(LitElement) implem
     @property({ attribute: false })
     settings?: IGovUkSummaryListItemSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -33,9 +36,11 @@ export class GovUkSummaryListItemView extends UmbElementMixin(LitElement) implem
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <dl class="backoffice-block-view govuk-summary-list">
-            ${ renderSummaryListItem(this.content?.itemKey, this.content?.itemValue?.markup, this.content?.actions?.contentData) }
-        </dl>
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
+            <dl class="govuk-summary-list">
+                ${ renderSummaryListItem(this.content?.itemKey, this.content?.itemValue?.markup, this.content?.actions?.contentData) }
+            </dl>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderSummaryList } from '../helpers/summary-list-helper';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
@@ -23,6 +23,9 @@ export class GovUkSummaryListView extends UmbElementMixin(LitElement) implements
     @property({ attribute: false })
     settings?: IGovUkSummaryListSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -30,12 +33,12 @@ export class GovUkSummaryListView extends UmbElementMixin(LitElement) implements
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.items?.contentData ? 
                 renderSummaryList(this.content?.items?.contentData || [], this.settings?.cssClasses) :
                 html`<p class="backoffice-additional-blocks">Summary list with no list items.</p>`
             }
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
@@ -1,12 +1,11 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
 import { renderSummaryList } from '../helpers/summary-list-helper';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 
 interface IGovUkSummaryListContent extends UmbBlockDataType {
-    items: IBlockListProperty | null;
+    items: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkSummaryListSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list-summary.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list-summary.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 
 interface IGovUkTaskListSummaryContent extends UmbBlockDataType {
@@ -22,6 +22,9 @@ export class GovUkTaskListSummaryView extends UmbElementMixin(LitElement) implem
     @property({ attribute: false })
     settings?: IGovUkTaskListSummarySettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -29,10 +32,10 @@ export class GovUkTaskListSummaryView extends UmbElementMixin(LitElement) implem
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-task-list-summary backoffice-block-view ${ this.settings?.cssClasses}">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-task-list-summary backoffice-block-view ${ this.settings?.cssClasses}">
             <h2 class="govuk-task-list-summary__heading govuk-heading-s">${ this.content?.incompleteStatus || 'Tasks incomplete' }</h2>
             <p class="govuk-task-list-summary__tracker govuk-body">${ this.content?.tracker || "You've completed 1 of 2 tasks." }</p>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IBlockListProperty } from '../interfaces/IBlockListProperty';
 import { renderTask } from '../helpers/task-list-helper';
@@ -23,6 +23,9 @@ export class GovUkTaskListView extends UmbElementMixin(LitElement) implements Um
     @property({ attribute: false })
     settings?: IGovUkTaskListSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -30,8 +33,7 @@ export class GovUkTaskListView extends UmbElementMixin(LitElement) implements Um
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.tasks?.contentData ? 
                 html`<ul class="govuk-task-list ${this.settings?.cssClasses}">
                     ${ repeat(this.content?.tasks?.contentData,
@@ -49,7 +51,7 @@ export class GovUkTaskListView extends UmbElementMixin(LitElement) implements Um
                     )}
                     </ul>`
                     : html`<p class="backoffice-additional-blocks">Task list with no tasks.</li>` }
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
@@ -1,12 +1,12 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IBlockListProperty } from '../interfaces/IBlockListProperty';
+import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { renderTask } from '../helpers/task-list-helper';
 
 interface IGovUkTaskListContent extends UmbBlockDataType {
-    tasks: IBlockListProperty | null;
+    tasks: UmbBlockValueDataPropertiesBaseType | null;
 }
 
 interface IGovUkTaskListSettings extends UmbBlockDataType {
@@ -39,12 +39,12 @@ export class GovUkTaskListView extends UmbElementMixin(LitElement) implements Um
                     ${ repeat(this.content?.tasks?.contentData,
                         (task) => task.key,
                         (task, index) => {
-                            const taskName= task?.values.find(props => props.alias == "taskName")?.value;
-                            const hint = task?.values.find(props => props.alias == "hint")?.value;
+                            const taskName = (task?.values.find(props => props.alias == "taskName")?.value as string)?.toString();
+                            const hint = (task?.values.find(props => props.alias == "hint")?.value as UmbPropertyEditorRteValueType);
 
                             const settings = this.content?.tasks?.settingsData[index];
-                            const status = settings?.values.find(props => props.alias == "status")?.value;
-                            const cssClasses = settings?.values.find(props => props.alias == "cssClasses")?.value;
+                            const status = (settings?.values.find(props => props.alias == "status")?.value as string)?.toString();
+                            const cssClasses = (settings?.values.find(props => props.alias == "cssClasses")?.value as string)?.toString();
 
                             return renderTask(true, taskName, hint?.markup, status, cssClasses);
                         }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task.ts
@@ -1,6 +1,6 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderTask } from '../helpers/task-list-helper';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
@@ -25,6 +25,9 @@ export class GovUkTaskView extends UmbElementMixin(LitElement) implements UmbBlo
     @property({ attribute: false })
     settings?: IGovUkTaskSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -32,9 +35,9 @@ export class GovUkTaskView extends UmbElementMixin(LitElement) implements UmbBlo
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="backoffice-block-view">
+        <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ renderTask(true, this.content?.taskName, this.content?.hint?.markup, this.settings?.status, this.settings?.cssClasses) }
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task.ts
@@ -3,11 +3,11 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderTask } from '../helpers/task-list-helper';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 
 interface IGovUkTaskContent extends UmbBlockDataType {
     taskName: string;
-    hint: IRichTextProperty | null;
+    hint: UmbPropertyEditorRteValueType | null;
 }
 
 interface IGovUkTaskSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-text-input.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-text-input.ts
@@ -1,8 +1,9 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
 interface IGovUkTextInputContent extends UmbBlockDataType {
     label: string;
     hint: IRichTextProperty;
@@ -26,6 +27,9 @@ export class GovUkTextInputView extends UmbElementMixin(LitElement) implements U
 
     @property({ attribute: false })
     settings?: IGovUkTextInputSettings;
+
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
 
     constructor() {
         super();
@@ -60,20 +64,20 @@ export class GovUkTextInputView extends UmbElementMixin(LitElement) implements U
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-form-group backoffice-block-view ${this.settings?.cssClasses}">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${this.settings?.cssClasses}">
             ${this.settings?.labelIsPageHeading ?
                 html`<h1 class="govuk-label-wrapper">
                     <label class="govuk-label govuk-label--l">${this.content?.label}</label>
                 </h1>` :
                 html`<label class="govuk-label">${this.content?.label}</label>`}
-            ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(this.content?.hint?.markup)}</div>` : null}
+            ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
             <div class="govuk-input__wrapper">
                 ${this.settings?.prefix ? html`<div class="govuk-input__prefix" aria-hidden="true">${this.settings?.prefix}</div>` : null }
                 ${ this.settings?.readOnly ? html`<input class="govuk-input ${inputClass}" type="text" id="${crypto.randomUUID()}" readonly />` :
                 html`<input class="govuk-input ${inputClass}" type="text" id="${crypto.randomUUID()}" />` }
                 ${this.settings?.suffix ? html`<div class="govuk-input__suffix" aria-hidden="true">${this.settings?.suffix}</div>` : null }
             </div>
-        </div>`
+        </a>`
     }
 }
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-text-input.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-text-input.ts
@@ -2,11 +2,11 @@ import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 interface IGovUkTextInputContent extends UmbBlockDataType {
     label: string;
-    hint: IRichTextProperty;
+    hint: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkTextInputSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-textarea.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-textarea.ts
@@ -2,12 +2,12 @@ import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkTextareaContent extends UmbBlockDataType {
     label: string;
-    hint: IRichTextProperty;
+    hint: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkTextareaSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-textarea.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-textarea.ts
@@ -1,8 +1,10 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
+
 interface IGovUkTextareaContent extends UmbBlockDataType {
     label: string;
     hint: IRichTextProperty;
@@ -26,6 +28,9 @@ export class GovUkTextareaView extends UmbElementMixin(LitElement) implements Um
     @property({ attribute: false })
     settings?: IGovUkTextareaSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -35,17 +40,17 @@ export class GovUkTextareaView extends UmbElementMixin(LitElement) implements Um
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-form-group backoffice-block-view ${this.settings?.cssClasses}">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${this.settings?.cssClasses}">
             ${this.settings?.labelIsPageHeading ?
                 html`<h1 class="govuk-label-wrapper">
                     <label class="govuk-label govuk-label--l">${this.content?.label}</label>
                 </h1>` :
                 html`<label class="govuk-label">${this.content?.label}</label>`}
-            ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(this.content?.hint?.markup)}</div>` : null}
+            ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
             ${ this.settings?.readOnly ? html`<textarea class="govuk-textarea" rows="${rows}" id="${crypto.randomUUID()}" readonly></textarea>` :
                 html`<textarea class="govuk-textarea" rows="${rows}" id="${crypto.randomUUID()}"></textarea>`}
             ${this.settings?.showCharacterCount ? html`<div class="govuk-hint govuk-character-count__message govuk-character-count__status" aria-hidden="true">You have xxx characters remaining</div>` : null }
-        </div>
+        </a>
         `
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-typography.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-typography.ts
@@ -2,11 +2,11 @@ import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkTypographyContent extends UmbBlockDataType {
-    text: IRichTextProperty;
+    text: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkTypographySettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-typography.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-typography.ts
@@ -1,8 +1,9 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkTypographyContent extends UmbBlockDataType {
     text: IRichTextProperty;
@@ -21,6 +22,9 @@ export class GovUkTypographyView extends UmbElementMixin(LitElement) implements 
     @property({ attribute: false })
     settings?: IGovUkTypographySettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -28,7 +32,7 @@ export class GovUkTypographyView extends UmbElementMixin(LitElement) implements 
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-body backoffice-block-view">${unsafeHTML(this.content?.text.markup) }</div>
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-body backoffice-block-view">${unsafeHTML(disableLinks(this.content?.text.markup)) }</a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-warning-text.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-warning-text.ts
@@ -1,8 +1,9 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement } from '@umbraco-cms/backoffice/block-custom-view';
+import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkWarningTextContent extends UmbBlockDataType {
     iconFallbackText: string;
@@ -23,6 +24,9 @@ export class GovUkWarningTextView extends UmbElementMixin(LitElement) implements
     @property({ attribute: false })
     settings?: IGovUkWarningTextSettings;
 
+    @property({ attribute: false })
+    config?: UmbBlockEditorCustomViewConfiguration;
+
     constructor() {
         super();
     }
@@ -30,13 +34,13 @@ export class GovUkWarningTextView extends UmbElementMixin(LitElement) implements
     override render() {
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
-        <div class="govuk-warning-text backoffice-block-view ${ this.settings?.cssClasses}">
+        <a href="${this.config?.editContentPath ?? ''}" class="govuk-warning-text backoffice-block-view ${ this.settings?.cssClasses}">
             <span aria-hidden="true" class="govuk-warning-text__icon">!</span>
             <strong class="govuk-warning-text__text" aria-hidden="true">
                 <span class="govuk-visually-hidden">${ this.content?.iconFallbackText || "Warning" }</span>
-                ${ unsafeHTML(this.content?.text.markup) }
+                ${ unsafeHTML(disableLinks(this.content?.text.markup)) }
             </strong>
-        </div>
+        </a>
         `;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-warning-text.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-warning-text.ts
@@ -2,12 +2,12 @@ import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
-import { IRichTextProperty } from '../interfaces/IRichTextProperty';
+import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkWarningTextContent extends UmbBlockDataType {
     iconFallbackText: string;
-    text: IRichTextProperty;
+    text: UmbPropertyEditorRteValueType;
 }
 
 interface IGovUkWarningTextSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
+++ b/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
@@ -5,22 +5,28 @@
     margin: 20px 20px 0;
     border-bottom: 1px dashed #bbbabf;
     padding-top: .1px;
+    display: block;
+    cursor: pointer;
+    color: $govuk-text-colour;
 }
+
+.backoffice-block-view:link, .backoffice-block-view:visited {
+    text-decoration: none;
+}
+
 .backoffice-block-view p,
-.backoffice-block-view.govuk-heading-l {
+.backoffice-block-view > .govuk-heading-l {
     margin-top: 0;
 }
 
 .backoffice-block-view > .govuk-accordion,
-.backoffice-block-view.govuk-caption-l,
-.backoffice-block-view.govuk-error-message,
+.backoffice-block-view > .govuk-caption-l,
 .backoffice-block-view:has(> .govuk-link),
 .backoffice-block-view:has(.govuk-textarea) {
     padding-bottom: 20px;
 }
 
-.backoffice-block-view.govuk-caption-l,
-.backoffice-block-view.govuk-details,
+.backoffice-block-view > .govuk-details,
 .backoffice-block-view > .govuk-error-summary,
 .backoffice-block-view > .govuk-fieldset,
 .backoffice-block-view.govuk-form-group:not(.backoffice-block-view-textarea),
@@ -30,8 +36,7 @@
     padding-top: 20px;
 }
 .backoffice-block-view > .govuk-accordion,
-.backoffice-block-view.govuk-details > summary,
-.backoffice-block-view.govuk-error-message,
+.backoffice-block-view > .govuk-error-message,
 .backoffice-block-view > .govuk-error-summary,
 .backoffice-block-view.govuk-panel,
 .backoffice-block-view > .govuk-summary-list,
@@ -44,8 +49,8 @@
 .backoffice-block-view > .govuk-notification-banner__content {
     padding-bottom: 0;
 }
-.backoffice-block-view.govuk-panel a:link,
-.backoffice-block-view.govuk-panel a:visited {
+.backoffice-block-view.govuk-panel,
+.backoffice-block-view.govuk-panel span.govuk-link {
     color: #fff;
 }
 .backoffice-block-view > .govuk-fieldset {
@@ -105,4 +110,13 @@
 }
 .backoffice-block-view-inverse > :last-child {
     margin-bottom: 0;
+}
+
+/* Links are disabled by converting them to span, but should still look like links. */
+.backoffice-block-view span.govuk-link {
+    color: $govuk-link-colour;
+    cursor: pointer;
+}
+.backoffice-block-view .govuk-error-summary span.govuk-link {
+    color: $govuk-error-colour;
 }


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

Backoffice views for GOV.UK components have already been migrated to Umbraco 17, but this does another sweep over all of them to pick up a few issues:

- More `label` settings have gone from Angular syntax like `{{...}}` to empty strings. This is just removing obsolete code, because the label is never visible when there's a backoffice preview.
- Views use built-in Umbraco TypeScript types where possible rather than custom ones.
- Restoring the v13 feature where you can click anywhere in a preview to edit the block content, rather than just on the tiny edit icon.

The new previews are built in the recommended stack for the new Umbraco backoffice, which is:
- TypeScript
- [Lit](https://lit.dev/) to make web components easier to build
- [Vite](https://vite.dev/) as a client-side build tool

To review this PR, as well as running the Umbraco example app in the normal way you'll also need to compile the backoffice views with the following commands:

```cmd
cd GovUk.Frontend.Umbraco\Backoffice
npm install
npm run build
```

This will compile the TypeScript, and then use Vite to publish the output under the `wwwroot/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco` folder.

## Out-of-scope for this PR

Everything else. 

Outside of the backoffice you can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load

Otherwise you can expect:
- TPR blocks still appear just as a rectangle with the name of the block
- build warnings
- TODO comments in code, and commented-out code for Smidge
- broken client-side features (ie JavaScript) because Smidge is gone
- elements of the Umbraco back office to be unusable (mainly rich text editing)
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Support for rich text editing in the Umbraco backoffice 
- Improved support for client-side assets following removal of Smidge between Umbraco 13 and 17
- Refactor MSBuild code to remove a lot of duplication and complexity
- Fixing the favicon bug we've been working around since the release of .NET 9
- Fix the unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating namespaces for greater clarity
- Modernising example apps and docs to support top-level statements in Program.cs
- Fix task list non-conformance issues
- Convert all remaining NUnit tests to XUnit
