### PR TITLE
256262 FAQs with multiple CTA don't go to widget

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.2.0</Version>
+    <Version>9.2.1</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
@@ -452,8 +452,8 @@ document.addEventListener("DOMContentLoaded", function () {
 
     initialiseAccordion();
 
-    const navigateToSearchButton = document.getElementsByClassName("tpr-search-results__nav-button")[0];
-    if (navigateToSearchButton != null) {
+    const navigateToSearchButtons = document.getElementsByClassName("tpr-search-results__nav-button");
+    for (const navigateToSearchButton of navigateToSearchButtons) {
         const newTabSpan = navigateToSearchButton.querySelector("span.govuk-visually-hidden");
         if (newTabSpan) {
             newTabSpan.remove();


### PR DESCRIPTION
This pull request includes a version bump and a JavaScript enhancement to improve accessibility handling for navigation buttons on the search results page.

Versioning:

* Updated the project version in `Directory.Build.props` from `9.2.0` to `9.2.1`.

Frontend accessibility improvement:

* Modified the logic in `tpr-search-results.js` so that accessibility-related changes (removal of visually hidden spans) are applied to all elements with the `tpr-search-results__nav-button` class, instead of just the first one. This ensures consistent behavior across multiple navigation buttons.