### PR TITLE
Add a cache-busting parameter to our stylesheet loaded in the backoffice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,3 +431,6 @@ GovUk.Frontend.Umbraco/uSync/v17/ContentTypes/
 GovUk.Frontend.Umbraco/uSync/v17/DataTypes/
 ThePensionsRegulator.Frontend.Umbraco/uSync/v17/ContentTypes/
 ThePensionsRegulator.Frontend.Umbraco/uSync/v17/DataTypes/
+
+# Generated files with package version info
+*.generated.*

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion-section.ts
@@ -4,6 +4,7 @@ import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration 
 import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { renderAccordionSection } from '../helpers/accordion-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkAccordionSectionContent extends UmbBlockDataType {
     heading: string;
@@ -30,7 +31,7 @@ export class GovUkAccordionSectionView extends UmbElementMixin(LitElement) imple
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderAccordionSection(this.content?.heading, this.content?.summary, this?.content?.blocks?.contentData) }
         </a>`;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-accordion.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { renderAccordionSection } from '../helpers/accordion-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkAccordionContent extends UmbBlockDataType {
     sections: UmbBlockValueType<UmbBlockListLayoutModel> | undefined;
@@ -28,7 +29,7 @@ export class GovUkAccordionView extends UmbElementMixin(LitElement) implements U
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.sections?.contentData ? html`
                 <div class="govuk-accordion">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button-group.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkButtonGroupContent extends UmbBlockDataType {
     buttons: UmbBlockValueType<UmbBlockListLayoutModel> | null;
@@ -34,7 +35,7 @@ export class GovUkButtonGroupView extends UmbElementMixin(LitElement) implements
         if (this.content?.buttons?.contentData?.length === 1) { blocks = "1 block." }
         if ((this.content?.buttons?.contentData?.length || 0) > 1) { blocks = `${this.content?.buttons?.contentData?.length} blocks.` }
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view ${ this.settings?.cssClasses}">
             <h2 class="govuk-heading-s">Button group</h2>
             <p class="backoffice-additional-blocks">${ blocks }</p>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-button.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkButtonContent extends UmbBlockDataType {
     text: string;
 }
@@ -39,7 +40,7 @@ export class GovUkButtonView extends UmbElementMixin(LitElement) implements UmbB
         }
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="${ blockViewClass }">
                 <button class="govuk-button ${ buttonClass} ${this.settings?.cssClasses}" type="button">${this.content?.text }</button>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-caption.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-caption.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkCaptionContent extends UmbBlockDataType {
     caption: string;
 }
@@ -29,7 +30,7 @@ export class GovUkCaptionView extends UmbElementMixin(LitElement) implements Umb
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="govuk-caption-l ${ this.settings?.cssClasses}">${this.content?.caption }</div>
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkbox.ts
@@ -5,6 +5,7 @@ import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffic
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkCheckboxContent extends UmbBlockDataType {
     label: string;
@@ -41,7 +42,7 @@ export class GovUkCheckboxView extends UmbElementMixin(LitElement) implements Um
         if ((this.content?.conditionalBlocks?.contentData?.length || 0) > 1) { conditionalBlocksText = `${this.content?.conditionalBlocks.contentData.length} conditional blocks.` }
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <div class="govuk-checkboxes ${ this.settings?.cssClasses}">
                 <div class="govuk-checkboxes__item">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes-divider.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes-divider.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderCheckboxesDivider } from '../helpers/checkboxes-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkCheckboxesDividerContent extends UmbBlockDataType {
     text: string;
 }
