### PR TITLE
#254381 Include list of documents component within the accordion component

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.1.0</Version>
+    <Version>9.2.0</Version>
   </PropertyGroup>
 </Project>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRAccordionSectionBlockGrid.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v9/DataTypes/TPRAccordionSectionBlockGrid.config
@@ -754,6 +754,27 @@
       "stylesheet": "~/css/govuk-umbraco-backoffice.css",
       "thumbnail": null,
       "view": "~/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRYouTubeVideo.html"
+    },
+    {
+      "allowAtRoot": true,
+      "allowInAreas": true,
+      "areaGridColumns": null,
+      "areas": [],
+      "backgroundColor": null,
+      "columnSpanOptions": [],
+      "contentElementTypeKey": "f08c68b1-f171-4941-83b2-1ededfa019ab",
+      "editorSize": "medium",
+      "forceHideContentEditorInOverlay": false,
+      "groupKey": "0cda3bd0-ba4f-483e-9402-09a275a172a9",
+      "iconColor": null,
+      "inlineEditing": false,
+      "label": "",
+      "rowMaxSpan": 1,
+      "rowMinSpan": 1,
+      "settingsElementTypeKey": null,
+      "stylesheet": "~/css/govuk-umbraco-backoffice.css",
+      "thumbnail": null,
+      "view": "~/App_Plugins/ThePensionsRegulator.Frontend.Umbraco/blocks/views/TPRDocuments.html"
     }
   ],
   "CreateLabel": null,

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
@@ -7,7 +7,7 @@
 @addTagHelper *, ThePensionsRegulator.Frontend
 
 @{
-    var outerCssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var outerCssClasses = Model.Settings is not null ? Model.Settings.Value<string>(PropertyAliases.CssClasses) : "";
     var documents = Model.Content.Value<IEnumerable<BlockListItem>>(TprPropertyAliases.DocumentsBlockList);
 }
 


### PR DESCRIPTION
In this PR:
- Including the list of documents component as an option within the TPR accordion component;
- Iterated the version from v9.1.0 to v9.2.0, as I intend to publish a new version once this PR is merged.