### PR TITLE
Minify JS files packaged by this repo 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,6 +422,10 @@ govuk-frontend*.css
 govuk-frontend*.css.map
 tpr.css*
 
+# Minified JS files
+**/wwwroot/govuk/*.min.js
+**/wwwroot/tpr/*.min.js
+
 # Jest
 junit.xml
 cobertura-coverage.xml

--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -38,6 +38,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="FileSignatures" Version="5.0.2" />
 		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.4.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/BodyClosing.cshtml
@@ -1,4 +1,4 @@
 ﻿@using GovUk.Frontend.AspNetCore
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 <script src="/govuk-frontend.min.js?v=@GovUkFrontendInfo.Version" type="module"></script>
-<script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js" type="module" asp-append-version="true"></script>
+<script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.min.js" type="module" asp-append-version="true"></script>

--- a/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/Validation.cshtml
+++ b/GovUk.Frontend.AspNetCore.Extensions/Views/Shared/GOVUK/Validation.cshtml
@@ -1,5 +1,5 @@
 ﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/lib/jquery/dist/jquery.min.js" type="module" asp-append-version="true"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/lib/jquery-validation/dist/jquery.validate.min.js" type="module" asp-append-version="true"></script>
-<script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-validation.js" type="module" asp-append-version="true"></script>
+<script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-validation.min.js" type="module" asp-append-version="true"></script>
 <script src="/_content/ThePensionsRegulator.GovUk.Frontend/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js" type="module" asp-append-version="true"></script>

--- a/GovUk.Frontend.AspNetCore.Extensions/bundleconfig.json
+++ b/GovUk.Frontend.AspNetCore.Extensions/bundleconfig.json
@@ -1,0 +1,16 @@
+[
+  {
+    "outputFileName": "wwwroot/govuk/govuk-js-init.min.js",
+    "inputFiles": [
+      "wwwroot/govuk/govuk-js-init.js"
+    ],
+    "minify": { "enabled": true }
+  },
+  {
+    "outputFileName": "wwwroot/govuk/govuk-validation.min.js",
+    "inputFiles": [
+      "wwwroot/govuk/govuk-validation.js"
+    ],
+    "minify": { "enabled": true }
+  }
+]

--- a/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
+++ b/GovUk.Frontend.AspNetCore.Extensions/wwwroot/govuk/govuk-validation.js
@@ -511,7 +511,7 @@ function createGovUkValidator() {
     },
 
     // Ported from .NET Core code so that behaviour matches https://source.dot.net/#System.ComponentModel.Annotations/System/ComponentModel/DataAnnotations/PhoneAttribute.cs
-    validatePhone(value, element) {
+    validatePhone: function(value, element) {
       if (!value) {
         return true;
       }
@@ -615,7 +615,7 @@ function createGovUkValidator() {
     },
 
     // Custom range validator to handle numbers with commas in
-    validateRangeWithCommas(value, element, param) {
+    validateRangeWithCommas: function(value, element, param) {
       var commaFreeVal = Number(value.replace(/,/g, ""));
       if (!value) {
         return true;

--- a/GovUk.Frontend.ExampleApp/Views/SearchResults/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/SearchResults/Index.cshtml
@@ -3,7 +3,7 @@
 @model TextInputViewModel
 
 @section scripts {
-    <script src="_Content/ThePensionsRegulator.Frontend/tpr/tpr-search-results.js" type="module" asp-append-version="true"></script>
+    <script src="_Content/ThePensionsRegulator.Frontend/tpr/tpr-search-results.min.js" type="module" asp-append-version="true"></script>
 }
 
 @{

--- a/GovUk.Frontend.ExampleApp/wwwroot/scripts/custom-validation.js
+++ b/GovUk.Frontend.ExampleApp/wwwroot/scripts/custom-validation.js
@@ -1,4 +1,4 @@
-import { govuk } from "../_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-validation.js";
+import { govuk } from "../_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-validation.min.js";
 
 const validator = govuk().getValidator();
 govuk().createErrorSummary();

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/SearchResults.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/SearchResults.cshtml
@@ -7,7 +7,7 @@
 }
 
 @section scripts {
-    <script src="/_Content/ThePensionsRegulator.Frontend/tpr/tpr-search-results.js" type="module" asp-append-version="true"></script>
+    <script src="/_Content/ThePensionsRegulator.Frontend/tpr/tpr-search-results.min.js" type="module" asp-append-version="true"></script>
 }
 
 <partial name="GOVUK/BlockGrid" model="Model.Blocks" />

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -30,6 +30,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.4.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />

--- a/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
@@ -52,3 +52,5 @@
         </ul>
     }
 }
+
+<script src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-side-navigation.js" type="module" asp-append-version="true"></script>

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
@@ -1,7 +1,3 @@
-﻿@using GovUk.Frontend.AspNetCore
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-<script src="/govuk-frontend.min.js?v=@GovUkFrontendInfo.Version" type="module"></script>
-<script src="/_content/ThePensionsRegulator.GovUk.Frontend/govuk/govuk-js-init.js" type="module" asp-append-version="true"></script>
-<script src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.js" type="module" asp-append-version="true"></script>
-<script src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-side-navigation.js" type="module" asp-append-version="true"></script>
-<script src="/_content/ThePensionsRegulator.Frontend/tpr/headermenu.js" type="module" asp-append-version="true"></script>
+﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+<partial name="GOVUK/BodyClosing" />
+<script src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-back-to-top.min.js" type="module" asp-append-version="true"></script>

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRAutocomplete.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRAutocomplete.cshtml
@@ -1,3 +1,3 @@
 ﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-<script src="/_content/ThePensionsRegulator.Frontend/tpr/autocomplete.js" type="module" asp-append-version="true"></script>
+<script src="/_content/ThePensionsRegulator.Frontend/tpr/autocomplete.min.js" type="module" asp-append-version="true"></script>
 <script src="/_content/ThePensionsRegulator.Frontend/tpr/lib/accessible-autocomplete.min.js" type="module" asp-append-version="true"></script>

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRHeaderMenu.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRHeaderMenu.cshtml
@@ -1,4 +1,4 @@
 ﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-<script src="/_content/ThePensionsRegulator.Frontend/tpr/headermenu.js" type="module" asp-append-version="true"></script>
+<script src="/_content/ThePensionsRegulator.Frontend/tpr/headermenu.min.js" type="module" asp-append-version="true"></script>
 
 

--- a/ThePensionsRegulator.Frontend/bundleconfig.json
+++ b/ThePensionsRegulator.Frontend/bundleconfig.json
@@ -1,0 +1,37 @@
+[
+  {
+    "outputFileName": "wwwroot/tpr/autocomplete.min.js",
+    "inputFiles": [
+      "wwwroot/tpr/autocomplete.js"
+    ],
+    "minify": { "enabled": true }
+  },
+  {
+    "outputFileName": "wwwroot/tpr/headermenu.min.js",
+    "inputFiles": [
+      "wwwroot/tpr/headermenu.js"
+    ],
+    "minify": { "enabled": true }
+  },
+  {
+    "outputFileName": "wwwroot/tpr/tpr-back-to-top.min.js",
+    "inputFiles": [
+      "wwwroot/tpr/tpr-back-to-top.js"
+    ],
+    "minify": { "enabled": true }
+  },
+  {
+    "outputFileName": "wwwroot/tpr/tpr-search-results.min.js",
+    "inputFiles": [
+      "wwwroot/tpr/tpr-search-results.js"
+    ],
+    "minify": { "enabled": true }
+  },
+  {
+    "outputFileName": "wwwroot/tpr/tpr-side-navigation.min.js",
+    "inputFiles": [
+      "wwwroot/tpr/tpr-side-navigation.js"
+    ],
+    "minify": { "enabled": true }
+  }
+]

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -22,7 +22,7 @@ document.addEventListener("DOMContentLoaded", function () {
             toggles.forEach(t => t.addEventListener("click", toggleMobileMenu));
             toggles.forEach(t => t.addEventListener("keydown", keyboardToggleMobileMenu));
 
-            overlay.forEach(o => o.addEventListener("click", toggleMobileMenu));
+            if (overlay) { overlay.forEach(o => o.addEventListener("click", toggleMobileMenu)); }
 
             arrows.forEach(a => a.addEventListener("click", expandMobileMenuSubMenu))
 
@@ -40,7 +40,8 @@ document.addEventListener("DOMContentLoaded", function () {
             });
         } else {
 
-            overlay?.forEach(o => o.classList.remove("tpr-header-menu__nav-overlay--visible"));
+            if (overlay) { overlay.forEach(o => o.classList.remove("tpr-header-menu__nav-overlay--visible")); }
+
             toggles.forEach(t => t.removeEventListener("click", toggleMobileMenu))
             overlay.forEach(o => o.removeEventListener("click", toggleMobileMenu));
             nav.addEventListener("focusin", restoreDefaultMenuState);
@@ -114,7 +115,7 @@ function displayDesktopOverlayOnHover() {
 
             ["mouseenter"].forEach((evt) =>
                 item.addEventListener(evt, () => {
-                    overlay?.classList.add("tpr-header-menu__nav-overlay--visible");
+                    if (overlay) { overlay.classList.add("tpr-header-menu__nav-overlay--visible"); }
                     if (window.innerWidth > 993) {
                         subMenu.style.display = 'grid';
 
@@ -125,7 +126,7 @@ function displayDesktopOverlayOnHover() {
             );
             ["mouseleave"].forEach((evt) =>
                 item.addEventListener(evt, () => {
-                    overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+                    if (overlay) { overlay.classList.remove("tpr-header-menu__nav-overlay--visible"); }
                     if (window.innerWidth > 993) {
                         subMenu.style.display = 'none';
 
@@ -174,20 +175,22 @@ function desktopKeyboardNavigation(e) {
     switch (e.key) {
         case "ArrowRight":
             e.preventDefault();
-            menuItems[(currentIndex + 1) % menuItems.length].querySelector('a')?.focus();
+            const rightLink = menuItems[(currentIndex + 1) % menuItems.length].querySelector('a');
+            if (rightLink) { rightLink.focus(); }
             if (hasSubMenu) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
-                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+                if (overlay) { overlay.classList.remove("tpr-header-menu__nav-overlay--visible"); }
             }
             break;
         case "ArrowLeft":
             e.preventDefault();
-            menuItems[(currentIndex - 1 + menuItems.length) % menuItems.length].querySelector('a')?.focus();
+            const leftLink = menuItems[(currentIndex - 1 + menuItems.length) % menuItems.length].querySelector('a');
+            if (leftLink) { leftLink.focus(); }
             if (hasSubMenu) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
-                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+                if (overlay) { overlay.classList.remove("tpr-header-menu__nav-overlay--visible"); }
             }
             break;
         case "ArrowUp":
@@ -196,7 +199,7 @@ function desktopKeyboardNavigation(e) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
                 a.focus();
-                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+                if (overlay) { overlay.classList.remove("tpr-header-menu__nav-overlay--visible"); }
             }
             break;
         case "ArrowDown":
@@ -205,14 +208,14 @@ function desktopKeyboardNavigation(e) {
                 subMenu.style.display = 'grid';
                 a.setAttribute("aria-expanded", "true");
                 subMenu.querySelector(".tpr-header-menu__nav-sub-menu-item").removeAttribute("style");
-                overlay?.classList.add("tpr-header-menu__nav-overlay--visible");
+                if (overlay) { overlay.classList.add("tpr-header-menu__nav-overlay--visible"); }
             }
             break;
         case "Escape":
             if (hasSubMenu) {
                 subMenu.style.display = 'none';
                 a.setAttribute("aria-expanded", "false");
-                overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+                if (overlay) { overlay.classList.remove("tpr-header-menu__nav-overlay--visible"); }
                 a.focus();
             }
             break;
@@ -223,7 +226,7 @@ function desktopKeyboardNavigation(e) {
                 const activeElement = document.activeElement;
 
                 if (!nav.contains(activeElement)) {
-                    overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+                    if (overlay) { overlay.classList.remove("tpr-header-menu__nav-overlay--visible"); }
 
                     document.querySelectorAll(".tpr-header-menu__nav-sub-menu").forEach(s => s.style.display = "none");
 
@@ -255,16 +258,16 @@ function restoreDefaultMenuState(e) {
         if (item !== newlyFocusedItem) {
             if (sub) {
                 sub.style.display = "none";
-                a?.setAttribute("aria-expanded", "false");
+                if (a) { a.setAttribute("aria-expanded", "false"); }
             }
         }
 
         const focusedTopLevelItem = newlyFocusedItem.querySelector("a");
         if (e.target === focusedTopLevelItem) {
-            overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
+            if (overlay) { overlay.classList.remove("tpr-header-menu__nav-overlay--visible"); }
             if (sub) {
                 sub.style.display = "none";
-                a?.setAttribute("aria-expanded", "false");
+                if (a) { a.setAttribute("aria-expanded", "false"); }
             }
         }
     });
@@ -276,7 +279,7 @@ function toggleMobileMenu() {
     toggle.classList.toggle("tpr-mobile-menu__toggle--open");
 
     const svg = document.querySelector(".tpr-mobile-menu__svg");
-    svg?.classList.toggle("tpr-mobile-menu__svg--hide");
+    if (svg) { svg.classList.toggle("tpr-mobile-menu__svg--hide"); }
 
     const button = document.querySelector(".tpr-header-menu__button");
     if (button) {
@@ -319,11 +322,12 @@ function mobileKeyboardNavigation(e) {
 
         const menuItem = e.currentTarget;
         const subMenu = menuItem.querySelector(".tpr-header-menu__nav-sub-menu");
-        subMenu.removeAttribute("style");
-
+        if (subMenu) {
+            subMenu.removeAttribute("style");      
+            subMenu.classList.toggle("tpr-header-menu__nav-sub-menu--active");
+        }
+        
         const arrow = menuItem.querySelector(".tpr-mobile-menu__arrow");
-
-        subMenu?.classList.toggle("tpr-header-menu__nav-sub-menu--active");
         arrow.classList.toggle("tpr-mobile-menu__arrow-down");
 
         const a = menuItem.querySelector("a");

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
@@ -12,459 +12,460 @@ const SHOW_MORE_QUERY_PARAM = "showMore";
 const INITIAL_VISIBLE_RESULTS = 2;
 
 function getSearchInput() {
-    return document.getElementById("tpr-search-results-ask-input");
+   return document.getElementById("tpr-search-results-ask-input");
 }
 
 function getSearchResultsText() {
-    return document.getElementById("tpr-search-results-text");
+   return document.getElementById("tpr-search-results-text");
 }
 
 function hideSearchResultsText(hideText) {
-    const searchResultsText = getSearchResultsText();
-    if (searchResultsText != null) {
-        if (hideText) {
-            searchResultsText.classList.add('govuk-visually-hidden');
-        }
-        else {
-            searchResultsText.classList.remove('govuk-visually-hidden');
-        }
-    }
+   const searchResultsText = getSearchResultsText();
+   if (searchResultsText != null) {
+       if (hideText) {
+           searchResultsText.classList.add('govuk-visually-hidden');
+       }
+       else {
+           searchResultsText.classList.remove('govuk-visually-hidden');
+       }
+   }
 }
 
 function setSearchResultsText(resultsTextContent) {
-    const searchResultsText = getSearchResultsText();
-    if (searchResultsText != null) {
-        searchResultsText.innerHTML = resultsTextContent;
-        hideSearchResultsText(false);
-    }
+   const searchResultsText = getSearchResultsText();
+   if (searchResultsText != null) {
+       searchResultsText.innerHTML = resultsTextContent;
+       hideSearchResultsText(false);
+   }
 }
 
 function sanitizeString(input) {
-    if (!input || typeof input !== 'string' || input.trim() === '') {
-        return '';
-    }
+   if (!input || typeof input !== 'string' || input.trim() === '') {
+       return '';
+   }
 
-    const trimmedInput = input.trim();
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(trimmedInput, 'text/html');
-    return (doc.body.textContent || '').trim();
+   const trimmedInput = input.trim();
+   const parser = new DOMParser();
+   const doc = parser.parseFromString(trimmedInput, 'text/html');
+   return (doc.body.textContent || '').trim();
 }
 
 function resetSearchInput(){
-    const searchInput = getSearchInput();
-    if (searchInput != null) {
-        searchInput.value = '';
-    }
+   const searchInput = getSearchInput();
+   if (searchInput != null) {
+       searchInput.value = '';
+   }
 }
 
 function getShowMoreQuestionsButton() {
-    return document.getElementById("tpr-search-results-show-more-questions");
+   return document.getElementById("tpr-search-results-show-more-questions");
 }
 
 async function fetchJson(url) {
-    const response = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
-    return response.json();
+   const response = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
+   return response.json();
 }
 
 async function fetchContentById(contentId) {
-    try {
-        const url = `${getContentByIdApiUrl}/${contentId}`;
-        return await fetchJson(url);
-    } catch (error) {
-        console.error("Failed to fetch content by ID:", error);
-        return null;
-    }
+   try {
+       const url = `${getContentByIdApiUrl}/${contentId}`;
+       return await fetchJson(url);
+   } catch (error) {
+       console.error("Failed to fetch content by ID:", error);
+       return null;
+   }
 }
 
 async function initialiseAccordion() {
-    let results = [];
-    let queryStringSearchTerm = getSearchTermQueryString(SEARCH_TERM_QUERY_PARAM);
-    let queryStringShowMore = getSearchTermQueryString(SHOW_MORE_QUERY_PARAM);
+   let results = [];
+   let queryStringSearchTerm = getSearchTermQueryString(SEARCH_TERM_QUERY_PARAM);
+   let queryStringShowMore = getSearchTermQueryString(SHOW_MORE_QUERY_PARAM);
 
-    searchResults = [];
+   searchResults = [];
 
-    resetShowMoreAnswersButton();
-    showErrorTextVisibility(false);
+   resetShowMoreAnswersButton();
+   showErrorTextVisibility(false);
 
-    if (queryStringShowMore) {
-        showMoreQuestions = queryStringShowMore.toLowerCase() === 'true';
-    }
+   if (queryStringShowMore) {
+       showMoreQuestions = queryStringShowMore.toLowerCase() === 'true';
+   }
 
-    if(queryStringSearchTerm)
-    {
-        await searchWithTerm(queryStringSearchTerm);        
-        return;
-    }
+   if(queryStringSearchTerm)
+   {
+       await searchWithTerm(queryStringSearchTerm);        
+       return;
+   }
 
-    try {
-        results = await fetchJson(`${popularContentApiUrl}`);
-    } catch (error) {
-        console.error("Failed to fetch most popular content:", error);
-    }
+   try {
+       results = await fetchJson(`${popularContentApiUrl}`);
+   } catch (error) {
+       console.error("Failed to fetch most popular content:", error);
+   }
 
-    results = results || [];
+   results = results || [];
 
-    if (results.length === 0) {
-        createNoResultsFoundHeading();
+   if (results.length === 0) {
+       createNoResultsFoundHeading();
         
-    } else {
-        searchResults = results;
+   } else {
+       searchResults = results;
         
-        await displayResults();
-    }
+       await displayResults();
+   }
 }
 
 async function searchWithTerm(searchValue) {
-    searchValue = sanitizeString(searchValue?.trim()) || '';
+    searchValue = (searchValue || '').trim();
+    searchValue = sanitizeString(searchValue) ;
 
-    showErrorTextVisibility(false);
-    hideShowMoreQuestionsButton(true);
+   showErrorTextVisibility(false);
+   hideShowMoreQuestionsButton(true);
 
-    if (searchValue.length < 2) {
-        setErrorText('Your question must be 2 characters or more.', searchValue);
-        return;
-    }
+   if (searchValue.length < 2) {
+       setErrorText('Your question must be 2 characters or more.', searchValue);
+       return;
+   }
 
-    if (!searchValue || searchValue.trim() === '') {
-        resetSearchInput();
-        navigateToSearchInput(false);
-        showErrorTextVisibility(true);
-        return;
-    }
+   if (!searchValue || searchValue.trim() === '') {
+       resetSearchInput();
+       navigateToSearchInput(false);
+       showErrorTextVisibility(true);
+       return;
+   }
 
-    setSearchTermQueryString(SEARCH_TERM_QUERY_PARAM, searchValue);
+   setSearchTermQueryString(SEARCH_TERM_QUERY_PARAM, searchValue);
 
-    let searchUrl = new URL(searchContentApiUrl, window.location.origin);
-    searchUrl.searchParams.set(SEARCH_TERM_QUERY_PARAM, searchValue);
+   let searchUrl = new URL(searchContentApiUrl, window.location.origin);
+   searchUrl.searchParams.set(SEARCH_TERM_QUERY_PARAM, searchValue);
 
-    let jsonResults = [];
+   let jsonResults = [];
 
-    try {
-        jsonResults = await fetchJson(searchUrl.toString());
-    } catch (error) {
-        console.error("Failed to search content:", error);
-    }
+   try {
+       jsonResults = await fetchJson(searchUrl.toString());
+   } catch (error) {
+       console.error("Failed to search content:", error);
+   }
 
-    const results = jsonResults.results || [];
+   const results = jsonResults.results || [];
 
-    removeAccordion("search-results-accordion");
+   removeAccordion("search-results-accordion");
 
-    if (results.length === 0) {
-        setSearchResultsText(`Your search for <strong>'${searchValue}'</strong> returned no results.`);
-    } else {
-        removeNoResultsFound();
+   if (results.length === 0) {
+       setSearchResultsText(`Your search for <strong>'${searchValue}'</strong> returned no results.`);
+   } else {
+       removeNoResultsFound();
 
-        setSearchResultsText(`Your search for <strong>'${searchValue}'</strong> returned these results:`);
+       setSearchResultsText(`Your search for <strong>'${searchValue}'</strong> returned these results:`);
 
-        searchResults = await Promise.all(
-            results.map(async (result) => {
-                return await fetchContentById(result.key);
-            })
-        );
+       searchResults = await Promise.all(
+           results.map(async (result) => {
+               return await fetchContentById(result.key);
+           })
+       );
 
-        await displayResults();
-    }
+       await displayResults();
+   }
 }
 
 async function displayResults()
 {
-    const accordionSections = [];
+   const accordionSections = [];
 
-    let showNow = [];
+   let showNow = [];
 
-    if (showMoreQuestions === false) {
-        showNow = searchResults.slice(0, INITIAL_VISIBLE_RESULTS);
-    }
-    else
-    {
-        showNow = searchResults;
-    }
+   if (showMoreQuestions === false) {
+       showNow = searchResults.slice(0, INITIAL_VISIBLE_RESULTS);
+   }
+   else
+   {
+       showNow = searchResults;
+   }
 
-    showNow.forEach(result => {
-        let section = createAccordionSection(result.name, result.pageContent, result.key);
-        accordionSections.push(section)
-    });
+   showNow.forEach(result => {
+       let section = createAccordionSection(result.name, result.pageContent, result.key);
+       accordionSections.push(section)
+   });
 
-    await createAccordion(accordionSections);
-    await updateShowMoreButton();
+   await createAccordion(accordionSections);
+   await updateShowMoreButton();
 }
 
 function removeAccordion(id) {
-    const accordion = document.getElementById(id);
+   const accordion = document.getElementById(id);
 
-    if (accordion != null) {
-        accordion.remove();
-    }
+   if (accordion != null) {
+       accordion.remove();
+   }
 }
 
 async function createAccordion(accordionSections) {
-    const newAccordion = createElementWithClassName("div", "govuk-accordion");
-    newAccordion.setAttribute("id", "search-results-accordion");
-    newAccordion.setAttribute("data-module", "govuk-accordion");
+   const newAccordion = createElementWithClassName("div", "govuk-accordion");
+   newAccordion.setAttribute("id", "search-results-accordion");
+   newAccordion.setAttribute("data-module", "govuk-accordion");
 
-    accordionSections.forEach((accordionSection) => { newAccordion.appendChild(accordionSection); });
+   accordionSections.forEach((accordionSection) => { newAccordion.appendChild(accordionSection); });
 
-    new Accordion(newAccordion);
+   new Accordion(newAccordion);
 
-    const searchBlock = document.getElementsByClassName("tpr-search-results__form")[0];
-    searchBlock.after(newAccordion);
+   const searchBlock = document.getElementsByClassName("tpr-search-results__form")[0];
+   searchBlock.after(newAccordion);
 }
 
 function createAccordionSection(heading, content, index) {
-    const accordionSection = createElementWithClassName("div", "govuk-accordion__section");
+   const accordionSection = createElementWithClassName("div", "govuk-accordion__section");
 
-    const accordionHeader = createElementWithClassName("div", "govuk-accordion__section-header");
-    const accordionHeadingElement = createElementWithClassName(`h${newHeadingLevel}`, "govuk-accordion__section-heading");
+   const accordionHeader = createElementWithClassName("div", "govuk-accordion__section-header");
+   const accordionHeadingElement = createElementWithClassName(`h${newHeadingLevel}`, "govuk-accordion__section-heading");
 
-    const accordionHeadingElementText = document.createTextNode(heading);
+   const accordionHeadingElementText = document.createTextNode(heading);
 
-    const accordionHeadingButtonElement = createElementWithClassName("span", "govuk-accordion__section-button");
-    accordionHeadingButtonElement.setAttribute("id", `accordion-heading-${index}`);
-    accordionHeadingButtonElement.appendChild(accordionHeadingElementText);
+   const accordionHeadingButtonElement = createElementWithClassName("span", "govuk-accordion__section-button");
+   accordionHeadingButtonElement.setAttribute("id", `accordion-heading-${index}`);
+   accordionHeadingButtonElement.appendChild(accordionHeadingElementText);
 
-    accordionHeadingElement.appendChild(accordionHeadingButtonElement);
-    accordionHeader.appendChild(accordionHeadingElement);
+   accordionHeadingElement.appendChild(accordionHeadingButtonElement);
+   accordionHeader.appendChild(accordionHeadingElement);
 
-    const accordionContent = document.createElement("div");
-    accordionContent.className = "govuk-accordion__section-content";
-    accordionContent.innerHTML = content;
+   const accordionContent = document.createElement("div");
+   accordionContent.className = "govuk-accordion__section-content";
+   accordionContent.innerHTML = content;
 
-    accordionSection.appendChild(accordionHeader);
-    accordionSection.appendChild(accordionContent);
+   accordionSection.appendChild(accordionHeader);
+   accordionSection.appendChild(accordionContent);
 
-    return accordionSection;
+   return accordionSection;
 }
 
 function showErrorTextVisibility(showErrorText, errorTextContent = '') {
-    const errorText = document.getElementById("tpr-search-results-error-text");
-    const formGroup = document.querySelector('.tpr-search-results__form .govuk-form-group');
-    const searchInput = getSearchInput();
+   const errorText = document.getElementById("tpr-search-results-error-text");
+   const formGroup = document.querySelector('.tpr-search-results__form .govuk-form-group');
+   const searchInput = getSearchInput();
 
-    if (errorText != null && searchInput != null && formGroup != null) {
-        if (showErrorText) {
-            errorText.classList.remove("govuk-visually-hidden");
-            errorText.textContent = errorTextContent;
-            searchInput.classList.add("govuk-input--error");
-            formGroup.classList.add("govuk-form-group--error");
-        } else {
-            errorText.classList.add("govuk-visually-hidden");
-            searchInput.classList.remove("govuk-input--error");
-            formGroup.classList.remove("govuk-form-group--error");
-        }
-    }
+   if (errorText != null && searchInput != null && formGroup != null) {
+       if (showErrorText) {
+           errorText.classList.remove("govuk-visually-hidden");
+           errorText.textContent = errorTextContent;
+           searchInput.classList.add("govuk-input--error");
+           formGroup.classList.add("govuk-form-group--error");
+       } else {
+           errorText.classList.add("govuk-visually-hidden");
+           searchInput.classList.remove("govuk-input--error");
+           formGroup.classList.remove("govuk-form-group--error");
+       }
+   }
 }
 
 function setErrorText(errorMessage, value = '') {
-    const searchInput = getSearchInput();
-    searchInput.value = value;
-    navigateToSearchInput(false);
-    showErrorTextVisibility(true, errorMessage);
+   const searchInput = getSearchInput();
+   searchInput.value = value;
+   navigateToSearchInput(false);
+   showErrorTextVisibility(true, errorMessage);
 }
 
 async function searchButtonOnClick(event) {
-    event.preventDefault();
+   event.preventDefault();
 
-    const searchInput = getSearchInput();
-    if (searchInput == null) {
-        return;
-    }
+   const searchInput = getSearchInput();
+   if (searchInput == null) {
+       return;
+   }
 
-    const searchValue = searchInput.value?.trim() || '';
-    if (!searchValue) {
-        setErrorText('Please enter a question or phrase.');
-        return;
-    }
+   const searchValue = (searchInput.value || '').trim();
+   if (!searchValue) {
+       setErrorText('Please enter a question or phrase.');
+       return;
+   }
 
-    await searchWithTerm(searchValue);
+   await searchWithTerm(searchValue);
 }
 
 async function resetButtonOnClick() {
-    resetSearchInput();
-    removeAccordion("search-results-accordion");
-    setSearchTermQueryString(SEARCH_TERM_QUERY_PARAM, undefined);
-    setSearchTermQueryString(SHOW_MORE_QUERY_PARAM, undefined);
-    await initialiseAccordion();
-    hideSearchResultsText(true);
-    navigateToSearchInput(false);
+   resetSearchInput();
+   removeAccordion("search-results-accordion");
+   setSearchTermQueryString(SEARCH_TERM_QUERY_PARAM, undefined);
+   setSearchTermQueryString(SHOW_MORE_QUERY_PARAM, undefined);
+   await initialiseAccordion();
+   hideSearchResultsText(true);
+   navigateToSearchInput(false);
 }
 
 async function resetShowMoreAnswersButton() {
-    showMoreQuestions = false;
-    hideShowMoreQuestionsButton(false);
-    const showMoreButton = getShowMoreQuestionsButton();
-    if (showMoreButton != null) {
-        showMoreButton.textContent = 'Show more questions';
-    }
+   showMoreQuestions = false;
+   hideShowMoreQuestionsButton(false);
+   const showMoreButton = getShowMoreQuestionsButton();
+   if (showMoreButton != null) {
+       showMoreButton.textContent = 'Show more questions';
+   }
 }
 
 async function showMoreAnswersOnClick() {
-    removeAccordion("search-results-accordion");
+   removeAccordion("search-results-accordion");
 
-    if (showMoreQuestions === false) {
-        showMoreQuestions = true;
-        setSearchTermQueryString(SHOW_MORE_QUERY_PARAM,true);
-    }
-    else {
-        showMoreQuestions = false;
-        setSearchTermQueryString(SHOW_MORE_QUERY_PARAM,undefined);
-    }
-    updateShowMoreButton()
-    await displayResults();
+   if (showMoreQuestions === false) {
+       showMoreQuestions = true;
+       setSearchTermQueryString(SHOW_MORE_QUERY_PARAM,true);
+   }
+   else {
+       showMoreQuestions = false;
+       setSearchTermQueryString(SHOW_MORE_QUERY_PARAM,undefined);
+   }
+   updateShowMoreButton()
+   await displayResults();
 }
 
 async function updateShowMoreButton(){
 
-    if(searchResults.length <= INITIAL_VISIBLE_RESULTS)
-    {
-        hideShowMoreQuestionsButton(true);
-        return;
-    }
-    else
-    {
-        hideShowMoreQuestionsButton(false);
-        const showMoreButton = getShowMoreQuestionsButton();
-        if (showMoreQuestions === false) {
-            if (showMoreButton) showMoreButton.textContent = 'Show more questions';
-        }
-        else {
-            if (showMoreButton) showMoreButton.textContent = 'Show fewer questions';
-        }
-    }
+   if(searchResults.length <= INITIAL_VISIBLE_RESULTS)
+   {
+       hideShowMoreQuestionsButton(true);
+       return;
+   }
+   else
+   {
+       hideShowMoreQuestionsButton(false);
+       const showMoreButton = getShowMoreQuestionsButton();
+       if (showMoreQuestions === false) {
+           if (showMoreButton) showMoreButton.textContent = 'Show more questions';
+       }
+       else {
+           if (showMoreButton) showMoreButton.textContent = 'Show fewer questions';
+       }
+   }
 }
 
 function createElementWithClassName(elementName, className) {
-    const element = document.createElement(elementName);
-    element.className = className;
+   const element = document.createElement(elementName);
+   element.className = className;
 
-    return element;
+   return element;
 }
 
 function createNoResultsFoundHeading() {
-    const existingHeading = document.getElementsByClassName('tpr-search-results__no-results-found')[0];
-    if (existingHeading == null) {
-        const noResultsHeading = document.createElement(`h${newHeadingLevel}`);
-        noResultsHeading.className = "govuk-heading-m tpr-search-results__no-results-found";
-        noResultsHeading.textContent = "No results found";
+   const existingHeading = document.getElementsByClassName('tpr-search-results__no-results-found')[0];
+   if (existingHeading == null) {
+       const noResultsHeading = document.createElement(`h${newHeadingLevel}`);
+       noResultsHeading.className = "govuk-heading-m tpr-search-results__no-results-found";
+       noResultsHeading.textContent = "No results found";
 
-        const searchBlock = document.getElementsByClassName("tpr-search-results__form")[0];
-        searchBlock.after(noResultsHeading);
-    }
+       const searchBlock = document.getElementsByClassName("tpr-search-results__form")[0];
+       searchBlock.after(noResultsHeading);
+   }
 
-    hideShowMoreQuestionsButton(true);
+   hideShowMoreQuestionsButton(true);
 }
 
 function hideShowMoreQuestionsButton(hideButton) {
-    const showMoreButton = getShowMoreQuestionsButton();
-    if (showMoreButton != null) {
-        if (hideButton) {
-            showMoreButton.classList.add('govuk-visually-hidden');
-        }
-        else {
-            showMoreButton.classList.remove('govuk-visually-hidden');
-        }
-    }
+   const showMoreButton = getShowMoreQuestionsButton();
+   if (showMoreButton != null) {
+       if (hideButton) {
+           showMoreButton.classList.add('govuk-visually-hidden');
+       }
+       else {
+           showMoreButton.classList.remove('govuk-visually-hidden');
+       }
+   }
 }
 
 function removeNoResultsFound() {
-    const element = document.getElementsByClassName('tpr-search-results__no-results-found')[0];
-    if (element != null) {
-        element.remove();
-    }
+   const element = document.getElementsByClassName('tpr-search-results__no-results-found')[0];
+   if (element != null) {
+       element.remove();
+   }
 }
 
 function setSearchResults(toSet) {
-    searchResults = toSet;
+   searchResults = toSet;
 }
 
 function navigateToSearchButtonOnClick(event) {
-    navigateToSearchInput(true);
-    event.preventDefault();
+   navigateToSearchInput(true);
+   event.preventDefault();
 }
 
 function navigateToSearchInput(scrollIntoView) {
-    const searchInput = getSearchInput();
-    if (searchInput != null) {
-        if (scrollIntoView === true) {
-            searchInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-        searchInput.focus({ preventScroll: true });
-    }
+   const searchInput = getSearchInput();
+   if (searchInput != null) {
+       if (scrollIntoView === true) {
+           searchInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+       }
+       searchInput.focus({ preventScroll: true });
+   }
 }
 
 function setSearchTermQueryString(key,value) {
-    const url = new URL(window.location.href); // Get the current URL
-    const params = url.searchParams; // Access query parameters
+   const url = new URL(window.location.href); // Get the current URL
+   const params = url.searchParams; // Access query parameters
 
-    if(value)
-    {
-        params.set(key, value); // Add or update the search parameter
-    }
-    else
-    {
-        params.delete(key); // Remove the search parameter
-    }
+   if(value)
+   {
+       params.set(key, value); // Add or update the search parameter
+   }
+   else
+   {
+       params.delete(key); // Remove the search parameter
+   }
 
-    if(params.size > 0)
-    {
-        window.history.replaceState({}, '', `${url.pathname}?${params.toString()}`); // Update the URL without reloading
-    }
-    else
-    {
-        window.history.replaceState({}, '', url.pathname); // Update the URL without reloading
-    }
+   if(params.size > 0)
+   {
+       window.history.replaceState({}, '', `${url.pathname}?${params.toString()}`); // Update the URL without reloading
+   }
+   else
+   {
+       window.history.replaceState({}, '', url.pathname); // Update the URL without reloading
+   }
 }
 
 function getSearchTermQueryString(key) {
-    const url = new URL(window.location.href); // Get the current URL
-    const params = url.searchParams; // Access query parameters
+   const url = new URL(window.location.href); // Get the current URL
+   const params = url.searchParams; // Access query parameters
 
-    return params.get(key);
+   return params.get(key);
 }
 
 document.addEventListener("DOMContentLoaded", function () {
-    const searchButton = document.getElementById("tpr-search-results-ask-button");
-    const resetButton = document.getElementById("tpr-search-results-reset-button");
-    const showMoreButton = getShowMoreQuestionsButton();
+   const searchButton = document.getElementById("tpr-search-results-ask-button");
+   const resetButton = document.getElementById("tpr-search-results-reset-button");
+   const showMoreButton = getShowMoreQuestionsButton();
 
-    if (searchButton == null || showMoreButton == null) {
-        return;
-    }
+   if (searchButton == null || showMoreButton == null) {
+       return;
+   }
 
-    searchButton.addEventListener("click", searchButtonOnClick);
-    resetButton.addEventListener("click", resetButtonOnClick);
-    showMoreButton.addEventListener("click", showMoreAnswersOnClick);
+   searchButton.addEventListener("click", searchButtonOnClick);
+   resetButton.addEventListener("click", resetButtonOnClick);
+   showMoreButton.addEventListener("click", showMoreAnswersOnClick);
 
-    const searchAside = document.getElementsByClassName("tpr-search-results")[0];
-    popularContentApiUrl = searchAside.getAttribute("data-popular-content-url");
-    searchContentApiUrl = searchAside.getAttribute("data-search-content-url");
-    getContentByIdApiUrl = searchAside.getAttribute("data-content-by-id-url");
+   const searchAside = document.getElementsByClassName("tpr-search-results")[0];
+   popularContentApiUrl = searchAside.getAttribute("data-popular-content-url");
+   searchContentApiUrl = searchAside.getAttribute("data-search-content-url");
+   getContentByIdApiUrl = searchAside.getAttribute("data-content-by-id-url");
 
-    const searchResultsSection = document.getElementsByClassName("tpr-search-results__heading")[0];
-    const headingLevel = searchResultsSection.tagName.toLowerCase();
-    const headingLevelNumber = parseInt(headingLevel.replace('h', ''));
+   const searchResultsSection = document.getElementsByClassName("tpr-search-results__heading")[0];
+   const headingLevel = searchResultsSection.tagName.toLowerCase();
+   const headingLevelNumber = parseInt(headingLevel.replace('h', ''));
 
-    if (headingLevelNumber >= 6) {
-        newHeadingLevel = 6;
-    }
-    else {
-        newHeadingLevel = headingLevelNumber + 1;
-    }
+   if (headingLevelNumber >= 6) {
+       newHeadingLevel = 6;
+   }
+   else {
+       newHeadingLevel = headingLevelNumber + 1;
+   }
 
-    initialiseAccordion();
+   initialiseAccordion();
 
-    const navigateToSearchButton = document.getElementsByClassName("tpr-search-results__nav-button")[0];
-    if (navigateToSearchButton != null) {
-        const newTabSpan = navigateToSearchButton.querySelector("span.govuk-visually-hidden");
-        if (newTabSpan) {
-            newTabSpan.remove();
-        }
+   const navigateToSearchButton = document.getElementsByClassName("tpr-search-results__nav-button")[0];
+   if (navigateToSearchButton != null) {
+       const newTabSpan = navigateToSearchButton.querySelector("span.govuk-visually-hidden");
+       if (newTabSpan) {
+           newTabSpan.remove();
+       }
 
-        if (navigateToSearchButton.hasAttribute("rel")) {
-            navigateToSearchButton.removeAttribute("rel");
-        }
+       if (navigateToSearchButton.hasAttribute("rel")) {
+           navigateToSearchButton.removeAttribute("rel");
+       }
 
-        navigateToSearchButton.addEventListener("click", navigateToSearchButtonOnClick);
-    }
+       navigateToSearchButton.addEventListener("click", navigateToSearchButtonOnClick);
+   }
 });
 
 export { initialiseAccordion, searchButtonOnClick, resetButtonOnClick, showMoreAnswersOnClick, setSearchResults, navigateToSearchButtonOnClick, removeNoResultsFound, resetShowMoreAnswersButton, showErrorTextVisibility, setSearchTermQueryString, SEARCH_TERM_QUERY_PARAM, SHOW_MORE_QUERY_PARAM, sanitizeString };


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

In Umbraco 13 [Smidge](https://github.com/shazwazza/smidge) was included by default for bundling and minifying client-side assets. Between v13 and v17 it was removed, and so this PR is part of a complete review of how we include client-side assets. 

This PR minifies our JavaScript for faster downloads. Previously we have only targeted low-traffic B2B sites and not done minification. 

- Use the `BuildBundlerMinifier` package to minify our JS files
- Update some JS from one valid syntax to another because `BuildBunderMinifier` didn't like it
- Update the TPR version of `BodyClosing.cshtml` to reuse rather than repeat the GOV.UK version
- Move less-commonly-used scripts out of the TPR version of `BodyClosing.cshtml` so they don't need to be loaded by every site (the side 

## Out-of-scope for this PR

Everything else. 

Outside of the backoffice you can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- the Umbraco backoffice works

Otherwise you can expect:
- build warnings
- TODO comments in code
- broken client-side features (ie JavaScript) because the client-side review is not complete
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Further improved support for client-side assets following removal of Smidge between Umbraco 13 and 17
- Refactor MSBuild code to remove a lot of duplication and complexity
- Fixing the favicon bug we've been working around since the release of .NET 9
- Fix the unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating namespaces for greater clarity
- Modernising example apps and docs to support top-level statements in Program.cs
- Fix task list non-conformance issues
- Convert all remaining NUnit tests to XUnit

#535