@@ -22,7 +23,7 @@ export class GovUkCheckboxesDividerView extends UmbElementMixin(LitElement) impl
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderCheckboxesDivider(this.content?.text) }
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-checkboxes.ts
@@ -7,6 +7,7 @@ import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderCheckboxesDivider, renderCheckbox } from '../helpers/checkboxes-helper';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkCheckboxesContent extends UmbBlockDataType {
     legend: string;
@@ -58,7 +59,7 @@ export class GovUkCheckboxesView extends UmbElementMixin(LitElement) implements 
         const legendClass = this.settings?.legendIsPageHeading ? 'govuk-fieldset__legend--l' : 'govuk-fieldset__legend--for-field';
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <fieldset class="govuk-fieldset govuk-checkboxes__fieldset ${this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend}</legend>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-date-input.ts
@@ -6,6 +6,7 @@ import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkDateInputContent extends UmbBlockDataType {
     fieldsetBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
@@ -61,7 +62,7 @@ export class GovUkDateInputView extends UmbElementMixin(LitElement) implements U
         const legendClass = this.settings?.legendIsPageHeading ? 'govuk-fieldset__legend--l' : 'govuk-fieldset__legend--for-field';
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <fieldset class="govuk-fieldset govuk-date-input__fieldset ${ this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend }</legend>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-details.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-details.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkDetailsContent extends UmbBlockDataType {
     summary: string;
@@ -33,7 +34,7 @@ export class GovUkDetailsView extends UmbElementMixin(LitElement) implements Umb
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <details class="govuk-details ${ this.settings?.cssClasses}" open>
                 <summary class="govuk-details__summary"><span class="govuk-details__summary-text">${ this.content?.summary }</span></summary>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-message.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-message.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkErrorMessageContent extends UmbBlockDataType {
     error: string;
 }
@@ -29,7 +30,7 @@ export class GovUkErrorMessageView extends UmbElementMixin(LitElement) implement
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <p class="govuk-error-message ${ this.settings?.cssClasses}">${this.content?.error }</p>
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-summary.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-error-summary.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkErrorSummaryContent extends UmbBlockDataType {
     title: string;
 }
@@ -29,7 +30,7 @@ export class GovUkErrorSummaryView extends UmbElementMixin(LitElement) implement
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="govuk-error-summary">
                 <h2 class="govuk-error-summary__title">${ this.content?.title || "There is a problem" }</h2>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-fieldset.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkFieldsetContent extends UmbBlockDataType {
     legend: string;
@@ -54,7 +55,7 @@ export class GovUkFieldsetView extends UmbElementMixin(LitElement) implements Um
         const legendClass = this.settings?.legendIsPageHeading ? 'govuk-fieldset__legend--l' : 'govuk-fieldset__legend--for-fieldset';
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <fieldset class="govuk-fieldset ${ this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${ this.settings?.legendIsPageHeading ? html `<h1 class="govuk-fieldset__heading">${ legend }</h1>`: legend }</legend>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-file-upload.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-file-upload.ts
@@ -5,6 +5,7 @@ import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkFileUploadContent extends UmbBlockDataType {
     label: string;
     hint: UmbPropertyEditorRteValueType;
@@ -51,7 +52,7 @@ export class GovUkFileUploadView extends UmbElementMixin(LitElement) implements 
 
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
 
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${ this.settings?.cssClasses }">
             ${this.settings?.labelIsPageHeading ?

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-hidden.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-hidden.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkHiddenSettings extends UmbBlockDataType {
     modelProperty: string;
@@ -23,7 +24,7 @@ export class GovUkHiddenView extends UmbElementMixin(LitElement) implements UmbB
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <p class="backoffice-additional-blocks">Hidden field ${this.settings?.modelProperty ? '(bound to ' + this.settings.modelProperty + ')' : '(not bound to a property)'}</p>
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-inset-text.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-inset-text.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkInsetTextContent extends UmbBlockDataType {
     text: UmbPropertyEditorRteValueType;
@@ -32,7 +33,7 @@ export class GovUkInsetTextView extends UmbElementMixin(LitElement) implements U
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-inset-text backoffice-block-view ${ this.settings?.cssClasses}">${unsafeHTML(disableLinks(this.content?.text.markup)) }</a>
         `;
     }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link-as-button.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link-as-button.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkLinkAsButtonContent extends UmbBlockDataType {
     text: string;
 }
@@ -39,7 +40,7 @@ export class GovUkLinkAsButtonView extends UmbElementMixin(LitElement) implement
             blockViewClass = "backoffice-block-view-inverse";
         }
 
-        return html`<link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        return html`<link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
             <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
                 <div class="${ blockViewClass }">
                 ${ this.settings?.isStartButton ?

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-link.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkLinkContent extends UmbBlockDataType {
     text: string;
 }
@@ -29,7 +30,7 @@ export class GovUkLinkView extends UmbElementMixin(LitElement) implements UmbBlo
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <span class="govuk-link ${this.settings?.cssClasses}">${this.content?.text}</span>
         </a>`;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-notification-banner.ts
@@ -5,6 +5,7 @@ import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/blo
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkNotificationBannerContent extends UmbBlockDataType {
     heading: UmbPropertyEditorRteValueType;
@@ -46,7 +47,7 @@ export class GovUkNotificationBannerView extends UmbElementMixin(LitElement) imp
         }
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="${bannerClass} ${ this.settings?.cssClasses }">
                 <div class="govuk-notification-banner__header">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-page-heading.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-page-heading.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkPageHeadingContent extends UmbBlockDataType {
     text: string;
@@ -44,7 +45,7 @@ export class GovUkPageHeadingView extends UmbElementMixin(LitElement) implements
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <h1 class="govuk-heading-l ${ this.settings?.cssClasses}">${this.content?.text ? this.content.text : this._nodeName }</h1>
         </a>`;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-pagination.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-pagination.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkPaginationContent extends UmbBlockDataType {
 }
@@ -30,7 +31,7 @@ export class GovUkPaginationView extends UmbElementMixin(LitElement) implements 
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editSettingsPath ?? ''}" class="backoffice-block-view">
             <nav class="govuk-pagination--block govuk-pagination ${ this.settings?.cssClasses}">
                 <div class="govuk-pagination__next">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-panel.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-panel.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkPanelContent extends UmbBlockDataType {
     panelHeading: string;
@@ -33,7 +34,7 @@ export class GovUkPanelView extends UmbElementMixin(LitElement) implements UmbBl
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-panel--confirmation govuk-panel backoffice-block-view ${ this.settings?.cssClasses}">
             ${this?.content?.panelHeading ? html`<h1 class="govuk-panel__title">${ this.content?.panelHeading }</h1>` : null }
             ${this.content?.panelText.markup ? html`<div class="govuk-panel__body">${ unsafeHTML(disableLinks(this.content?.panelText.markup)) }</div>` : null }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radio.ts
@@ -5,6 +5,7 @@ import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffic
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { renderRadioButton } from '../helpers/radios-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkRadioContent extends UmbBlockDataType {
     conditionalBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
@@ -34,7 +35,7 @@ export class GovUkRadioView extends UmbElementMixin(LitElement) implements UmbBl
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderRadioButton(this.content?.label, this.content?.value, this.content?.hint?.markup, this.content?.conditionalBlocks?.contentData, true) }
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios-divider.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios-divider.ts
@@ -3,6 +3,8 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderRadiosDivider } from '../helpers/radios-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
+
 interface IGovUkRadiosDividerContent extends UmbBlockDataType {
     text: string;
 }
@@ -22,7 +24,7 @@ export class GovUkRadiosDividerView extends UmbElementMixin(LitElement) implemen
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderRadiosDivider(this.content?.text) }
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-radios.ts
@@ -7,6 +7,7 @@ import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/document';
 import { renderRadiosDivider, renderRadioButton } from '../helpers/radios-helper';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkRadiosContent extends UmbBlockDataType {
     fieldsetBlocks: UmbBlockValueType<UmbBlockListLayoutModel>;
@@ -61,7 +62,7 @@ export class GovUkRadiosView extends UmbElementMixin(LitElement) implements UmbB
         const horizontalLayout = this.settings?.layout === 'Horizontal';
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view">
             <fieldset class="govuk-fieldset govuk-radios__fieldset ${ this.settings?.cssClasses}">
                 <legend class="govuk-fieldset__legend ${legendClass}">${this.settings?.legendIsPageHeading ? html`<h1 class="govuk-fieldset__heading">${legend}</h1>` : legend }</legend>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-section-break.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-section-break.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkSectionBreakSettings extends UmbBlockDataType {
     hidden: boolean;
@@ -25,7 +26,7 @@ export class GovUkSectionBreakView extends UmbElementMixin(LitElement) implement
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <p class="govuk-body backoffice-section-break"><span>${this.settings?.hidden ? 'Hidden section break' : 'Section break'} (${this.settings?.size || 'Large'})</span></p>
         </a>`;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-select.ts
@@ -5,6 +5,7 @@ import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffic
 import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkSelectContent extends UmbBlockDataType {
     label: string;
@@ -36,7 +37,7 @@ export class GovUkSelectView extends UmbElementMixin(LitElement) implements UmbB
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${ this.settings?.cssClasses }">
             ${ this.settings?.labelIsPageHeading ?
             html`<h1 class="govuk-label-wrapper">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-card.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { renderSummaryList } from '../helpers/summary-list-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkSummaryCardContent extends UmbBlockDataType {
     cardTitle: string;
@@ -34,7 +35,7 @@ export class GovUkSummaryCardView extends UmbElementMixin(LitElement) implements
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="govuk-summary-card ${ this.settings?.cssClasses}">
                 <div class="govuk-summary-card__title-wrapper"><h2 class="govuk-summary-card__title">${this.content?.cardTitle}</h2>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-action.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-action.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderSummaryListAction } from '../helpers/summary-list-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkSummaryListActionContent extends UmbBlockDataType {
     text: string;
@@ -22,7 +23,7 @@ export class GovUkSummaryListActionView extends UmbElementMixin(LitElement) impl
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${renderSummaryListAction(this.content?.text)}
         </a>`;

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list-item.ts
@@ -5,6 +5,7 @@ import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffic
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { renderSummaryListItem } from '../helpers/summary-list-helper';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkSummaryListItemContent extends UmbBlockDataType {
     itemKey: string;
@@ -35,7 +36,7 @@ export class GovUkSummaryListItemView extends UmbElementMixin(LitElement) implem
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <dl class="govuk-summary-list">
                 ${ renderSummaryListItem(this.content?.itemKey, this.content?.itemValue?.markup, this.content?.actions) }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-summary-list.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { renderSummaryList } from '../helpers/summary-list-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkSummaryListContent extends UmbBlockDataType {
     items: UmbBlockValueType<UmbBlockListLayoutModel> | null;
@@ -32,7 +33,7 @@ export class GovUkSummaryListView extends UmbElementMixin(LitElement) implements
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.items?.contentData ? 
                 renderSummaryList(this.content?.items, this.settings?.cssClasses) :

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list-summary.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list-summary.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkTaskListSummaryContent extends UmbBlockDataType {
     incompleteStatus: string;
@@ -31,7 +32,7 @@ export class GovUkTaskListSummaryView extends UmbElementMixin(LitElement) implem
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-task-list-summary backoffice-block-view ${ this.settings?.cssClasses}">
             <h2 class="govuk-task-list-summary__heading govuk-heading-s">${ this.content?.incompleteStatus || 'Tasks incomplete' }</h2>
             <p class="govuk-task-list-summary__tracker govuk-body">${ this.content?.tracker || "You've completed 1 of 2 tasks." }</p>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task-list.ts
@@ -5,6 +5,7 @@ import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffic
 import { UmbBlockListLayoutModel, UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS } from '@umbraco-cms/backoffice/block-list';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { renderTask } from '../helpers/task-list-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkTaskListContent extends UmbBlockDataType {
     tasks: UmbBlockValueType<UmbBlockListLayoutModel> | null;
@@ -33,7 +34,7 @@ export class GovUkTaskListView extends UmbElementMixin(LitElement) implements Um
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ this.content?.tasks?.contentData ? 
                 html`<ul class="govuk-task-list ${this.settings?.cssClasses}">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-task.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { renderTask } from '../helpers/task-list-helper';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkTaskContent extends UmbBlockDataType {
     taskName: string;
@@ -34,7 +35,7 @@ export class GovUkTaskView extends UmbElementMixin(LitElement) implements UmbBlo
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ renderTask(true, this.content?.taskName, this.content?.hint?.markup, this.settings?.status, this.settings?.cssClasses) }
         </a>

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-text-input.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-text-input.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface IGovUkTextInputContent extends UmbBlockDataType {
     label: string;
     hint: UmbPropertyEditorRteValueType;
@@ -63,7 +64,7 @@ export class GovUkTextInputView extends UmbElementMixin(LitElement) implements U
         }
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${this.settings?.cssClasses}">
             ${this.settings?.labelIsPageHeading ?
                 html`<h1 class="govuk-label-wrapper">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-textarea.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-textarea.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkTextareaContent extends UmbBlockDataType {
     label: string;
@@ -39,7 +40,7 @@ export class GovUkTextareaView extends UmbElementMixin(LitElement) implements Um
         const rows = this.settings?.rows ?? 5;
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-form-group backoffice-block-view ${this.settings?.cssClasses}">
             ${this.settings?.labelIsPageHeading ?
                 html`<h1 class="govuk-label-wrapper">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-typography.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-typography.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkTypographyContent extends UmbBlockDataType {
     text: UmbPropertyEditorRteValueType;
@@ -31,7 +32,7 @@ export class GovUkTypographyView extends UmbElementMixin(LitElement) implements 
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-body backoffice-block-view">${unsafeHTML(disableLinks(this.content?.text.markup)) }</a>
         `;
     }

--- a/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-warning-text.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/blocks/views/govuk-warning-text.ts
@@ -4,6 +4,7 @@ import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfigura
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
 import { disableLinks } from '../helpers/html-helper';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IGovUkWarningTextContent extends UmbBlockDataType {
     iconFallbackText: string;
@@ -33,7 +34,7 @@ export class GovUkWarningTextView extends UmbElementMixin(LitElement) implements
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="govuk-warning-text backoffice-block-view ${ this.settings?.cssClasses}">
             <span aria-hidden="true" class="govuk-warning-text__icon">!</span>
             <strong class="govuk-warning-text__text" aria-hidden="true">

--- a/GovUk.Frontend.Umbraco/Backoffice/src/property-editors/views/govuk-model-property-picker.ts
+++ b/GovUk.Frontend.Umbraco/Backoffice/src/property-editors/views/govuk-model-property-picker.ts
@@ -4,6 +4,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
 import { umbHttpClient } from '@umbraco-cms/backoffice/http-client';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content'; 
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 @customElement('govuk-model-property-picker')
 export class GovUkModelPropertyPickerView extends UmbLitElement implements UmbPropertyEditorUiElement {
@@ -60,7 +61,7 @@ export class GovUkModelPropertyPickerView extends UmbLitElement implements UmbPr
 			selected: option.value === this.value
 		}));
 
-		return html`<link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+		return html`<link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
 				${propertyNamesWithSelected.length ? html`<uui-select .options="${propertyNamesWithSelected}" @change="${this.#onChange}" />` :
 				html`<div class="govuk-umbraco-error">
 						<span class="govuk-umbraco-error__icon">

--- a/GovUk.Frontend.Umbraco/Directory.Build.targets
+++ b/GovUk.Frontend.Umbraco/Directory.Build.targets
@@ -43,4 +43,12 @@
 		<Message Text="Restoring Backoffice npm packages" Importance="high" />
 		<Exec Command="npm install" WorkingDirectory="Backoffice" />
 	</Target>
+
+	<!-- Create a version to use as a cache-busting parameter for backoffice customisation -->
+	<Target Name="GovUkFrontendUmbraco_GenerateTypeScriptVersion" BeforeTargets="Build">
+		<WriteLinesToFile
+		  File="Backoffice/src/package-version.generated.ts"
+		  Lines="export const PACKAGE_VERSION = '$(Version)'"
+		  Overwrite="true" />
+	</Target>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-back-to-menu.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-back-to-menu.ts
@@ -2,6 +2,7 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface ITprBackToMenuContent extends UmbBlockDataType {
     text: string;
 }
@@ -29,7 +30,7 @@ export class TprBackToMenuView extends UmbElementMixin(LitElement) implements Um
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <p class="tpr-back-to-menu govuk-body ${ this.settings?.cssClasses}">
                 <span class="govuk-link">${this.content?.text }</span>

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-box.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-box.ts
@@ -3,7 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockGridTypeModel } from '@umbraco-cms/backoffice/block-grid';
-
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface IColourPickerValue {
     label: string;
@@ -38,7 +38,7 @@ export class TprBoxView extends UmbElementMixin(LitElement) implements UmbBlockE
         const isNestedBox = this.blockType?.contentElementTypeKey == "2e831668-9e36-44d9-95f4-de209f9a35d0";
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a class="backoffice-block-header ${isNestedBox ? 'for-tpr-nested-box' : 'for-tpr-box'}" href="${this.config?.editSettingsPath}">
 			<uui-icon-registry-essential>
                 <uui-icon name="icon-checkbox-empty" aria-hidden="true" />

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-document.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-document.ts
@@ -7,6 +7,7 @@ import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT, UmbDocumentItemRepository } from
 import { ILinkPickerModel } from '../types/ILinkPickerModel';
 import { createDocumentBlock, renderDocument, updateNodeName } from '../helpers/document-helper';
 import { ITprDocumentBlock } from '../types/ITprDocumentBlock';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface ITprDocumentContent extends UmbBlockDataType {
     key: string;
@@ -85,7 +86,7 @@ export class TprDocumentView extends UmbElementMixin(LitElement) implements UmbB
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             ${ renderDocument(this.#document,false) }
         </a>`;

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-documents.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-documents.ts
@@ -8,6 +8,7 @@ import { UMB_DOCUMENT_PROPERTY_DATASET_CONTEXT, UmbDocumentItemRepository } from
 import { ILinkPickerModel } from '../types/ILinkPickerModel';
 import { updateNodeName, createDocumentBlock, renderDocument } from '../helpers/document-helper';
 import { ITprDocumentBlock } from '../types/ITprDocumentBlock';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface ITprDocumentsContent extends UmbBlockDataType {
     documents: UmbBlockValueType<UmbBlockListLayoutModel>;
@@ -84,7 +85,7 @@ export class TprDocumentsView extends UmbElementMixin(LitElement) implements Umb
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <dl class="tpr-documents govuk-list ${ this.settings?.cssClasses}">
                 ${repeat(this.#documents || [],

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-featured-image.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-featured-image.ts
@@ -4,6 +4,7 @@ import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration 
 import { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
 import { UmbMediaItemRepository, UmbMediaUrlRepository, UmbMediaItemModel, UmbMediaUrlModel, UmbMediaPickerPropertyValueEntry } from '@umbraco-cms/backoffice/media';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface ITprFeaturedImageContent extends UmbBlockDataType {
     image: Array<UmbMediaPickerPropertyValueEntry>;
@@ -75,7 +76,7 @@ export class TprFeaturedImageView extends UmbElementMixin(LitElement) implements
         if ((this.content?.blocks?.contentData?.length || 0) > 1) { blocksText = `${this.content?.blocks.contentData.length} blocks.` }
 
         return html`
-            <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+            <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
             <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
                 <div class="tpr-featured-image${this.settings?.horizontal ? ' tpr-featured-image--horizontal' : null}">
                     <div class="tpr-featured-image_thumbnail">

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-header-menu-item.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-header-menu-item.ts
@@ -2,6 +2,8 @@ import { html, customElement, LitElement, property } from '@umbraco-cms/backoffi
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import { PACKAGE_VERSION } from '../../package-version.generated';
+
 interface ITprHeaderMenuItemContent extends UmbBlockDataType {
     linkText: string;
 }
@@ -21,7 +23,7 @@ export class TprHeaderMenuItemView extends UmbElementMixin(LitElement) implement
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <span class="govuk-link">${this.content?.linkText}</span>
         </a>`;

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-image.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-image.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { UmbMediaItemRepository, UmbMediaUrlRepository, UmbMediaItemModel, UmbMediaUrlModel, UmbMediaPickerPropertyValueEntry } from '@umbraco-cms/backoffice/media';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface ITprImageContent extends UmbBlockDataType {
     image: Array<UmbMediaPickerPropertyValueEntry>;
@@ -78,7 +79,7 @@ export class TprImageView extends UmbElementMixin(LitElement) implements UmbBloc
         const displayImage = imageExtensions.find(ext => ext === this.#imageUrl?.extension?.toLowerCase()) && !this.#image?.isTrashed;
 
         return html`
-            <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+            <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
             <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
                 ${displayImage ? html`<img src="${this.#imageUrl?.url}" alt="${altText}" class="${cssClasses}" />` : null}
                 <p class="govuk-body backoffice-image-label ${this.#image?.isTrashed ? 'is-trashed' : null}">

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-related-links.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-related-links.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { ILinkPickerModel } from '../types/ILinkPickerModel';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface ITprRelatedLinksContent extends UmbBlockDataType {
     heading: string;
@@ -32,7 +33,7 @@ export class TprRelatedLinksView extends UmbElementMixin(LitElement) implements 
 
     override render() {
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="tpr-related-links ${ this.settings?.cssClasses}">
                 <h2 class="govuk-heading-m">${ this.content?.heading ? this.content.heading : 'Related' }</h2>

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-search-results.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-search-results.ts
@@ -3,6 +3,8 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { ILinkPickerModel } from '../types/ILinkPickerModel';
+import { PACKAGE_VERSION } from '../../package-version.generated';
+
 interface ITprSearchResultsContent extends UmbBlockDataType {
     heading: string;
     footerLinks: Array<ILinkPickerModel>;
@@ -52,7 +54,7 @@ export class TprSearchResultsView extends UmbElementMixin(LitElement) implements
     override render() {
         const inputId = crypto.randomUUID();
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view js-enabled">
             <aside class="tpr-search-results ${this.settings?.cssClasses}">
                 ${this.#renderHeading(this.content?.heading, this.settings?.headingClass, this.settings?.headingLevel?.[0])}

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-section-cards.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-section-cards.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import { UmbBlockListLayoutModel } from '@umbraco-cms/backoffice/block-list';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 
 interface ITprSectionCardsContent extends UmbBlockDataType {
     cards: UmbBlockValueType<UmbBlockListLayoutModel>;
@@ -35,7 +36,7 @@ export class TprSectionCardsView extends UmbElementMixin(LitElement) implements 
         if ((this.content?.cards?.contentData?.length || 0) > 1) { blocksText = `${this.content?.cards.contentData.length} blocks.` }
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="${this.settings?.cssClasses}">
                 <h2 class="govuk-heading-s">Section cards</h2>

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-youtube-video.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-youtube-video.ts
@@ -3,6 +3,7 @@ import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbBlockEditorCustomViewElement, UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
 import { ILinkPickerModel } from '../types/ILinkPickerModel';
+import { PACKAGE_VERSION } from '../../package-version.generated';
 interface ITprYouTubeVideoContent extends UmbBlockDataType {
     title: string;
     url: string;
@@ -50,7 +51,7 @@ export class TprYouTubeVideoView extends UmbElementMixin(LitElement) implements 
         const parseUrlResult = this.#tryParseVideoUrl(this.content?.url);
 
         return html`
-        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css" />
+        <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="tpr-video-wrapper-no-cookies ${this.settings?.cssClasses}">
                 <div class="tpr-video-wrapper-no-cookies__video-container">

--- a/ThePensionsRegulator.Frontend.Umbraco/Directory.Build.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/Directory.Build.targets
@@ -40,8 +40,16 @@
 	</Target>
 
 	<!-- Restore npm packages for backoffice development. -->
-	<Target Name="GovUkFrontendUmbraco_NpmInstall" BeforeTargets="BeforeBuild">
+	<Target Name="TprFrontendUmbraco_NpmInstall" BeforeTargets="BeforeBuild">
 		<Message Text="Restoring Backoffice npm packages" Importance="high" />
 		<Exec Command="npm install" WorkingDirectory="Backoffice" />
+	</Target>
+
+	<!-- Create a version to use as a cache-busting parameter for backoffice customisation -->
+	<Target Name="TprFrontendUmbraco_GenerateTypeScriptVersion" BeforeTargets="Build">
+		<WriteLinesToFile
+		  File="Backoffice/src/package-version.generated.ts"
+		  Lines="export const PACKAGE_VERSION = '$(Version)'"
+		  Overwrite="true" />
 	</Target>
 </Project>


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

In Umbraco 13 [Smidge](https://github.com/shazwazza/smidge) was included by default for bundling and minifying client-side assets. Between v13 and v17 it was removed, and so this PR is part of a complete review of how we include client-side assets. 

This PR adds a cache-busting parameter to our stylesheet when loaded by property editors and block previews in the backoffice. The value for the cache-busting parameter is based on the value we set for the NuGet package version. This ensures that consuming projects will get the latest CSS based on the package version they have imported, without us having to maintain the version in an extra place.

We specify the NuGet version in an MSBuild property, so this PR uses MSBuild to generate a TypeScript file at build time with that same version. We already use MSBuild to generate files in this repo, so this is a consistent pattern. 

It doesn't end the TypeScript line with a semi-colon because that got swallowed by MSBuild every way I tried, but since it's generating a single-line file that doesn't cause a problem with parsing.

## Out-of-scope for this PR

Everything else. 

Outside of the backoffice you can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- the Umbraco backoffice works

Otherwise you can expect:
- build warnings
- TODO comments in code
- broken client-side features (ie JavaScript) because the client-side review is not complete
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Further improved support for client-side assets following removal of Smidge between Umbraco 13 and 17
- Refactor MSBuild code to remove a lot of duplication and complexity
- Fixing the favicon bug we've been working around since the release of .NET 9
- Fix the unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating namespaces for greater clarity
- Modernising example apps and docs to support top-level statements in Program.cs
- Fix task list non-conformance issues
- Convert all remaining NUnit tests to XUnit

#535