### PR TITLE
Add long-term caching headers to CSS and scripts served by these packages

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.UnitTests/Caching/CacheStaticFilesMiddlewareTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.UnitTests/Caching/CacheStaticFilesMiddlewareTests.cs
@@ -1,0 +1,98 @@
+using GovUk.Frontend.AspNetCore.Extensions.Caching;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests.Caching
+{
+    public class CacheStaticFilesMiddlewareTests
+    {
+        private readonly Mock<RequestDelegate> _nextMiddleware = new();
+        private readonly Mock<IStaticFileCachePolicy> _cachePolicy = new();
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task InvokeAsync_WithCacheablePath_SetsCacheControlHeaders(bool expectCacheHeaders)
+        {
+            // Arrange
+            const string path = "/govuk/style.css";
+            _cachePolicy.Setup(p => p.IsImmutable(path, It.IsAny<IQueryCollection>())).Returns(expectCacheHeaders);
+
+            var middleware = new CacheStaticFilesMiddleware(_nextMiddleware.Object, new[] { _cachePolicy.Object });
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal(expectCacheHeaders, context.Response.Headers.ContainsKey("Cache-Control"));
+            if (expectCacheHeaders)
+            {
+                var cacheControlValue = context.Response.Headers["Cache-Control"].ToString();
+                Assert.Contains("public", cacheControlValue);
+                Assert.Contains("max-age=31536000", cacheControlValue);
+                Assert.Contains("immutable", cacheControlValue);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task InvokeAsync_WithMultiplePolicies_AnyMatchingPolicySetsHeaders(bool policy1Result, bool policy2Result)
+        {
+            // Arrange
+            const string path = "/file.css";
+            var policy1 = new Mock<IStaticFileCachePolicy>();
+            var policy2 = new Mock<IStaticFileCachePolicy>();
+
+            policy1.Setup(p => p.IsImmutable(path, It.IsAny<IQueryCollection>())).Returns(policy1Result);
+            policy2.Setup(p => p.IsImmutable(path, It.IsAny<IQueryCollection>())).Returns(policy2Result);
+
+            var middleware = new CacheStaticFilesMiddleware(_nextMiddleware.Object, new[] { policy1.Object, policy2.Object });
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal(policy1Result || policy2Result, context.Response.Headers.ContainsKey("Cache-Control"));
+        }
+
+        [Fact]
+        public async Task InvokeAsync_CallsNextMiddleware()
+        {
+            // Arrange
+            _cachePolicy.Setup(p => p.IsImmutable(It.IsAny<string>(), It.IsAny<IQueryCollection>())).Returns(false);
+
+            var middleware = new CacheStaticFilesMiddleware(_nextMiddleware.Object, new[] { _cachePolicy.Object });
+            var context = new DefaultHttpContext();
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _nextMiddleware.Verify(next => next(context), Times.Once);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_WithNullPath_HandlesGracefully()
+        {
+            // Arrange
+            _cachePolicy.Setup(p => p.IsImmutable(string.Empty, It.IsAny<IQueryCollection>())).Returns(false);
+
+            var middleware = new CacheStaticFilesMiddleware(_nextMiddleware.Object, new[] { _cachePolicy.Object });
+            var context = new DefaultHttpContext();
+            context.Request.Path = PathString.Empty;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _nextMiddleware.Verify(next => next(context), Times.Once);
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions.UnitTests/Caching/GovUkStaticFileCachePolicyTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.UnitTests/Caching/GovUkStaticFileCachePolicyTests.cs
@@ -1,0 +1,47 @@
+using GovUk.Frontend.AspNetCore.Extensions.Caching;
+using Microsoft.AspNetCore.Http;
+using System.Web;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests.Caching
+{
+    public class GovUkStaticFileCachePolicyTests
+    {
+        private readonly GovUkStaticFileCachePolicy _policy = new();
+
+        [Theory]
+        [InlineData("/_content/ThePensionsRegulator.GovUk.Frontend/style.css?v=1.0.0", true)]
+        [InlineData("/_content/ThePensionsRegulator.GovUk.Frontend/script.js?v=1.0.0", true)]
+        [InlineData("/_content/ThePensionsRegulator.GovUk.Frontend/image.png?v=1.0.0", true)]
+        [InlineData("/_CONTENT/THEPENSIONSREGULATOR.GOVUK.FRONTEND/STYLE.CSS?v=1.0.0", true)]
+
+        // no path
+        [InlineData("?v=1.0.0", false)]
+
+        // wrong path
+        [InlineData("/_content/OtherPackage/style.css?v=1.0.0", false)]
+        [InlineData("/_content/ThePensionsRegulator/style.css?v=1.0.0", false)]
+        [InlineData("/other-content/ThePensionsRegulator.GovUk.Frontend/style.css?v=1.0.0", false)]
+
+        // no querystring
+        [InlineData("/_content/ThePensionsRegulator.GovUk.Frontend/style.css", false)]
+        [InlineData("/govuk/style.css", false)]
+        [InlineData("/other/file.js", false)]
+
+        // wrong querystring
+        [InlineData("/_content/ThePensionsRegulator.GovUk.Frontend/style.css?other=value", false)]
+        [InlineData("/_content/ThePensionsRegulator.GovUk.Frontend/image.png?v=", false)]
+        public void IsImmutable_ReturnsExpectedResult(string path, bool expected)
+        {
+            // Arrange
+            var url = new Uri("https://example.com" + path);
+            var query = HttpUtility.ParseQueryString(url.Query);
+            var dict = query.Keys.OfType<string>().ToDictionary(k => k, k => (Microsoft.Extensions.Primitives.StringValues)query[k]);
+
+            // Act
+            var result = _policy.IsImmutable(path, new QueryCollection(dict));
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/ApplicationBuilderExtensions.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/ApplicationBuilderExtensions.cs
@@ -1,5 +1,5 @@
+using GovUk.Frontend.AspNetCore.Extensions.Caching;
 using Microsoft.AspNetCore.Builder;
-using System;
 
 namespace GovUk.Frontend.AspNetCore.Extensions
 {
@@ -11,6 +11,9 @@ namespace GovUk.Frontend.AspNetCore.Extensions
             {
                 throw new ArgumentNullException(nameof(app));
             }
+
+            app.UseMiddleware<CacheStaticFilesMiddleware>();
+            app.UseStaticFiles();
 
             app.UseGovUkFrontend();
 

--- a/GovUk.Frontend.AspNetCore.Extensions/Caching/CacheStaticFilesMiddleware.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Caching/CacheStaticFilesMiddleware.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Http;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.Caching
+{
+    /// <summary>
+    /// Middleware that adds long-term caching headers to static files.
+    /// The files are safe to cache because they use cache-busting via query string parameters.
+    /// </summary>
+    /// <remarks>
+    /// This must be called before UseStaticFiles() so it can intercept requests.
+    /// UseStaticFiles() short-circuits the pipeline, so middleware after it won't execute.
+    /// </remarks>
+    public class CacheStaticFilesMiddleware(RequestDelegate _next, IEnumerable<IStaticFileCachePolicy> _pathProviders)
+    {
+        private const int CacheDurationDays = 365;
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            // Check if any policy says this request should be cached
+            if (_pathProviders.Any(p => p.IsImmutable(context.Request.Path.Value ?? string.Empty, context.Request.Query)))
+            {
+                // Set cache control headers for 1 year
+                context.Response.Headers.CacheControl = $"public, max-age={CacheDurationDays * 24 * 60 * 60}, immutable";
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Caching/GovUkStaticFileCachePolicy.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Caching/GovUkStaticFileCachePolicy.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.Caching
+{
+    public class GovUkStaticFileCachePolicy : IStaticFileCachePolicy
+    {
+        public bool IsImmutable(string path, IQueryCollection query)
+        {
+            return path.StartsWith("/_content/ThePensionsRegulator.GovUk.Frontend/", StringComparison.OrdinalIgnoreCase) &&
+                   query.ContainsKey("v") &&
+                   !string.IsNullOrEmpty(query["v"]);
+        }
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Caching/IStaticFileCachePolicy.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Caching/IStaticFileCachePolicy.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace GovUk.Frontend.AspNetCore.Extensions.Caching
+{
+    /// <summary>
+    /// Determines whether a static file request should be cached with long-term cache headers.
+    /// </summary>
+    public interface IStaticFileCachePolicy
+    {
+        /// <summary>
+        /// Determines whether the specified request should be cached with long-term cache headers.
+        /// Implementations should check both the path and query string (for cache-busting parameters).
+        /// </summary>
+        /// <param name="path">The request path (e.g., "/govuk/govuk-frontend.css" or "/_content/Package/file.css")</param>
+        /// <param name="query">The query string from the request.</param>
+        /// <returns>True if the request should be cached with long-term headers; otherwise, false.</returns>
+        bool IsImmutable(string path, IQueryCollection query);
+    }
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/ServiceCollectionExtensions.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/ServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
+using GovUk.Frontend.AspNetCore.Extensions.Caching;
 using GovUk.Frontend.AspNetCore.Extensions.Configuration;
 using GovUk.Frontend.AspNetCore.Extensions.ModelBinding;
 using GovUk.Frontend.AspNetCore.Extensions.Security;
 using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
 namespace GovUk.Frontend.AspNetCore.Extensions
 {
@@ -40,6 +40,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions
                 options.ModelBinderProviders.Insert(0, new UkPostcodeModelBinderProvider());
             });
             services.AddSingleton(new GovUkFrontendOptionsProvider(configureOptionsWithDefaults));
+            services.AddTransient<IStaticFileCachePolicy, GovUkStaticFileCachePolicy>();
 
             return services;
         }

--- a/GovUk.Frontend.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.ExampleApp/Startup.cs
@@ -3,15 +3,9 @@ using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using GovUk.Frontend.ExampleApp.Middleware;
 using GovUk.Frontend.ExampleApp.Models.Validators;
 using GovUk.Frontend.ExampleSharedResource;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Razor;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using ThePensionsRegulator.Frontend;
@@ -88,13 +82,12 @@ namespace GovUk.Frontend.ExampleApp
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
+            app.UseTprFrontend();
             app.UseHttpsRedirection();
-            app.UseStaticFiles();
             app.UseSecurityHeaders();
 
             app.UseRouting();
 
-            app.UseTprFrontend();
 
             // Localization.
             var supportedCultures = new[] {

--- a/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
@@ -3,23 +3,14 @@ using GovUk.Frontend.Umbraco.ExampleApp.Middleware;
 using GovUk.Frontend.Umbraco.ExampleApp.PropertyEditors.ValueFormatters;
 using GovUk.Frontend.Umbraco.ExampleApp.Services;
 using GovUk.Frontend.Umbraco.Services;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using System;
 using ThePensionsRegulator.Frontend.Services;
 using ThePensionsRegulator.Frontend.Umbraco;
 using ThePensionsRegulator.Frontend.Umbraco.Services;
 using ThePensionsRegulator.Umbraco.PropertyEditors;
-using Umbraco.Cms.Core.DeliveryApi;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
-using Umbraco.Extensions;
 
 namespace GovUk.Frontend.Umbraco.ExampleApp
 {
@@ -89,6 +80,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp
 
             app.UseHttpsRedirection();
             app.UseSecurityHeaders();
+            app.UseTprFrontendUmbraco(mvcOptions, umbracoContextAccessor, publishedValueFallback);
 
             app.UseUmbraco()
                 .WithMiddleware(u =>
@@ -103,7 +95,6 @@ namespace GovUk.Frontend.Umbraco.ExampleApp
                 });
 
 
-            app.UseTprFrontendUmbraco(mvcOptions, umbracoContextAccessor, publishedValueFallback);
         }
     }
 }

--- a/GovUk.Frontend.Umbraco.Tests/Caching/GovUkUmbracoStaticFileCachePolicyTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Caching/GovUkUmbracoStaticFileCachePolicyTests.cs
@@ -1,0 +1,50 @@
+using GovUk.Frontend.Umbraco.Caching;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using System.Web;
+
+namespace GovUk.Frontend.Umbraco.Tests.Caching
+{
+    public class GovUkUmbracoStaticFileCachePolicyTests
+    {
+        private readonly GovUkUmbracoStaticFileCachePolicy _policy = new();
+
+        [Test]
+        [TestCase("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk-component-hfdksfhks.js", true)]
+        [TestCase("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/package-version.generated-hjrkehwrk.js", true)]
+        [TestCase("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/example-helper-code-hdjskhfjds.js", true)]
+        [TestCase("/govuk/govuk-frontend.css?v=1.0.0", true)]
+        [TestCase("/css/govuk-umbraco-backoffice.css?v=1.0.0", true)]
+        [TestCase("/GOVUK/GOVUK-FRONTEND.CSS?v=1.0.0", true)]
+
+        // no path
+        [TestCase("?v=1.0.0", false)]
+
+        // wrong path
+        [TestCase("/_content/OtherPackage/style.css?v=1.0.0", false)]
+        [TestCase("/_content/ThePensionsRegulator/style.css?v=1.0.0", false)]
+        [TestCase("/other-content/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk-component-hfjdkfs.js", false)]
+
+        // no querystring
+        [TestCase("/govuk/govuk-frontend.css", false)]
+        [TestCase("/css/govuk-umbraco-backoffice.css", false)]
+        [TestCase("/other/file.js", false)]
+
+        // wrong querystring
+        [TestCase("/govuk/govuk-frontend.css?other=value", false)]
+        [TestCase("/css/govuk-umbraco-backoffice.css?v=", false)]
+        public void IsImmutable_ReturnsExpectedResult(string path, bool expected)
+        {
+            // Arrange
+            var url = new Uri("https://example.com" + path);
+            var query = HttpUtility.ParseQueryString(url.Query);
+            var dict = query.Keys.OfType<string>().ToDictionary(k => k, k => (Microsoft.Extensions.Primitives.StringValues)query[k]);
+
+            // Act
+            var result = _policy.IsImmutable(path, new QueryCollection(dict));
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco/Caching/GovUkUmbracoStaticFileCachePolicy.cs
+++ b/GovUk.Frontend.Umbraco/Caching/GovUkUmbracoStaticFileCachePolicy.cs
@@ -1,0 +1,19 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Caching;
+using Microsoft.AspNetCore.Http;
+
+namespace GovUk.Frontend.Umbraco.Caching
+{
+    public class GovUkUmbracoStaticFileCachePolicy : IStaticFileCachePolicy
+    {
+        public bool IsImmutable(string path, IQueryCollection query)
+        {
+            const string basePath = "/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/";
+
+            return path.StartsWith($"{basePath}govuk-", StringComparison.OrdinalIgnoreCase) ||
+                   path.StartsWith($"{basePath}package-version.generated-", StringComparison.OrdinalIgnoreCase) ||
+                  (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase) && path.Contains("-helper-", StringComparison.OrdinalIgnoreCase)) ||
+                  (path.StartsWith("/govuk/govuk-frontend.css", StringComparison.OrdinalIgnoreCase) && query.ContainsKey("v") && !string.IsNullOrEmpty(query["v"])) ||
+                  (path.StartsWith("/css/govuk-umbraco-backoffice.css", StringComparison.OrdinalIgnoreCase) && query.ContainsKey("v") && !string.IsNullOrEmpty(query["v"]));
+        }
+    }
+}

--- a/GovUk.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/GovUk.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 using GovUk.Frontend.AspNetCore;
 using GovUk.Frontend.AspNetCore.Extensions;
+using GovUk.Frontend.AspNetCore.Extensions.Caching;
 using GovUk.Frontend.Umbraco.Blocks;
+using GovUk.Frontend.Umbraco.Caching;
 using GovUk.Frontend.Umbraco.HtmlGeneration;
 using GovUk.Frontend.Umbraco.ModelBinding;
-using GovUk.Frontend.Umbraco.PropertyEditors;
 using GovUk.Frontend.Umbraco.PropertyEditors.ModelPropertyPicker;
 using GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters;
 using GovUk.Frontend.Umbraco.Services;
@@ -11,7 +12,6 @@ using GovUk.Frontend.Umbraco.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using System;
 using ThePensionsRegulator.Umbraco;
 using ThePensionsRegulator.Umbraco.PropertyEditors;
 
@@ -69,6 +69,7 @@ namespace GovUk.Frontend.Umbraco
             services.AddTransient<IGovUkHeadingClassProvider, GovUkHeadingClassProvider>();
             services.AddTransient<BlockViewService>();
             services.AddTransient<IModelPropertyProvider, ModelTypeAttributeModelPropertyProvider>();
+            services.AddTransient<IStaticFileCachePolicy, GovUkUmbracoStaticFileCachePolicy>();
 
             return services;
         }

--- a/ThePensionsRegulator.Frontend.Tests/Caching/TprStaticFileCachePolicyTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Caching/TprStaticFileCachePolicyTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Http;
+using System.Web;
+using ThePensionsRegulator.Frontend.Caching;
+
+namespace ThePensionsRegulator.Frontend.Tests.Caching
+{
+    public class TprStaticFileCachePolicyTests
+    {
+        private readonly TprStaticFileCachePolicy _policy = new();
+
+        [Theory]
+        [InlineData("/_content/ThePensionsRegulator.Frontend/style.css?v=1.0.0", true)]
+        [InlineData("/_content/ThePensionsRegulator.Frontend/script.js?v=1.0.0", true)]
+        [InlineData("/_content/ThePensionsRegulator.Frontend/image.png?v=1.0.0", true)]
+        [InlineData("/_content/ThePensionsRegulator.Frontend/open-sans.woff?v=1.0.0", true)]
+        [InlineData("/_CONTENT/THEPENSIONSREGULATOR.FRONTEND/STYLE.CSS?v=1.0.0", true)]
+
+        // no path
+        [InlineData("?v=1.0.0", false)]
+
+        // wrong path
+        [InlineData("/_content/OtherPackage/style.css?v=1.0.0", false)]
+        [InlineData("/_content/ThePensionsRegulator/style.css?v=1.0.0", false)]
+        [InlineData("/other-content/ThePensionsRegulator.Frontend/style.css?v=1.0.0", false)]
+
+        // no querystring
+        [InlineData("/_content/ThePensionsRegulator.Frontend/style.css", false)]
+        [InlineData("/other/file.js", false)]
+
+        // wrong querystring
+        [InlineData("/_content/ThePensionsRegulator.Frontend/style.css?other=value", false)]
+        [InlineData("/_content/ThePensionsRegulator.Frontend/image.png?v=", false)]
+        public void IsImmutable_ReturnsExpectedResult(string path, bool expected)
+        {
+            // Arrange
+            var url = new Uri("https://example.com" + path);
+            var query = HttpUtility.ParseQueryString(url.Query);
+            var dict = query.Keys.OfType<string>().ToDictionary(k => k, k => (Microsoft.Extensions.Primitives.StringValues)query[k]);
+
+            // Act
+            var result = _policy.IsImmutable(path, new QueryCollection(dict));
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Caching/TprUmbracoStaticFileCachePolicyTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Caching/TprUmbracoStaticFileCachePolicyTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Http;
+using System.Web;
+using ThePensionsRegulator.Frontend.Umbraco.Caching;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Caching
+{
+    public class TprUmbracoStaticFileCachePolicyTests
+    {
+        private readonly TprUmbracoStaticFileCachePolicy _policy = new();
+
+        [Theory]
+        [InlineData("/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/tpr-component-hfdksfhks.js", true)]
+        [InlineData("/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/package-version.generated-hjrkehwrk.js", true)]
+        [InlineData("/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/example-helper-code-hdjskhfjds.js", true)]
+        [InlineData("/tpr/tpr.css?v=1.0.0", true)]
+        [InlineData("/TPR/TPR.CSS?v=1.0.0", true)]
+
+        // no path
+        [InlineData("?v=1.0.0", false)]
+
+        // wrong path
+        [InlineData("/_content/OtherPackage/style.css?v=1.0.0", false)]
+        [InlineData("/_content/ThePensionsRegulator/style.css?v=1.0.0", false)]
+        [InlineData("/other-content/ThePensionsRegulator.Frontend.Umbraco/tpr-component-hfjdkfs.js", false)]
+
+        // no querystring
+        [InlineData("/tpr/tpr.css", false)]
+        [InlineData("/other/file.js", false)]
+
+        // wrong querystring
+        [InlineData("/tpr/tpr.css?other=value", false)]
+        [InlineData("/tpr/tpr.css?v=", false)]
+        public void IsImmutable_ReturnsExpectedResult(string path, bool expected)
+        {
+            // Arrange
+            var url = new Uri("https://example.com" + path);
+            var query = HttpUtility.ParseQueryString(url.Query);
+            var dict = query.Keys.OfType<string>().ToDictionary(k => k, k => (Microsoft.Extensions.Primitives.StringValues)query[k]);
+
+            // Act
+            var result = _policy.IsImmutable(path, new QueryCollection(dict));
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/Caching/TprUmbracoStaticFileCachePolicy.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Caching/TprUmbracoStaticFileCachePolicy.cs
@@ -1,0 +1,18 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Caching;
+using Microsoft.AspNetCore.Http;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Caching
+{
+    public class TprUmbracoStaticFileCachePolicy : IStaticFileCachePolicy
+    {
+        public bool IsImmutable(string path, IQueryCollection query)
+        {
+            const string basePath = "/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/";
+
+            return path.StartsWith($"{basePath}tpr-", StringComparison.OrdinalIgnoreCase) ||
+                   path.StartsWith($"{basePath}package-version.generated-", StringComparison.OrdinalIgnoreCase) ||
+                  (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase) && path.Contains("-helper-", StringComparison.OrdinalIgnoreCase)) ||
+                  (path.StartsWith("/tpr/tpr.css", StringComparison.OrdinalIgnoreCase) && query.ContainsKey("v") && !string.IsNullOrEmpty(query["v"]));
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -1,14 +1,15 @@
 using GovUk.Frontend.AspNetCore;
+using GovUk.Frontend.AspNetCore.Extensions.Caching;
 using GovUk.Frontend.AspNetCore.Extensions.Security;
 using GovUk.Frontend.Umbraco;
 using GovUk.Frontend.Umbraco.Blocks;
 using GovUk.Frontend.Umbraco.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using System;
+using ThePensionsRegulator.Frontend.Caching;
 using ThePensionsRegulator.Frontend.Security;
 using ThePensionsRegulator.Frontend.Services;
-using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors;
+using ThePensionsRegulator.Frontend.Umbraco.Caching;
 using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
 using ThePensionsRegulator.Frontend.Umbraco.Services;
 using ThePensionsRegulator.Umbraco.PropertyEditors;
@@ -81,6 +82,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             // ThePensionsRegulator.Frontend
             services.AddTransient<IConsentCookieReader, TprConsentCookieReader>();
             services.AddTransient<IContextAwareHostUpdater, TprHostUpdater>();
+            services.AddTransient<IStaticFileCachePolicy, TprStaticFileCachePolicy>();
 
             var tprFrontendOptions = new TprFrontendOptions();
             if (configureTprOptions is not null) { configureTprOptions(tprFrontendOptions); }
@@ -96,6 +98,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             services.AddTransient<IDefaultColumnClassProvider, TprSectionCardsColumnClassProvider>();
             services.AddTransient<IYouTubeVideoIdParser, YouTubeVideoIdParser>();
             services.AddTransient<ITprGlobalNavigationService, TprGlobalNavigationService>();
+            services.AddTransient<IStaticFileCachePolicy, TprUmbracoStaticFileCachePolicy>();
 
             return services;
         }

--- a/ThePensionsRegulator.Frontend/Caching/TprStaticFileCachePolicy.cs
+++ b/ThePensionsRegulator.Frontend/Caching/TprStaticFileCachePolicy.cs
@@ -1,0 +1,14 @@
+﻿using GovUk.Frontend.AspNetCore.Extensions.Caching;
+using Microsoft.AspNetCore.Http;
+
+namespace ThePensionsRegulator.Frontend.Caching
+{
+    public class TprStaticFileCachePolicy : IStaticFileCachePolicy
+    {
+        public bool IsImmutable(string path, IQueryCollection query)
+        {
+            return path.StartsWith("/_content/ThePensionsRegulator.Frontend/", StringComparison.OrdinalIgnoreCase) &&
+                   query.ContainsKey("v") && !string.IsNullOrEmpty(query["v"]);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 using GovUk.Frontend.AspNetCore;
 using GovUk.Frontend.AspNetCore.Extensions;
+using GovUk.Frontend.AspNetCore.Extensions.Caching;
 using GovUk.Frontend.AspNetCore.Extensions.Security;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using System;
+using ThePensionsRegulator.Frontend.Caching;
 using ThePensionsRegulator.Frontend.Security;
 using ThePensionsRegulator.Frontend.Services;
 
@@ -33,6 +34,7 @@ namespace ThePensionsRegulator.Frontend
 
             services.AddTransient<IContextAwareHostUpdater, TprHostUpdater>();
             services.AddTransient<IConsentCookieReader, TprConsentCookieReader>();
+            services.AddTransient<IStaticFileCachePolicy, TprStaticFileCachePolicy>();
 
             services.AddGovUkFrontendExtensions(configureGovUkOptions);
 

--- a/docs/aspnet/new-aspnet-project-govuk.md
+++ b/docs/aspnet/new-aspnet-project-govuk.md
@@ -24,6 +24,8 @@
    }
    ```
 
+   You shouldn't need to call `app.UseStaticFiles()` as it's called for you, but if you do it must be called after `app.UseGovUkFrontendExtensions()`.
+
 4. Add partial views and the `govuk-template__body` class to `Views/Shared/_Layout.cshtml` as shown below. You should also make sure you have a `<main>` element in your markup.
 
    ```html

--- a/docs/aspnet/new-aspnet-project-tpr.md
+++ b/docs/aspnet/new-aspnet-project-tpr.md
@@ -29,6 +29,8 @@
    }
    ```
 
+   You shouldn't need to call `app.UseStaticFiles()` as it's called for you, but if you do it must be called after `app.UseTprFrontend()`.
+
 6. Add partial views and the `govuk-template__body` class to `Views/Shared/_Layout.cshtml` as shown below. You should also make sure you have a `<main>` element in your markup.
 
    ```html

--- a/docs/contributing/include-client-side-files-in-packages.md
+++ b/docs/contributing/include-client-side-files-in-packages.md
@@ -23,3 +23,24 @@ Update the `*.csproj` file to add the `<package-name>.props` file to the package
     <PackagePath>build;buildTransitive</PackagePath>
 </Content>
 ```
+
+## Minifying and caching client-side files
+
+When including a client-side file on a page, always enable client-side caching with a cache-busting parameter that ensures the cache is reset when a new version of the package is published.
+
+### JavaScript files
+
+Configure minification in `bundleconfig.json` at the root of the project. This is processed by the `BuildBundlerMinifier` NuGet package. Then use `asp-append-version="true"` to add a cache-busting parameter:
+
+```razor
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+<script src="/<package-name>/js/my-js-file.min.js" type="module" asp-append-version="true"></script>
+```
+
+### Add a Cache-Control header
+
+If you add files to expected locations they will automatically get a `Cache-Control` header which caches them for a long time.
+
+This is controlled by a class in each project which implements `ThePensionsRegulator.GovUk.Frontend.Caching.IStaticFileCachePolicy`. You can update the class for the project you're working on if you need the header added to other client-side paths.
+
+`ThePensionsRegulator.GovUk.Frontend.Caching.CacheStaticFilesMiddleware` looks at all the `IStaticFileCachePolicy` instances and, if the path of the request matches, it adds the `Cache-Control` header.

--- a/docs/umbraco/new-umbraco-project-govuk.md
+++ b/docs/umbraco/new-umbraco-project-govuk.md
@@ -104,12 +104,12 @@
     WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
     builder.Services.AddGovUkFrontendUmbraco();
 
-    // default code from `builder.CreateUmbracoBuilder()` down to `app.UseUmbraco()` goes here...
-
     var mvcOptions = app.Services.GetRequiredService<IOptions<MvcOptions>>();
     var umbracoContextAccessor = app.Services.GetRequiredService<IUmbracoContextAccessor>();
     var publishedValueFallback = app.Services.GetRequiredService<IPublishedValueFallback>();
     app.UseGovUkFrontendUmbraco(mvcOptions, umbracoContextAccessor, publishedValueFallback);
+
+    // default code from `builder.CreateUmbracoBuilder()` down to `app.UseUmbraco()` goes here...
 
     // await app.RunAsync(); goes here...
     ```

--- a/docs/umbraco/new-umbraco-project-tpr.md
+++ b/docs/umbraco/new-umbraco-project-tpr.md
@@ -113,12 +113,12 @@
     WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
     builder.Services.AddTprFrontendUmbraco();
 
-    // default code from `builder.CreateUmbracoBuilder()` down to `app.UseUmbraco()` goes here...
-
     var mvcOptions = app.Services.GetRequiredService<IOptions<MvcOptions>>();
     var umbracoContextAccessor = app.Services.GetRequiredService<IUmbracoContextAccessor>();
     var publishedValueFallback = app.Services.GetRequiredService<IPublishedValueFallback>();
     app.UseTprFrontendUmbraco(mvcOptions, umbracoContextAccessor, publishedValueFallback);
+
+    // default code from `builder.CreateUmbracoBuilder()` down to `app.UseUmbraco()` goes here...
 
     // await app.RunAsync(); goes here...
     ```


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

In Umbraco 13 [Smidge](https://github.com/shazwazza/smidge) was included by default for bundling and minifying client-side assets. Between v13 and v17 it was removed, and so this PR is part of a complete review of how we include client-side assets. 

Recent PRs have added a cache-busting parameter to our scripts and stylesheets. This PR adds long-term cache headers to those files, knowing that the cache-busting parameter will change if the files change so the cache will not prevent the user receiving up-to-date files. 

This will speed up consuming sites for users and reduce bandwidth usage (and cost) for both users and us.

The implementation is designed to affect only the scripts and CSS provided in these packages, identified by their paths. For example `site.css` is not cached because it's intended to be replaced and linked by the consuming project, and we can't predict how they'll manage it. Images, fonts and favicon.ico are all tackled in later PRs.

It is extensible for consuming sites to implement `IStaticFileCachePolicy` to add more paths to be cached. (They could also just add the cache header another way.)

The order of calls during startup is changed because `app.UseStaticFiles()` short-circuits, meaning once it identifies a file as a static file it prevents all further middleware from running, therefore the caching middleware must be called before that.

## Out-of-scope for this PR

Everything else. 

Outside of the backoffice you can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- the Umbraco backoffice works

Otherwise you can expect:
- build warnings
- TODO comments in code
- broken client-side features (ie JavaScript) because the client-side review is not complete
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Further improved support for client-side assets following removal of Smidge between Umbraco 13 and 17
- Refactor MSBuild code to remove a lot of duplication and complexity
- Fixing the favicon bug we've been working around since the release of .NET 9
- Fix the unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating namespaces for greater clarity
- Modernising example apps and docs to support top-level statements in Program.cs
- Fix task list non-conformance issues
- Convert all remaining NUnit tests to XUnit

#535