### PR TITLE
Fix block order and hidden blocks in v17 backoffice views

### DIFF
--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/summary-list-helper.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/helpers/summary-list-helper.ts
@@ -1,23 +1,25 @@
 ﻿import { html, repeat, TemplateResult, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
-import { UmbBlockDataModel, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
+import { UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
-export function renderSummaryList(listItems: Array<UmbBlockDataModel> | [], cssClasses: string | undefined = undefined): TemplateResult {
+export function renderSummaryList(listItems: UmbBlockValueType<UmbBlockListLayoutModel> | undefined, cssClasses: string | undefined = undefined): TemplateResult {
         return html`
             <dl class="govuk-summary-list ${cssClasses}">
-                ${repeat(listItems || [],
-                    (block) => block.key,
-                    (block) => {
+                ${repeat(listItems?.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                    (layout) => layout.contentKey,
+                    (layout) => {
+                        const block = listItems?.contentData.find(item => item.key === layout.contentKey)!;
                         const itemKey = (block.values.find(props => props.alias == "itemKey")?.value as string)?.toString();
                         const itemValue = (block.values.find(props => props.alias == "itemValue")?.value as UmbPropertyEditorRteValueType)?.markup;
-                        const actions = (block.values.find(props => props.alias == "actions")?.value as UmbBlockValueDataPropertiesBaseType)?.contentData;
+                        const actions = (block.values.find(props => props.alias == "actions")?.value as UmbBlockValueType<UmbBlockListLayoutModel>);
                         return renderSummaryListItem(itemKey, itemValue, actions);
                     })}
             </dl>`;
 }
 
-export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml: string | undefined, actions: Array<UmbBlockDataModel> | null | undefined):  TemplateResult {
+export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml: string | undefined, actions: UmbBlockValueType<UmbBlockListLayoutModel> | undefined):  TemplateResult {
     return html`
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">${itemKey}</dt>
@@ -25,9 +27,10 @@ export function renderSummaryListItem(itemKey: string | undefined, itemValueHtml
             ${actions ? html`
                 <dd class="govuk-summary-list__actions">
                     <ul class="govuk-summary-list__actions-list">
-                    ${repeat(actions || [],
-                        (action: UmbBlockDataModel) => action.key,
-                        (action: UmbBlockDataModel) => {
+                    ${repeat(actions.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                        (layout) => layout.contentKey,
+                        (layout) => {
+                            const action = actions?.contentData.find(item => item.key === layout.contentKey)!;
                             const text = (action.values.find(props => props.alias == "text")?.value as string);
                             return html`<li class="govuk-summary-list__actions-list-item">
                                 ${renderSummaryListAction(text)}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
@@ -1,13 +1,14 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
+import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { renderAccordionSection } from '../helpers/accordion-helper';
 
 interface IGovUkAccordionSectionContent extends UmbBlockDataType {
     heading: string;
     summary: string;
-    blocks: UmbBlockValueDataPropertiesBaseType | null;
+    blocks: UmbBlockValueType<UmbBlockListLayoutModel> | null;
 }
 
 interface IGovUkAccordionSectionSettings extends UmbBlockDataType {
@@ -31,7 +32,7 @@ export class GovUkAccordionSectionView extends UmbElementMixin(LitElement) imple
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
-            ${ renderAccordionSection(this.content?.heading, this.content?.summary, this?.content?.blocks?.contentData) }
+            ${renderAccordionSection(this.content?.heading, this.content?.summary, this?.content?.blocks?.contentData) }
         </a>`;
     }
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
@@ -1,11 +1,12 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType, UmbBlockDataModel } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { renderAccordionSection } from '../helpers/accordion-helper';
 
 interface IGovUkAccordionContent extends UmbBlockDataType {
-    sections: UmbBlockValueDataPropertiesBaseType | null;
+    sections: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
 }
 
 interface IGovUkAccordionSettings extends UmbBlockDataType {
@@ -31,12 +32,13 @@ export class GovUkAccordionView extends UmbElementMixin(LitElement) implements U
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.sections?.contentData ? html`
                 <div class="govuk-accordion">
-                    ${repeat(this.content.sections.contentData,
-                        (section: UmbBlockDataModel) => section.key,
-                        (section: UmbBlockDataModel) => {
+                    ${repeat(this.content.sections.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                        (layout) => layout.contentKey,
+                        (layout) => {
+                            const section = this.content?.sections?.contentData.find(item => item.key === layout.contentKey)!;
                             const heading = (section?.values.find(props => props.alias == "heading")?.value as string);
                             const summary = (section?.values.find(props => props.alias == "summary")?.value as string);
-                            const blocks = (section?.values.find(props => props.alias == "blocks")?.value as UmbBlockValueDataPropertiesBaseType)?.contentData;
+                            const blocks = (section?.values.find(props => props.alias == "blocks")?.value as UmbBlockValueType<UmbBlockListLayoutModel>)?.contentData;
                             return renderAccordionSection(heading, summary, blocks);
                         }
                     )}

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
@@ -1,10 +1,11 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 
 interface IGovUkButtonGroupContent extends UmbBlockDataType {
-    buttons: UmbBlockValueDataPropertiesBaseType | null;
+    buttons: UmbBlockValueType<UmbBlockListLayoutModel> | null;
 }
 
 interface IGovUkButtonGroupSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
@@ -1,7 +1,8 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
@@ -9,7 +10,7 @@ interface IGovUkCheckboxContent extends UmbBlockDataType {
     label: string;
     value: string;
     hint: UmbPropertyEditorRteValueType;
-    conditionalBlocks: UmbBlockValueDataPropertiesBaseType;
+    conditionalBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
 }
 
 interface IGovUkCheckboxSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
@@ -1,7 +1,8 @@
 import { html, customElement, LitElement, property, unsafeHTML, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
+import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderCheckboxesDivider, renderCheckbox } from '../helpers/checkboxes-helper';
@@ -10,8 +11,8 @@ import { disableLinks } from '../helpers/html-helper';
 interface IGovUkCheckboxesContent extends UmbBlockDataType {
     legend: string;
     hint: UmbPropertyEditorRteValueType;
-    fieldsetBlocks: UmbBlockValueDataPropertiesBaseType;
-    checkboxes: UmbBlockValueDataPropertiesBaseType;
+    fieldsetBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
+    checkboxes: UmbBlockValueType<UmbBlockListLayoutModel>;
 }
 
 interface IGovUkCheckboxesSettings extends UmbBlockDataType {
@@ -59,15 +60,16 @@ export class GovUkCheckboxesView extends UmbElementMixin(LitElement) implements 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
-            <fieldset class="govuk-fieldset govuk-checkboxes__fieldset ${ this.settings?.cssClasses}">
-                <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend }</legend>
+            <fieldset class="govuk-fieldset govuk-checkboxes__fieldset ${this.settings?.cssClasses}">
+                <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend}</legend>
                 <div class="govuk-form-group">
                     <p class="backoffice-additional-blocks">${blocksText}</p>
                     ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
                     <div class="govuk-checkboxes">
-                        ${repeat(this.content?.checkboxes?.contentData || [],
-                            (checkbox) => checkbox.key,
-                            (checkbox) => {
+                        ${repeat(this.content?.checkboxes?.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                            (layout) => layout.contentKey,
+                            (layout) => {
+                                const checkbox = this.content?.checkboxes?.contentData.find(item => item.key === layout.contentKey)!;
                                 const govukCheckboxesDivider = "ee99c671-93dc-4d08-9933-e61e50dc234a";
                                 if (checkbox.contentTypeKey === govukCheckboxesDivider) {
                                     const text = (checkbox?.values.find(props => props.alias == "text")?.value as string);
@@ -76,7 +78,7 @@ export class GovUkCheckboxesView extends UmbElementMixin(LitElement) implements 
                                     const label = (checkbox?.values.find(props => props.alias == "label")?.value as string);
                                     const value = (checkbox?.values.find(props => props.alias == "value")?.value as string);
                                     const hint = (checkbox?.values.find(props => props.alias == "hint")?.value as UmbPropertyEditorRteValueType);
-                                    const conditionalBlocks = (checkbox?.values.find(props => props.alias == "conditionalBlocks")?.value as UmbBlockValueDataPropertiesBaseType);
+                                    const conditionalBlocks = (checkbox?.values.find(props => props.alias == "conditionalBlocks")?.value as UmbBlockValueType<UmbBlockListLayoutModel>);
                                     return renderCheckbox(label, value, hint?.markup, conditionalBlocks?.contentData)
                                 }
                             }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
@@ -1,13 +1,14 @@
 import { html, customElement, LitElement, property, unsafeHTML, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkDateInputContent extends UmbBlockDataType {
-    fieldsetBlocks: UmbBlockValueDataPropertiesBaseType;
+    fieldsetBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
     legend: string;
     hint: UmbPropertyEditorRteValueType;
 }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
@@ -1,12 +1,13 @@
 import { html, customElement, LitElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 
 interface IGovUkFieldsetContent extends UmbBlockDataType {
     legend: string;
-    blocks: UmbBlockValueDataPropertiesBaseType | null;
+    blocks: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
 }
 
 interface IGovUkFieldsetSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
@@ -1,14 +1,15 @@
 import { html, customElement, LitElement, property, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
+import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkNotificationBannerContent extends UmbBlockDataType {
     heading: UmbPropertyEditorRteValueType;
     text: UmbPropertyEditorRteValueType;
-    blocks: UmbBlockValueDataPropertiesBaseType | null;
+    blocks: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
 }
 
 interface IGovUkNotificationBannerSettings extends UmbBlockDataType {

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
@@ -1,12 +1,13 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { renderRadioButton } from '../helpers/radios-helper';
 
 interface IGovUkRadioContent extends UmbBlockDataType {
-    conditionalBlocks: UmbBlockValueDataPropertiesBaseType;
+    conditionalBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
     hint: UmbPropertyEditorRteValueType;
     label: string;
     value: string;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
@@ -1,15 +1,16 @@
 import { html, customElement, LitElement, property, state, unsafeHTML, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
+import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderRadiosDivider, renderRadioButton } from '../helpers/radios-helper';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkRadiosContent extends UmbBlockDataType {
-    fieldsetBlocks: UmbBlockValueDataPropertiesBaseType;
-    radioButtons: UmbBlockValueDataPropertiesBaseType;
+    fieldsetBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
+    radioButtons: UmbBlockValueType<UmbBlockListLayoutModel>;
     legend: string;
     hint: UmbPropertyEditorRteValueType;
 }
@@ -51,7 +52,6 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
     }
 
     override render() {
-
         let blocksText = "No blocks.";
         if (this.content?.fieldsetBlocks?.contentData?.length === 1) { blocksText = "1 block." }
         if ((this.content?.fieldsetBlocks?.contentData?.length || 0) > 1) { blocksText = `${this.content?.fieldsetBlocks?.contentData.length} blocks.` }
@@ -69,9 +69,10 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
                 <div class="govuk-form-group">
                     ${this.content?.hint?.markup ? html`<div class="govuk-hint">${unsafeHTML(disableLinks(this.content?.hint?.markup))}</div>` : null}
                     <div class="govuk-radios ${horizontalLayout ? "govuk-radios--inline" : null}">
-                        ${ repeat(this.content?.radioButtons?.contentData || [],
-                            (radio) => radio.key,
-                            (radio) => {
+                        ${ repeat(this.content?.radioButtons?.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                            (layout) => layout.contentKey,
+                            (layout) => {
+                                const radio = this.content?.radioButtons?.contentData.find(item => item.key === layout.contentKey)!;
                                 const govukRadiosDivider = "5bbc1a49-49b7-4119-b6ad-c113226d92e0";
                                 if (radio.contentTypeKey === govukRadiosDivider) {
                                     const text = (radio?.values.find(props => props.alias == "text")?.value as string);
@@ -80,7 +81,7 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
                                     const label = (radio?.values.find(props => props.alias == "label")?.value as string);
                                     const value = (radio?.values.find(props => props.alias == "value")?.value as string);
                                     const hint = (radio?.values.find(props => props.alias == "hint")?.value as UmbPropertyEditorRteValueType);
-                                    const conditionalBlocks = (radio?.values.find(props => props.alias == "conditionalBlocks")?.value as UmbBlockValueDataPropertiesBaseType);
+                                    const conditionalBlocks = (radio?.values.find(props => props.alias == "conditionalBlocks")?.value as UmbBlockValueType<UmbBlockListLayoutModel>);
                                     return renderRadioButton(label, value, hint?.markup, conditionalBlocks?.contentData, !horizontalLayout)
                                 }
                             }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
@@ -1,14 +1,15 @@
 import { html, customElement, LitElement, property, repeat, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
 
 interface IGovUkSelectContent extends UmbBlockDataType {
     label: string;
     hint: UmbPropertyEditorRteValueType;
-    options: UmbBlockValueDataPropertiesBaseType | null;
+    options: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
 }
 
 interface IGovUkSelectSettings extends UmbBlockDataType {
@@ -44,9 +45,10 @@ export class GovUkSelectView extends UmbElementMixin(LitElement) implements UmbB
             html`<label class="govuk-label">${this.content?.label}</label>` }            
             ${ this.content?.hint.markup ? html`<div class="govuk-hint">${ unsafeHTML(disableLinks(this.content?.hint.markup))}</div>` : null }
             <select class="govuk-select">
-                ${ this?.content?.options?.contentData ? repeat(this.content?.options?.contentData,
-                    (opt) => opt.key,
-                    (opt) => {
+                ${ this?.content?.options?.contentData ? repeat(this.content?.options?.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                    (layout) => layout.contentKey,
+                    (layout) => {
+                        const opt = this.content?.options?.contentData.find(item => item.key === layout.contentKey);
                         const value = opt?.values.find(props => props.alias == "value")?.value;
                         const label = opt?.values.find(props => props.alias == "label")?.value;
 

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
@@ -1,13 +1,14 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { renderSummaryList } from '../helpers/summary-list-helper';
 
 interface IGovUkSummaryCardContent extends UmbBlockDataType {
     cardTitle: string;
-    cardActions: UmbBlockValueDataPropertiesBaseType | null;
-    summaryListItems: UmbBlockValueDataPropertiesBaseType | null;
+    cardActions: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
+    summaryListItems: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
 }
 
 interface IGovUkSummaryCardSettings extends UmbBlockDataType {
@@ -38,15 +39,18 @@ export class GovUkSummaryCardView extends UmbElementMixin(LitElement) implements
             <div class="govuk-summary-card ${ this.settings?.cssClasses}">
                 <div class="govuk-summary-card__title-wrapper"><h2 class="govuk-summary-card__title">${this.content?.cardTitle}</h2>
                     ${this.content?.cardActions?.contentData ? html`<div class="govuk-summary-card__actions">
-                        ${repeat(this.content?.cardActions?.contentData || [],
-                            (action) => action.key,
-                            (action) => html`<div class="govuk-summary-card__action">
+                        ${repeat(this.content?.cardActions?.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                            (layout) => layout.contentKey,
+                            (layout) => {
+                                const action = this.content?.cardActions?.contentData.find(item => item.key === layout.contentKey)!;
+                                return html`<div class="govuk-summary-card__action">
                                     <a class="govuk-link" href="javascript:return false">${action.values.find(props => props.alias == "text")?.value}</a>
-                                </div>`)}
+                                </div>`}
+                            )}
                             </div>` : null }                
                 </div>
                 ${ this.content?.summaryListItems?.contentData ? 
-                    html`<div class="govuk-summary-card__content">${ renderSummaryList(this.content?.summaryListItems?.contentData || []) }</div>` :
+                    html`<div class="govuk-summary-card__content">${ renderSummaryList(this.content?.summaryListItems) }</div>` :
                     html`<p class="backoffice-additional-blocks">Summary card with no list items.</p>` }
             </div>
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
@@ -1,14 +1,15 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { renderSummaryListItem } from '../helpers/summary-list-helper';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 
 interface IGovUkSummaryListItemContent extends UmbBlockDataType {
     itemKey: string;
     itemValue: UmbPropertyEditorRteValueType;
-    actions: UmbBlockValueDataPropertiesBaseType | null;
+    actions: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
 }
 
 interface IGovUkSummaryListItemSettings extends UmbBlockDataType {
@@ -37,7 +38,7 @@ export class GovUkSummaryListItemView extends UmbElementMixin(LitElement) implem
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <dl class="govuk-summary-list">
-                ${ renderSummaryListItem(this.content?.itemKey, this.content?.itemValue?.markup, this.content?.actions?.contentData) }
+                ${ renderSummaryListItem(this.content?.itemKey, this.content?.itemValue?.markup, this.content?.actions) }
             </dl>
         </a>
         `;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
@@ -1,11 +1,12 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { renderSummaryList } from '../helpers/summary-list-helper';
 
 interface IGovUkSummaryListContent extends UmbBlockDataType {
-    items: UmbBlockValueDataPropertiesBaseType | null;
+    items: UmbBlockValueType<UmbBlockListLayoutModel> | null;
 }
 
 interface IGovUkSummaryListSettings extends UmbBlockDataType {
@@ -34,7 +35,7 @@ export class GovUkSummaryListView extends UmbElementMixin(LitElement) implements
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.items?.contentData ? 
-                renderSummaryList(this.content?.items?.contentData || [], this.settings?.cssClasses) :
+                renderSummaryList(this.content?.items, this.settings?.cssClasses) :
                 html`<p class="backoffice-additional-blocks">Summary list with no list items.</p>`
             }
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
@@ -1,12 +1,13 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { renderTask } from '../helpers/task-list-helper';
 
 interface IGovUkTaskListContent extends UmbBlockDataType {
-    tasks: UmbBlockValueDataPropertiesBaseType | null;
+    tasks: UmbBlockValueType<UmbBlockListLayoutModel> | null;
 }
 
 interface IGovUkTaskListSettings extends UmbBlockDataType {
@@ -36,13 +37,14 @@ export class GovUkTaskListView extends UmbElementMixin(LitElement) implements Um
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.tasks?.contentData ? 
                 html`<ul class="govuk-task-list ${this.settings?.cssClasses}">
-                    ${ repeat(this.content?.tasks?.contentData,
-                        (task) => task.key,
-                        (task, index) => {
+                    ${ repeat(this.content?.tasks?.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [],
+                        (layout) => layout.contentKey,
+                        (layout) => {
+                            const task = this.content?.tasks?.contentData.find(item => item.key === layout.contentKey)!;
                             const taskName = (task?.values.find(props => props.alias == "taskName")?.value as string)?.toString();
                             const hint = (task?.values.find(props => props.alias == "hint")?.value as UmbPropertyEditorRteValueType);
 
-                            const settings = this.content?.tasks?.settingsData[index];
+                            const settings = this.content?.tasks?.settingsData.find(item => item.key === layout.settingsKey)!;
                             const status = (settings?.values.find(props => props.alias == "status")?.value as string)?.toString();
                             const cssClasses = (settings?.values.find(props => props.alias == "cssClasses")?.value as string)?.toString();
 

--- a/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
+++ b/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
@@ -121,3 +121,10 @@
 .backoffice-block-view .govuk-error-summary span.govuk-link {
     color: $govuk-error-colour;
 }
+
+/* If govuk-\!-display-none is applied the preview could disappear entirely, leaving no backoffice UI,
+    so override it to show a faded version instead. */
+.backoffice-block-view .govuk-\!-display-none {
+    display: block !important;
+    opacity: 0.3;
+}

--- a/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
+++ b/GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
@@ -20,6 +20,7 @@
 }
 
 .backoffice-block-view > .govuk-accordion,
+.backoffice-block-view > .govuk-accordion__section,
 .backoffice-block-view > .govuk-caption-l,
 .backoffice-block-view:has(> .govuk-link),
 .backoffice-block-view:has(.govuk-textarea) {

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-box.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-box.ts
@@ -34,8 +34,6 @@ export class TprBoxView extends UmbElementMixin(LitElement) implements UmbBlockE
     }
 
     override render() {
-        console.log(this.blockType) 
-
         const cssClasses = this.settings?.styleOfBox === 'Bordered' ? ' tpr-box--bordered' : (this.settings?.backgroundColour.label === 'Blue' ? ' tpr-box--blue' : null);
         const isNestedBox = this.blockType?.contentElementTypeKey == "2e831668-9e36-44d9-95f4-de209f9a35d0";
 

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-documents.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-documents.ts
@@ -1,7 +1,8 @@
 import { html, customElement, LitElement, property, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { UmbMediaItemRepository } from '@umbraco-cms/backoffice/media';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT, UmbDocumentItemRepository } from '@umbraco-cms/backoffice/document';
 import { ILinkPickerModel } from '../types/ILinkPickerModel';
@@ -9,7 +10,7 @@ import { updateNodeName, createDocumentBlock, renderDocument } from '../helpers/
 import { ITprDocumentBlock } from '../types/ITprDocumentBlock';
 
 interface ITprDocumentsContent extends UmbBlockDataType {
-    documents: UmbBlockValueDataPropertiesBaseType;
+    documents: UmbBlockValueType<UmbBlockListLayoutModel>;
 }
 
 interface ITprDocumentsSettings extends UmbBlockDataType {
@@ -52,12 +53,13 @@ export class TprDocumentsView extends UmbElementMixin(LitElement) implements Umb
     override willUpdate(changedProperties: Map<string, any>) {
         // Called before render(). Convert block data into ITprDocumentBlock objects.
         if (changedProperties.has('content')) {
-            const docs = this.content?.documents?.contentData || [];
-            this.#documents = docs.map(doc => {
-                const docLink = (doc?.values.find(props => props.alias == "document")?.value as Array<ILinkPickerModel>)[0];
-                const datePublished = doc?.values.find(props => props.alias == "datePublished")?.value as string;
-                const numberOfPages = (doc?.values.find(props => props.alias == "numberOfPages")?.value as number);
-                const description = (doc?.values.find(props => props.alias == "description")?.value as string);
+            const docs = this.content?.documents?.layout[UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS] || [];
+            this.#documents = docs.map(layout => {
+                const doc = this.content?.documents?.contentData.find(item => item.key === layout.contentKey)!;
+                const docLink = (doc.values.find(props => props.alias == "document")?.value as Array<ILinkPickerModel>)[0];
+                const datePublished = doc.values.find(props => props.alias == "datePublished")?.value as string;
+                const numberOfPages = (doc.values.find(props => props.alias == "numberOfPages")?.value as number);
+                const description = (doc.values.find(props => props.alias == "description")?.value as string);
 
                 return createDocumentBlock(doc.key, docLink, datePublished, numberOfPages, description);
             });

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-featured-image.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-featured-image.ts
@@ -1,12 +1,13 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbMediaItemRepository, UmbMediaUrlRepository, UmbMediaItemModel, UmbMediaUrlModel, UmbMediaPickerPropertyValueEntry } from '@umbraco-cms/backoffice/media';
 
 interface ITprFeaturedImageContent extends UmbBlockDataType {
     image: Array<UmbMediaPickerPropertyValueEntry>;
-    blocks: UmbBlockValueDataPropertiesBaseType;
+    blocks: UmbBlockValueType<UmbBlockListLayoutModel>;
 }
 
 interface ITprFeaturedImageSettings extends UmbBlockDataType {

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-section-cards.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-section-cards.ts
@@ -1,9 +1,11 @@
 import { html, customElement, LitElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
-import type { UmbBlockDataType, UmbBlockValueDataPropertiesBaseType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
+
 interface ITprSectionCardsContent extends UmbBlockDataType {
-    cards: UmbBlockValueDataPropertiesBaseType;
+    cards: UmbBlockValueType<UmbBlockListLayoutModel>;
 }
 
 interface ITprSectionCardsSettings extends UmbBlockDataType {


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

All backoffice views have already been migrated to Umbraco 17, but this PR fixes a couple of issues with those views:

- I noticed that where a component has a child block list, the child blocks in the preview were sometimes rendered in the wrong order. It turns out this is because the blocks collection is ordered by the date the blocks were created, and the desired order is stored in a separate property. This PR uses that separate property to order the blocks correctly.
- If `govuk-!-display-none` CSS property was applied to a block (which is common in blocks that have JS enhancements) then it also hid the block in the preview, sometimes collapsing the preview to 0px high. This PR adds a style override that partially fades the block to indicate the presence of that class rather than hiding it entirely.

The new previews are built in the recommended stack for the new Umbraco backoffice, which is:
- TypeScript
- [Lit](https://lit.dev/) to make web components easier to build
- [Vite](https://vite.dev/) as a client-side build tool

To review this PR, as well as running the Umbraco example app in the normal way you'll also need to compile the backoffice views with the following commands:

```cmd
cd GovUk.Frontend.Umbraco\Backoffice
npm install
npm run build

cd ..\..\ThePensionsRegulator.Frontend.Umbraco\Backoffice
npm install
npm run build
```

This will compile the TypeScript, and then use Vite to publish the output under the `wwwroot/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco` folder.

## Out-of-scope for this PR

Everything else. 

Outside of the backoffice you can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- all blocks have a backoffice preview

Otherwise you can expect:
- build warnings
- TODO comments in code, and commented-out code for Smidge
- broken client-side features (ie JavaScript) because Smidge is gone
- elements of the Umbraco back office to be unusable (mainly rich text editing)
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Support for rich text editing in the Umbraco backoffice 
- Improved support for client-side assets following removal of Smidge between Umbraco 13 and 17
- Refactor MSBuild code to remove a lot of duplication and complexity
- Fixing the favicon bug we've been working around since the release of .NET 9
- Fix the unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating namespaces for greater clarity
- Modernising example apps and docs to support top-level statements in Program.cs
- Fix task list non-conformance issues
- Convert all remaining NUnit tests to XUnit
