### PR TITLE
In the rich text editor elements should all have GOV.UK style 

### DIFF
--- a/GovUk.Frontend.Umbraco/Styles/_backoffice-rich-text-formats.scss
+++ b/GovUk.Frontend.Umbraco/Styles/_backoffice-rich-text-formats.scss
@@ -43,7 +43,33 @@ h6.govuk-heading-s {
     position: static;
 }
 
-/**umb_name:Paragraph*/
-p.govuk-body {
-    position: static;
+/* Apply GOV.UK by default to elements in the rich text editor, even when GOV.UK classes are not yet applied. */
+p {
+    @extend .govuk-body;
+}
+
+ul {
+    @extend .govuk-list;
+    @extend .govuk-list--bullet;
+}
+
+ol {
+    @extend .govuk-list;
+    @extend .govuk-list--number;
+}
+
+table {
+    @extend .govuk-table;
+}
+
+caption {
+    @extend .govuk-table__caption;
+}
+
+th {
+    @extend .govuk-table__header;
+}
+
+td, td:last-child {
+    @extend .govuk-table__cell;
 }

--- a/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
+++ b/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
@@ -19,22 +19,6 @@ p.tpr-add-link {
     margin: 5px;
 }
 
-table {
-    @extend .govuk-table;
-}
-
-caption {
-    @extend .govuk-table__caption;
-}
-
-th {
-    @extend .govuk-table__header;
-}
-
-td, td:last-child {
-    @extend .govuk-table__cell;
-}
-
 // Box and nested box blocks
 .backoffice-block-header {
     display: block;


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

This PR is just a tweak to the rich text editor. Previously you could select 'Paragraph' from the dropdown styles list and it would apply the `.govuk-body` style in the editor itself. This led to paragraphs looking different depending on whether this had been done. 

<img width="1030" height="134" alt="Different paragraph styles" src="https://github.com/user-attachments/assets/c7935161-5c03-4828-816e-e95e9ae12b25" />

This affects only the editor itself, since an `IPropertyValueFormatter` implementation ensures that this class is always applied when the paragraph is rendered to the page.

This PR makes all paragraphs in the rich text editor look like `.govuk-body`, removing the inconsistency and making it a more accurate preview. If no other style is selected from the dropdown TinyMCE still shows 'Paragraph' as a default, but since the 'Paragraph' option in the dropdown serves no further purpose it is removed from the choices.

It also does a similar thing for lists, and moves a similar thing for tables up from TPR-only styles to GOV.UK styles. All now use GOV.UK styles in the editing view.

<img width="1047" height="278" alt="Paragraphs and lists" src="https://github.com/user-attachments/assets/4e7163cb-3447-4c5a-8688-ca044230a948" />


## How to review this PR

To review this PR, follow the [updated instructions for running the Umbraco example app](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/blob/develop/docs/umbraco/run-example-application.md). When following these steps, immediately after cloning the repo switch to the branch for this PR.

You should now be able to visit any rich text editor and test the change. 

## Out-of-scope for this PR

Everything else. 

You can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- the Umbraco backoffice works

Otherwise you can expect:
- build warnings
- TODO comments in code, and commented-out code for Smidge
- broken client-side features (ie JavaScript) because Smidge is gone
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Improved support for client-side assets following removal of Smidge between Umbraco 13 and 17
- Refactor MSBuild code to remove a lot of duplication and complexity
- Fixing the favicon bug we've been working around since the release of .NET 9
- Fix the unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating namespaces for greater clarity
- Modernising example apps and docs to support top-level statements in Program.cs
- Fix task list non-conformance issues
- Convert all remaining NUnit tests to XUnit

#535