### PR TITLE
Refactor MSBuild to remove duplicated logic

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Directory.Build.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions/Directory.Build.targets
@@ -34,6 +34,26 @@
 		<Message Text="SassCompiler complete for $(MSBuildProjectFullPath)" Importance="high"/>
 	</Target>
 
+	<Target Name="GovUkFrontend_GenerateProps" BeforeTargets="BeforeBuild">
+		 <!--Generate a .props file so that ThePensionsRegulator.GovUk.Frontend.targets has access to the package version. --> 
+		<Message Text="ThePensionsRegulator.GovUk.Frontend generating $(ProjectDir)ThePensionsRegulator.GovUk.Frontend.props" Importance="high" />
+		<ItemGroup>
+			<TprGovUkFrontendPropsText Include="TprGovUkFrontendPropsText">
+				<Text>
+					<![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<TprGovUkFrontendPackageVersion>$(Version)</TprGovUkFrontendPackageVersion>
+	</PropertyGroup>
+</Project>
+				]]></Text>
+			</TprGovUkFrontendPropsText>
+			<TprGovUkFrontendProps Include="%(TprGovUkFrontendPropsText.Text)" />
+		</ItemGroup>
+		<WriteLinesToFile File="$(ProjectDir)ThePensionsRegulator.GovUk.Frontend.generated.props" Lines="@(TprGovUkFrontendProps)" Overwrite="True" />
+	</Target>
+
 	<!-- Clean up obsolete files from previous versions where they would cause a conflict. -->
 	<Target Name="GovUkFrontend_Clean" Condition="Exists('$(ProjectDir)wwwroot\govuk\')">
 		<ItemGroup>

--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -145,6 +145,10 @@
 			<Pack>true</Pack>
 			<PackagePath>build;buildTransitive</PackagePath>
 		</Content>
+		<Content Include="ThePensionsRegulator.GovUk.Frontend.generated.props">
+			<Pack>true</Pack>
+			<PackagePath>build</PackagePath>
+		</Content>
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
@@ -1,70 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Target Name="ThePensionsRegulatorGovUkFrontend" BeforeTargets="BeforeBuild">
-		<!-- Look for the PackageReference to this package to get the current version.
-			 Use that version to find the NuGet package folder, and copy govuk-frontend SASS files to the Styles folder in the consuming project.
-			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="TprGovUkFrontendVersion" />
-		</XmlPeek>
+	<Import Project="..\build\ThePensionsRegulator.GovUk.Frontend.generated.props"/>
 
+	<Target Name="ThePensionsRegulatorGovUkFrontend" BeforeTargets="BeforeBuild">
 		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
 			<Output TaskParameter="Result" ItemName="TprGovUkFrontend_TargetProjectSdk" />
 		</XmlPeek>
 		<PropertyGroup>
-			<TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend Condition="@(TprGovUkFrontendVersion->Count() )>0">true</TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend>
-			<TprGovUkFrontend_TargetProjectIsWebProject Condition="@(TprGovUkFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Web'">true</TprGovUkFrontend_TargetProjectIsWebProject>
 			<TprGovUkFrontend_TargetProjectIsWebOrRclProject Condition="@(TprGovUkFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(TprGovUkFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</TprGovUkFrontend_TargetProjectIsWebOrRclProject>
 		</PropertyGroup>
 
 		<!-- Copy files from this project to the consuming project. -->
 		<Message Text="ThePensionsRegulator.GovUk.Frontend not copying SASS files from ThePensionsRegulator.GovUk.Frontend because the target project is not a web project or Razor class library." Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) != true" Importance="high" />
-		<Message Text="ThePensionsRegulator.GovUk.Frontend not copying SASS files from ThePensionsRegulator.GovUk.Frontend because it is a transitive dependency without access to the correct path. These may be copied by the package that references ThePensionsRegulator.GovUk.Frontend or you may need to add a direct reference to ThePensionsRegulator.GovUk.Frontend." Importance="high"
-				 Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) == true And $(TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend) != true"/>
-		<CallTarget Targets="TprGovUkFrontend_CopyFiles" Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) == true And $(TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend) == true" />
-		<CallTarget Targets="TprGovUkFrontend_GenerateFiles" Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) == true" />
+		<CallTarget Targets="TprGovUkFrontend_CopyFiles" Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) == true" />
 	</Target>
 
 	<Target Name="TprGovUkFrontend_CopyFiles">
-		<!-- Look for the PackageReference to this package to get the current version.
-			 Use that version to find the NuGet package folder, and copy govuk-frontend SASS files to the Styles folder in the consuming project.
-			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="ThePensionsRegulatorGovUkFrontendVersion" />
-		</XmlPeek>
+		<!-- Use the version of this package to find the NuGet package folder, and copy files from the package to the consuming project. -->
 		<PropertyGroup>
-			<ThePensionsRegulatorGovUkFrontendVersion>@(ThePensionsRegulatorGovUkFrontendVersion)</ThePensionsRegulatorGovUkFrontendVersion>
-			<TprGovUkFrontend_CopyFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprGovUkFrontend_CopyFiles_StylesFolderExists>
-			<TprGovUkFrontend_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprGovUkFrontend_CopyFiles_UserProfile>
-			<TprGovUkFrontend_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprGovUkFrontend_CopyFiles_UserProfile>
-			<ThePensionsRegulatorGovUkFrontendSassFolder>$(TprGovUkFrontend_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
+			<TprGovUkFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprGovUkFrontend_StylesFolderExists>
+			<TprGovUkFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprGovUkFrontend_UserProfile>
+			<TprGovUkFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprGovUkFrontend_UserProfile>
+			<ThePensionsRegulatorGovUkFrontendSassFolder>$(TprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(TprGovUkFrontendPackageVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(ThePensionsRegulatorGovUkFrontendSassFolder)**\*.scss" />
 		</ItemGroup>
 
-		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.targets, ThePensionsRegulator.GovUk.Frontend.Umbraco.targets 
-		     and ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="ThePensionsRegulator.GovUk.Frontend not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high" Condition="$(TprGovUkFrontend_CopyFiles_StylesFolderExists) != true" />
-		<Message Text="ThePensionsRegulator.GovUk.Frontend copying SASS files from $(ThePensionsRegulatorGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high" Condition="$(TprGovUkFrontend_CopyFiles_StylesFolderExists) == true" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high" Condition="$(TprGovUkFrontend_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend copying SASS files from $(ThePensionsRegulatorGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high" Condition="$(TprGovUkFrontend_StylesFolderExists) == true" />
 
 		<Copy SourceFiles="@(ThePensionsRegulatorGovUkFrontendSassFiles)"
 			  DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(TprGovUkFrontend_CopyFiles_StylesFolderExists) == true" />
+			  Condition="$(TprGovUkFrontend_StylesFolderExists) == true" />
 
-	</Target>
-
-	<Target Name="TprGovUkFrontend_GenerateFiles">
 		<!-- Generate a .gitignore so that govuk-frontend SASS files copied from this package are not committed to the consuming project's source control.
 			 Only do that if the folder exists, otherwise they'll also get created in an projects with no interest in SASS. -->
-		<PropertyGroup>
-			<TprGovUkFrontend_GenerateFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprGovUkFrontend_GenerateFiles_StylesFolderExists>
-		</PropertyGroup>
-
-		<Message Text="ThePensionsRegulator.GovUk.Frontend generating $(ProjectDir)Styles\govuk\.gitignore to prevent commit of SASS files copied into the project" Importance="high" Condition="$(TprGovUkFrontend_GenerateFiles_StylesFolderExists) == true" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend generating $(ProjectDir)Styles\govuk\.gitignore to prevent commit of SASS files copied into the project." Importance="high" Condition="$(TprGovUkFrontend_StylesFolderExists) == true" />
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendGitIgnoreText Include="ThePensionsRegulatorGovUkFrontendGitIgnoreText">
 				<Text>
@@ -75,7 +48,7 @@
 			</ThePensionsRegulatorGovUkFrontendGitIgnoreText>
 			<ThePensionsRegulatorGovUkFrontendGitIgnore Include="%(ThePensionsRegulatorGovUkFrontendGitIgnoreText.Text)" />
 		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)Styles\govuk\.gitignore" Lines="@(ThePensionsRegulatorGovUkFrontendGitIgnore)" Overwrite="True" Condition="$(TprGovUkFrontend_GenerateFiles_StylesFolderExists) == true" />
+		<WriteLinesToFile File="$(ProjectDir)Styles\govuk\.gitignore" Lines="@(ThePensionsRegulatorGovUkFrontendGitIgnore)" Overwrite="True" Condition="$(TprGovUkFrontend_StylesFolderExists) == true" />
 	</Target>
 	
 	<!-- In pipeline builds if a CSS file exists AspNetCore.SassCompiler won't overwrite it with the generated version, 

--- a/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions/ThePensionsRegulator.GovUk.Frontend.targets
@@ -5,49 +5,81 @@
 			 Use that version to find the NuGet package folder, and copy govuk-frontend SASS files to the Styles folder in the consuming project.
 			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
 		-->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
+			<Output TaskParameter="Result" ItemName="TprGovUkFrontendVersion" />
+		</XmlPeek>
+
+		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
+			<Output TaskParameter="Result" ItemName="TprGovUkFrontend_TargetProjectSdk" />
+		</XmlPeek>
 		<PropertyGroup>
-			<UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</UserProfile>
-			<UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</UserProfile>
+			<TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend Condition="@(TprGovUkFrontendVersion->Count() )>0">true</TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend>
+			<TprGovUkFrontend_TargetProjectIsWebProject Condition="@(TprGovUkFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Web'">true</TprGovUkFrontend_TargetProjectIsWebProject>
+			<TprGovUkFrontend_TargetProjectIsWebOrRclProject Condition="@(TprGovUkFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(TprGovUkFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</TprGovUkFrontend_TargetProjectIsWebOrRclProject>
 		</PropertyGroup>
+
+		<!-- Copy files from this project to the consuming project. -->
+		<Message Text="ThePensionsRegulator.GovUk.Frontend not copying SASS files from ThePensionsRegulator.GovUk.Frontend because the target project is not a web project or Razor class library." Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) != true" Importance="high" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend not copying SASS files from ThePensionsRegulator.GovUk.Frontend because it is a transitive dependency without access to the correct path. These may be copied by the package that references ThePensionsRegulator.GovUk.Frontend or you may need to add a direct reference to ThePensionsRegulator.GovUk.Frontend." Importance="high"
+				 Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) == true And $(TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend) != true"/>
+		<CallTarget Targets="TprGovUkFrontend_CopyFiles" Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) == true And $(TprGovUkFrontend_HasPackageReferenceToTprGovUkFrontend) == true" />
+		<CallTarget Targets="TprGovUkFrontend_GenerateFiles" Condition="$(TprGovUkFrontend_TargetProjectIsWebOrRclProject) == true" />
+	</Target>
+
+	<Target Name="TprGovUkFrontend_CopyFiles">
+		<!-- Look for the PackageReference to this package to get the current version.
+			 Use that version to find the NuGet package folder, and copy govuk-frontend SASS files to the Styles folder in the consuming project.
+			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
+		-->
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
 			<Output TaskParameter="Result" ItemName="ThePensionsRegulatorGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<ThePensionsRegulatorGovUkFrontendVersion>@(ThePensionsRegulatorGovUkFrontendVersion)</ThePensionsRegulatorGovUkFrontendVersion>
-			<ThePensionsRegulatorGovUkFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
+			<TprGovUkFrontend_CopyFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprGovUkFrontend_CopyFiles_StylesFolderExists>
+			<TprGovUkFrontend_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprGovUkFrontend_CopyFiles_UserProfile>
+			<TprGovUkFrontend_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprGovUkFrontend_CopyFiles_UserProfile>
+			<ThePensionsRegulatorGovUkFrontendSassFolder>$(TprGovUkFrontend_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(ThePensionsRegulatorGovUkFrontendSassFolder)**\*.scss" />
 		</ItemGroup>
 
-		<Message Text="Not copying govuk-frontend SASS files to the Styles folder because ThePensionsRegulator.GovUk.Frontend is a transitive dependency. These may be copied by the package that references ThePensionsRegulator.GovUk.Frontend or you may need to add a direct reference to ThePensionsRegulator.GovUk.Frontend." Importance="high"
-			     Condition="@(ThePensionsRegulatorGovUkFrontendVersion->Count() )==0"/>
-		
 		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.targets, ThePensionsRegulator.GovUk.Frontend.Umbraco.targets 
 		     and ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="Copying govuk-frontend SASS files from $(ThePensionsRegulatorGovUkFrontendSassFolder) to $(ProjectDir)" Importance="high"
-			     Condition="@(ThePensionsRegulatorGovUkFrontendVersion->Count() )==1"/>
+		<Message Text="ThePensionsRegulator.GovUk.Frontend not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high" Condition="$(TprGovUkFrontend_CopyFiles_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend copying SASS files from $(ThePensionsRegulatorGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high" Condition="$(TprGovUkFrontend_CopyFiles_StylesFolderExists) == true" />
+
 		<Copy SourceFiles="@(ThePensionsRegulatorGovUkFrontendSassFiles)"
 			  DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="@(ThePensionsRegulatorGovUkFrontendVersion->Count() )==1"/>
+			  Condition="$(TprGovUkFrontend_CopyFiles_StylesFolderExists) == true" />
 
+	</Target>
+
+	<Target Name="TprGovUkFrontend_GenerateFiles">
 		<!-- Generate a .gitignore so that govuk-frontend SASS files copied from this package are not committed to the consuming project's source control.
-			 Only do that if the folder exists, otherwise they'll also get created in a test project with a project reference to the target project. -->
-		<Message Text="Generating $(ProjectDir)Styles\govuk\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)Styles')" />
+			 Only do that if the folder exists, otherwise they'll also get created in an projects with no interest in SASS. -->
+		<PropertyGroup>
+			<TprGovUkFrontend_GenerateFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprGovUkFrontend_GenerateFiles_StylesFolderExists>
+		</PropertyGroup>
+
+		<Message Text="ThePensionsRegulator.GovUk.Frontend generating $(ProjectDir)Styles\govuk\.gitignore to prevent commit of SASS files copied into the project" Importance="high" Condition="$(TprGovUkFrontend_GenerateFiles_StylesFolderExists) == true" />
 		<ItemGroup>
 			<ThePensionsRegulatorGovUkFrontendGitIgnoreText Include="ThePensionsRegulatorGovUkFrontendGitIgnoreText">
 				<Text>
+# Generated by ThePensionsRegulator.GovUk.Frontend
 *
 !.gitignore
 				</Text>
 			</ThePensionsRegulatorGovUkFrontendGitIgnoreText>
 			<ThePensionsRegulatorGovUkFrontendGitIgnore Include="%(ThePensionsRegulatorGovUkFrontendGitIgnoreText.Text)" />
 		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)Styles\govuk\.gitignore" Lines="@(ThePensionsRegulatorGovUkFrontendGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)Styles')" />
+		<WriteLinesToFile File="$(ProjectDir)Styles\govuk\.gitignore" Lines="@(ThePensionsRegulatorGovUkFrontendGitIgnore)" Overwrite="True" Condition="$(TprGovUkFrontend_GenerateFiles_StylesFolderExists) == true" />
 	</Target>
-
+	
 	<!-- In pipeline builds if a CSS file exists AspNetCore.SassCompiler won't overwrite it with the generated version, 
-	     so look for SCSS files which will generate CSS files, and delete the equivalent CSS file first -->
+	    so look for SCSS files which will generate CSS files, and delete the equivalent CSS file first -->
 	<Target Name="ThePensionsRegulatorGovUkFrontend_CleanGeneratedCss" BeforeTargets="CoreClean">
 		<ItemGroup>
 			<ScssSourceFiles Include="$(MSBuildProjectDirectory)\Styles\*.scss" Exclude="$(MSBuildProjectDirectory)\Styles\_*.scss" />

--- a/GovUk.Frontend.Umbraco/Directory.Build.targets
+++ b/GovUk.Frontend.Umbraco/Directory.Build.targets
@@ -56,4 +56,26 @@
 		<Message Text="Deleting obsolete files: @(GovUkFrontendUmbraco_DirsToRemove)" />
 		<RemoveDir Directories="@(GovUkFrontendUmbraco_DirsToRemove)" />
 	</Target>
+
+	<Target Name="TprGovUkFrontendUmbraco_GenerateProps" BeforeTargets="BeforeBuild">
+		<!--Generate a .props file so that ThePensionsRegulator.GovUk.Frontend.Umbraco.targets has access to the package version. -->
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco generating $(ProjectDir)ThePensionsRegulator.GovUk.Frontend.Umbraco.props" Importance="high" />
+		<ItemGroup>
+			<TprGovUkFrontendUmbracoPropsText Include="TprGovUkFrontendUmbracoPropsText">
+				<Text>
+					<![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<TprGovUkFrontendUmbracoPackageVersion>$(Version)</TprGovUkFrontendUmbracoPackageVersion>
+	</PropertyGroup>
+</Project>
+				]]>
+				</Text>
+			</TprGovUkFrontendUmbracoPropsText>
+			<TprGovUkFrontendUmbracoProps Include="%(TprGovUkFrontendUmbracoPropsText.Text)" />
+		</ItemGroup>
+		<WriteLinesToFile File="$(ProjectDir)ThePensionsRegulator.GovUk.Frontend.Umbraco.generated.props" Lines="@(TprGovUkFrontendUmbracoProps)" Overwrite="True" />
+	</Target>
+
 </Project>

--- a/GovUk.Frontend.Umbraco/Directory.Build.targets
+++ b/GovUk.Frontend.Umbraco/Directory.Build.targets
@@ -38,13 +38,7 @@
 		<Copy SourceFiles="@(ContentTypes)"
 			DestinationFiles="$(ProjectDir)uSync\v17\ContentTypes\%(RecursiveDir)%(Filename)%(Extension)" />
 	</Target>
-
-	<!-- Restore npm packages for backoffice development. -->
-	<Target Name="GovUkFrontendUmbraco_NpmInstall" BeforeTargets="BeforeBuild">
-		<Message Text="Restoring Backoffice npm packages" Importance="high" />
-		<Exec Command="npm install" WorkingDirectory="Backoffice" />
-	</Target>
-
+	
 	<!-- Create a version to use as a cache-busting parameter for backoffice customisation -->
 	<Target Name="GovUkFrontendUmbraco_GenerateTypeScriptVersion" BeforeTargets="Build">
 		<WriteLinesToFile

--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -43,6 +43,10 @@
 		  <PackagePath>build;buildTransitive</PackagePath>
 		  <Pack>true</Pack>
 		</Content>
+		<Content Include="ThePensionsRegulator.GovUk.Frontend.Umbraco.generated.props">
+			<PackagePath>build</PackagePath>
+			<Pack>true</Pack>
+		</Content>
 		<Content Include="Styles\govuk-umbraco-backoffice.css">
 			<PackagePath>contentFiles\any\$(TargetFramework)\Content\css</PackagePath>
 			<Pack>true</Pack>

--- a/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
+++ b/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
@@ -1,123 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="..\build\ThePensionsRegulator.GovUk.Frontend.Umbraco.generated.props"/>
+	
 	<Target Name="ThePensionsRegulatorGovUkFrontendUmbraco" AfterTargets="ThePensionsRegulatorGovUkFrontend">
-		<!-- Look for the PackageReference to this package to get the current version.
-			 Use that version to find the NuGet package folder, and copy files to the consuming project.
-			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbracoVersion" />
-		</XmlPeek>
-
 		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
 			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_TargetProjectSdk" />
 		</XmlPeek>
 		<PropertyGroup>
-			<GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco Condition="@(GovUkFrontendUmbracoVersion->Count() )>0">true</GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco>
 			<GovUkFrontendUmbraco_TargetProjectIsWebProject Condition="@(GovUkFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web'">true</GovUkFrontendUmbraco_TargetProjectIsWebProject>
-			<GovUkFrontendUmbraco_TargetProjectIsWebOrRclProject Condition="@(GovUkFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(GovUkFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</GovUkFrontendUmbraco_TargetProjectIsWebOrRclProject>
 		</PropertyGroup>
 
-		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend to the consuming project if it is a transitive dependency. -->
-		<CallTarget Targets="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend" Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebOrRclProject) == true And $(GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco) == true" />
-	
 		<!-- Copy files from this project to the consuming project. -->
-		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.GovUk.Frontend.Umbraco because the target project is not a web project." Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
-		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.GovUk.Frontend.Umbraco because it is a transitive dependency without access to the correct path. These may be copied by the package that references ThePensionsRegulator.GovUk.Frontend.Umbraco or you may need to add a direct reference to ThePensionsRegulator.GovUk.Frontend.Umbraco. .gitignore and site.css files will be generated." Importance="high"
-				 Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) == true And $(GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco) != true"/>
-		<CallTarget Targets="GovUkFrontendUmbraco_CopyFiles" Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) == true And $(GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco) == true" />
-		<CallTarget Targets="GovUkFrontendUmbraco_GenerateFiles" Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) == true" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco not copying uSync and backoffice CSS files from ThePensionsRegulator.GovUk.Frontend.Umbraco because the target project is not a web project." Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
+		<CallTarget Targets="GovUkFrontendUmbraco_CopyFiles" Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) == true" />
 
 		<!-- If the ModelsBuilder out-of-date flag is present, show a helpful warning. -->
 		<Warning Text="Umbraco Models Builder models are out-of-date. Go to Settings &gt; Models Builder &gt; Generate models in the Umbraco backoffice to update them." Condition="Exists('$(ProjectDir)Models\ModelsBuilder\ood.flag')" />
 	</Target>
 
-	<Target Name="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend">
-		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion" />
-		</XmlPeek>
-		
-		<PropertyGroup>
-			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion>
-		</PropertyGroup>
-		
-		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend to get the current version. If it's missing then 
-		     ThePensionsRegulator.GovUk.Frontend is a transitive dependency of this package, and will have been unable to copy 
-			 govuk-frontend SASS files to the Styles folder of the consuming project.
-			 
-			 If ThePensionsRegulator.GovUk.Frontend is a transitive dependency find its version in the metadata of ThePensionsRegulator.GovUk.Frontend.Umbraco. 
-			 Use the version of ThePensionsRegulator.GovUk.Frontend to find its NuGet package folder, and copy govuk-frontend SASS files to the 
-			 Styles folder in the consuming project.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend Condition="@(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion->Count() )==0">false</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend>
-			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists>
-			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) == true">true</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles>
-			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
-			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
-		</PropertyGroup>
-		
-		<XmlPeek XmlInputPath="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion)\thepensionsregulator.govuk.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
-			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true">
-			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion>@(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion>
-			<ThePensionsRegulatorGovUkFrontendSassFolder>$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
-		</PropertyGroup>
-		<ItemGroup>
-			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(ThePensionsRegulatorGovUkFrontendSassFolder)**\*.scss" />
-		</ItemGroup>
-		
-		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
-		 Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) != true" />
-		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying SASS files from $(ThePensionsRegulatorGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
-		<Copy SourceFiles="@(ThePensionsRegulatorGovUkFrontendSassFiles)"
-		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
-	</Target>
-
 	<Target Name="GovUkFrontendUmbraco_CopyFiles">
-		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion" />
-		</XmlPeek>
-
+		<!-- Use the version of this package to find the NuGet package folder, and copy files from the package to the consuming project. -->
 		<PropertyGroup>
-			<GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion)</GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion>
-		</PropertyGroup>
-
-		<PropertyGroup>
-			<GovUkFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</GovUkFrontendUmbraco_CopyFiles_UserProfile>
-			<GovUkFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</GovUkFrontendUmbraco_CopyFiles_UserProfile>
-			<GovUkFrontendUmbraco_CopyFiles_ContentFilesPath>$(GovUkFrontendUmbraco_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbraco_CopyFiles_ContentFilesPath>
+			<GovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</GovUkFrontendUmbraco_UserProfile>
+			<GovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</GovUkFrontendUmbraco_UserProfile>
+			<GovUkFrontendUmbraco_ContentFilesPath>$(GovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(TprGovUkFrontendUmbracoPackageVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbraco_ContentFilesPath>
 		</PropertyGroup>
 		<ItemGroup>
-			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_CopyFiles_ContentFilesPath)uSync\**" />
-			<WwwrootFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_CopyFiles_ContentFilesPath)Content\**" />
+			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_ContentFilesPath)uSync\**" />
+			<WwwrootFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_ContentFilesPath)Content\**" />
 		</ItemGroup>
 
-		<!-- The following copy tasks are also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco copying uSync/wwwroot files from $(GovUkFrontendUmbraco_CopyFiles_ContentFilesPath) to $(ProjectDir)" Importance="high" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco copying uSync and backoffice CSS files from $(GovUkFrontendUmbraco_ContentFilesPath) to $(ProjectDir)" Importance="high" />
 
 		<Copy SourceFiles="@(uSyncFilesFromGovUkFrontendUmbraco)"
 			  DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)" />
 		<Copy SourceFiles="@(WwwrootFilesFromGovUkFrontendUmbraco)"
 			  DestinationFiles="$(ProjectDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)" />
-	</Target>
 
-	<Target Name="GovUkFrontendUmbraco_GenerateFiles">
 		<!-- Rich text editor data types import wwwroot\css\site.css so that consuming projects can add their own styles, including styles for the 'Formats' dropdown.
 		     However if there is no site.css the backoffice generates a request with a 404 response, so create a placeholder file to respond to that request. -->
 		<PropertyGroup>
@@ -147,7 +67,7 @@ govuk-umbraco-backoffice.css.map
 			</GovUkFrontendUmbracoCssGitIgnoreText>
 			<GovUkFrontendUmbracoCssGitIgnore Include="%(GovUkFrontendUmbracoCssGitIgnoreText.Text)" />
 		</ItemGroup>
-		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco generating $(ProjectDir)wwwroot\css\.gitignore to prevent commit of backoffice CSS files copied into the project" Importance="high" Condition="Exists('$(ProjectDir)wwwroot\css')" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco generating $(ProjectDir)wwwroot\css\.gitignore to prevent commit of backoffice CSS files copied into the project." Importance="high" Condition="Exists('$(ProjectDir)wwwroot\css')" />
 		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\.gitignore" Lines="@(GovUkFrontendUmbracoCssGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)wwwroot\css')"/>
 
 		<ItemGroup>

--- a/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
+++ b/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
@@ -5,37 +5,45 @@
 			 Use that version to find the NuGet package folder, and copy files to the consuming project.
 			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
 		-->
-		<PropertyGroup>
-			<UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</UserProfile>
-			<UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</UserProfile>
-		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend.Umbraco']/@Version">
 			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbracoVersion" />
 		</XmlPeek>
+
+		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
+			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_TargetProjectSdk" />
+		</XmlPeek>
 		<PropertyGroup>
-			<GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbracoVersion)</GovUkFrontendUmbracoVersion>
-			<HasPackageReferenceForGovUkFrontendUmbraco Condition="@(GovUkFrontendUmbracoVersion->Count() )==0">false</HasPackageReferenceForGovUkFrontendUmbraco>
-			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</ContentFilesPath>
+			<GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco Condition="@(GovUkFrontendUmbracoVersion->Count() )>0">true</GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco>
+			<GovUkFrontendUmbraco_TargetProjectIsWebProject Condition="@(GovUkFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web'">true</GovUkFrontendUmbraco_TargetProjectIsWebProject>
+			<GovUkFrontendUmbraco_TargetProjectIsWebOrRclProject Condition="@(GovUkFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(GovUkFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</GovUkFrontendUmbraco_TargetProjectIsWebOrRclProject>
 		</PropertyGroup>
-		<ItemGroup>
-			<uSyncFilesFromGovUkFrontendUmbraco Include="$(ContentFilesPath)uSync\**" />
-			<WwwrootFilesFromGovUkFrontendUmbraco Include="$(ContentFilesPath)Content\**" />
-		</ItemGroup>
 
-		<Message Text="Not copying files from ThePensionsRegulator.GovUk.Frontend.Umbraco because it is a transitive dependency. These may be copied by the package that references ThePensionsRegulator.GovUk.Frontend.Umbraco or you may need to add a direct reference to ThePensionsRegulator.GovUk.Frontend.Umbraco." Importance="high"
-				 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false"/>
+		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend to the consuming project if it is a transitive dependency. -->
+		<CallTarget Targets="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend" Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebOrRclProject) == true And $(GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco) == true" />
+	
+		<!-- Copy files from this project to the consuming project. -->
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.GovUk.Frontend.Umbraco because the target project is not a web project." Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.GovUk.Frontend.Umbraco because it is a transitive dependency without access to the correct path. These may be copied by the package that references ThePensionsRegulator.GovUk.Frontend.Umbraco or you may need to add a direct reference to ThePensionsRegulator.GovUk.Frontend.Umbraco. .gitignore and site.css files will be generated." Importance="high"
+				 Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) == true And $(GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco) != true"/>
+		<CallTarget Targets="GovUkFrontendUmbraco_CopyFiles" Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) == true And $(GovUkFrontendUmbraco_HasPackageReferenceToGovUkFrontendUmbraco) == true" />
+		<CallTarget Targets="GovUkFrontendUmbraco_GenerateFiles" Condition="$(GovUkFrontendUmbraco_TargetProjectIsWebProject) == true" />
 
-		<!-- The following copy tasks are also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="Copying files from $(ContentFilesPath) to $(ProjectDir)" Importance="high"
-				 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false"/>
+		<!-- If the ModelsBuilder out-of-date flag is present, show a helpful warning. -->
+		<Warning Text="Umbraco Models Builder models are out-of-date. Go to Settings &gt; Models Builder &gt; Generate models in the Umbraco backoffice to update them." Condition="Exists('$(ProjectDir)Models\ModelsBuilder\ood.flag')" />
+	</Target>
 
-		<Copy SourceFiles="@(uSyncFilesFromGovUkFrontendUmbraco)"
-			  DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)" 
-			  Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false"/>
-		<Copy SourceFiles="@(WwwrootFilesFromGovUkFrontendUmbraco)"
-			  DestinationFiles="$(ProjectDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)" 
-			  Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false"/>
-
+	<Target Name="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend">
+		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
+		     Get the version, which we can use to find the paths to transitive packages. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend.Umbraco']/@Version">
+			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion" />
+		</XmlPeek>
+		
+		<PropertyGroup>
+			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion>
+		</PropertyGroup>
+		
 		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend to get the current version. If it's missing then 
 		     ThePensionsRegulator.GovUk.Frontend is a transitive dependency of this package, and will have been unable to copy 
 			 govuk-frontend SASS files to the Styles folder of the consuming project.
@@ -44,77 +52,115 @@
 			 Use the version of ThePensionsRegulator.GovUk.Frontend to find its NuGet package folder, and copy govuk-frontend SASS files to the 
 			 Styles folder in the consuming project.
 		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version"
-				 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false">
-			<Output TaskParameter="Result" ItemName="ThePensionsRegulatorGovUkFrontendVersion" />
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
+			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
-			<HasPackageReferenceForThePensionsRegulatorGovUkFrontend Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false and @(ThePensionsRegulatorGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForThePensionsRegulatorGovUkFrontend>
+			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend Condition="@(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion->Count() )==0">false</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend>
+			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists>
+			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) == true">true</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles>
+			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
+			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
 		</PropertyGroup>
-		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\thepensionsregulator.govuk.frontend.umbraco.nuspec"
+		
+		<XmlPeek XmlInputPath="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_GovUkFrontendUmbracoVersion)\thepensionsregulator.govuk.frontend.umbraco.nuspec"
 			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false and $(HasPackageReferenceForThePensionsRegulatorGovUkFrontend) == false">
-			<Output TaskParameter="Result" ItemName="ThePensionsRegulatorGovUkFrontendVersion" />
+			 Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true">
+			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
-			<ThePensionsRegulatorGovUkFrontendVersion Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false">@(ThePensionsRegulatorGovUkFrontendVersion)</ThePensionsRegulatorGovUkFrontendVersion>
-			<ThePensionsRegulatorGovUkFrontendSassFolder Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false">$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(ThePensionsRegulatorGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
+			<GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion>@(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion)</GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion>
+			<ThePensionsRegulatorGovUkFrontendSassFolder>$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_TprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</ThePensionsRegulatorGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
-			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(ThePensionsRegulatorGovUkFrontendSassFolder)**\*.scss" Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false" />
+			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(ThePensionsRegulatorGovUkFrontendSassFolder)**\*.scss" />
 		</ItemGroup>
-		<Message Text="Detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying govuk-frontend SASS files from $(ThePensionsRegulatorGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false and $(HasPackageReferenceForThePensionsRegulatorGovUkFrontend) == false" />
+		
+		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
+		 Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying SASS files from $(ThePensionsRegulatorGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
+			     Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
 		<Copy SourceFiles="@(ThePensionsRegulatorGovUkFrontendSassFiles)"
 		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) != false and $(HasPackageReferenceForThePensionsRegulatorGovUkFrontend) == false" />
+			  Condition="$(GovUkFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
+	</Target>
+
+	<Target Name="GovUkFrontendUmbraco_CopyFiles">
+		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
+		     Get the version, which we can use to find the paths to transitive packages. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend.Umbraco']/@Version">
+			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion" />
+		</XmlPeek>
+
+		<PropertyGroup>
+			<GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion)</GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion>
+		</PropertyGroup>
+
+		<PropertyGroup>
+			<GovUkFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</GovUkFrontendUmbraco_CopyFiles_UserProfile>
+			<GovUkFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</GovUkFrontendUmbraco_CopyFiles_UserProfile>
+			<GovUkFrontendUmbraco_CopyFiles_ContentFilesPath>$(GovUkFrontendUmbraco_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbraco_CopyFiles_GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbraco_CopyFiles_ContentFilesPath>
+		</PropertyGroup>
+		<ItemGroup>
+			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_CopyFiles_ContentFilesPath)uSync\**" />
+			<WwwrootFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_CopyFiles_ContentFilesPath)Content\**" />
+		</ItemGroup>
+
+		<!-- The following copy tasks are also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco copying uSync/wwwroot files from $(GovUkFrontendUmbraco_CopyFiles_ContentFilesPath) to $(ProjectDir)" Importance="high" />
+
+		<Copy SourceFiles="@(uSyncFilesFromGovUkFrontendUmbraco)"
+			  DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)" />
+		<Copy SourceFiles="@(WwwrootFilesFromGovUkFrontendUmbraco)"
+			  DestinationFiles="$(ProjectDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)" />
+	</Target>
+
+	<Target Name="GovUkFrontendUmbraco_GenerateFiles">
+		<!-- Rich text editor data types import wwwroot\css\site.css so that consuming projects can add their own styles, including styles for the 'Formats' dropdown.
+		     However if there is no site.css the backoffice generates a request with a 404 response, so create a placeholder file to respond to that request. -->
+		<PropertyGroup>
+			<GenerateUmbracoSiteCss Condition="!Exists('$(ProjectDir)wwwroot\css\site.css') and !Exists('$(ProjectDir)Styles\site.scss')">true</GenerateUmbracoSiteCss>
+		</PropertyGroup>
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco generating $(ProjectDir)wwwroot\css\site.css because it does not exist." Importance="high" Condition="$(GenerateUmbracoSiteCss) == true" />
+		<ItemGroup>
+			<GovUkFrontendUmbracoSiteCssText Include="GovUkFrontendUmbracoSiteCssText">
+				<Text>
+/* Generated by ThePensionsRegulator.GovUk.Frontend.Umbraco for the Umbraco rich text editor
+You can delete this file safely and replace it with your own site.css */
+				</Text>
+			</GovUkFrontendUmbracoSiteCssText>
+			<GovUkFrontendUmbracoSiteCss Include="%(GovUkFrontendUmbracoSiteCssText.Text)" />
+		</ItemGroup>
+		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\site.css" Lines="@(GovUkFrontendUmbracoSiteCss)" Overwrite="False" Condition="$(GenerateUmbracoSiteCss) == true" />
 
 		<!-- Generate .gitignore files so that files copied from this package are not committed to the consuming project's source control.	 
 			 Only do that if the folder exists, otherwise they'll also get created in a test project with a project reference to the target project. -->
 		<ItemGroup>
 			<GovUkFrontendUmbracoCssGitIgnoreText Include="GovUkFrontendUmbracoCssGitIgnoreText">
 				<Text>
+# Generated by ThePensionsRegulator.GovUk.Frontend.Umbraco
 govuk-umbraco-backoffice.css
 govuk-umbraco-backoffice.css.map
 				</Text>
 			</GovUkFrontendUmbracoCssGitIgnoreText>
 			<GovUkFrontendUmbracoCssGitIgnore Include="%(GovUkFrontendUmbracoCssGitIgnoreText.Text)" />
 		</ItemGroup>
-		<Message Text="Generating $(ProjectDir)wwwroot\css\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)wwwroot')" />
-		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\.gitignore" Lines="@(GovUkFrontendUmbracoCssGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)wwwroot')"/>
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco generating $(ProjectDir)wwwroot\css\.gitignore to prevent commit of backoffice CSS files copied into the project" Importance="high" Condition="Exists('$(ProjectDir)wwwroot\css')" />
+		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\.gitignore" Lines="@(GovUkFrontendUmbracoCssGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)wwwroot\css')"/>
 
 		<ItemGroup>
 			<GovUkFrontendUmbracoUSyncGitIgnoreText Include="GovUkFrontendUmbracoUSyncGitIgnoreText">
 				<Text>
+# Generated by ThePensionsRegulator.GovUk.Frontend.Umbraco
 **/govuk*.config
 **/GOVUK*.config
 				</Text>
 			</GovUkFrontendUmbracoUSyncGitIgnoreText>
 			<GovUkFrontendUmbracoUSyncGitIgnore Include="%(GovUkFrontendUmbracoUSyncGitIgnoreText.Text)" />
 		</ItemGroup>
-		<Message Text="Generating $(ProjectDir)uSync\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)uSync')" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco generating $(ProjectDir)uSync\.gitignore to prevent commit of uSync files copied into the project." Importance="high" Condition="Exists('$(ProjectDir)uSync')" />
 		<WriteLinesToFile File="$(ProjectDir)uSync\.gitignore" Lines="@(GovUkFrontendUmbracoUSyncGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)uSync')"/>
-
-		<!-- If the ModelsBuilder out-of-date flag is present, show a helpful warning. -->
-		<Warning Text="Umbraco Models Builder models are out-of-date. Go to Settings &gt; Models Builder &gt; Generate models in the Umbraco backoffice to update them." Condition="Exists('$(ProjectDir)Models\ModelsBuilder\ood.flag')" />
-
-		<!-- Rich text editor data types import wwwroot\css\site.css so that consuming projects can add their own styles, including styles for the 'Formats' dropdown.
-		     However if there is no site.css the backoffice generates a request with a 404 response, so create a placeholder file to respond to that request. -->
-		<PropertyGroup>
-			<GenerateUmbracoSiteCss Condition="Exists('$(ProjectDir)wwwroot') and !Exists('$(ProjectDir)wwwroot\css\site.css') and !Exists('$(ProjectDir)Styles\site.scss')">true</GenerateUmbracoSiteCss>
-		</PropertyGroup>
-		<Message Text="Generating $(ProjectDir)wwwroot\css\site.css" Importance="high" Condition="$(GenerateUmbracoSiteCss) == true" />
-		<ItemGroup>
-			<GovUkFrontendUmbracoSiteCssText Include="GovUkFrontendUmbracoSiteCssText">
-				<Text>
-/* Generated by ThePensionsRegulator.GovUk.Frontend.Umbraco for the Umbraco rich text editor
-   You can delete this file safely and replace it with your own site.css */
-				</Text>
-			</GovUkFrontendUmbracoSiteCssText>
-			<GovUkFrontendUmbracoSiteCss Include="%(GovUkFrontendUmbracoSiteCssText.Text)" />
-		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)wwwroot\css\site.css" Lines="@(GovUkFrontendUmbracoSiteCss)" Overwrite="False" Condition="$(GenerateUmbracoSiteCss) == true" />
 	</Target>
-
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/Directory.Build.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/Directory.Build.targets
@@ -57,4 +57,25 @@
 		<Message Text="Deleting obsolete files: @(TprFrontendUmbraco_DirsToRemove)" />
 		<RemoveDir Directories="@(TprFrontendUmbraco_DirsToRemove)" />
 	</Target>
+
+	<Target Name="TprFrontendUmbraco_GenerateProps" BeforeTargets="BeforeBuild">
+		<!--Generate a .props file so that ThePensionsRegulator.Frontend.Umbraco.targets has access to the package version. -->
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco generating $(ProjectDir)ThePensionsRegulator.Frontend.Umbraco.props to ..." Importance="high" />
+		<ItemGroup>
+			<TprFrontendUmbracoPropsText Include="TprFrontendUmbracoPropsText">
+				<Text>
+					<![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<TprFrontendUmbracoPackageVersion>$(Version)</TprFrontendUmbracoPackageVersion>
+	</PropertyGroup>
+</Project>
+				]]>
+				</Text>
+			</TprFrontendUmbracoPropsText>
+			<TprFrontendUmbracoProps Include="%(TprFrontendUmbracoPropsText.Text)" />
+		</ItemGroup>
+		<WriteLinesToFile File="$(ProjectDir)ThePensionsRegulator.Frontend.Umbraco.generated.props" Lines="@(TprFrontendUmbracoProps)" Overwrite="True" />
+	</Target>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/Directory.Build.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/Directory.Build.targets
@@ -40,12 +40,6 @@
 			DestinationFiles="$(ProjectDir)uSync\v17\ContentTypes\%(RecursiveDir)%(Filename)%(Extension)" />
 	</Target>
 
-	<!-- Restore npm packages for backoffice development. -->
-	<Target Name="TprFrontendUmbraco_NpmInstall" BeforeTargets="BeforeBuild">
-		<Message Text="Restoring Backoffice npm packages" Importance="high" />
-		<Exec Command="npm install" WorkingDirectory="Backoffice" />
-	</Target>
-
 	<!-- Create a version to use as a cache-busting parameter for backoffice customisation -->
 	<Target Name="TprFrontendUmbraco_GenerateTypeScriptVersion" BeforeTargets="Build">
 		<WriteLinesToFile

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -42,6 +42,10 @@
 		  <PackagePath>build;buildTransitive</PackagePath>
 		  <Pack>true</Pack>
 		</Content>
+		<Content Include="ThePensionsRegulator.Frontend.Umbraco.generated.props">
+			<PackagePath>build</PackagePath>
+			<Pack>true</Pack>
+		</Content>
 		<Content Include="Styles\govuk-umbraco-backoffice.css">
 			<PackagePath>contentFiles\any\$(TargetFramework)\Content\css</PackagePath>
 			<Pack>true</Pack>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
@@ -6,60 +6,107 @@
 			 There will be no PackageReference in the project if it has a project reference to another project that has the PackageReference. 
 			 This would be typical for a unit test project. Detect that and no nothing.
 		-->
-		<PropertyGroup>
-			<UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</UserProfile>
-			<UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</UserProfile>
-		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
 			<Output TaskParameter="Result" ItemName="TprFrontendUmbracoVersion" />
 		</XmlPeek>
 		<Message Text="No PackageReference to ThePensionsRegulator.Frontend.Umbraco found. Nothing to do." Condition="@(TprFrontendUmbracoVersion->Count() )==0" />
-		<CallTarget Targets="ThePensionsRegulatorFrontendUmbraco_PackageFound" Condition="@(TprFrontendUmbracoVersion->Count() )>0" />
+		<CallTarget Targets="TprFrontendUmbraco_PackageFound" Condition="@(TprFrontendUmbracoVersion->Count() )>0" />
 	</Target>
-	
-	<Target Name="ThePensionsRegulatorFrontendUmbraco_PackageFound">
+
+	<Target Name="TprFrontendUmbraco_PackageFound">
+		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
+			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_TargetProjectSdk" />
+		</XmlPeek>
+		<PropertyGroup>
+			<TprFrontendUmbraco_TargetProjectIsWebProject Condition="@(TprFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web'">true</TprFrontendUmbraco_TargetProjectIsWebProject>
+			<TprFrontendUmbraco_TargetProjectIsWebOrRclProject Condition="@(TprFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(TprFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</TprFrontendUmbraco_TargetProjectIsWebOrRclProject>
+		</PropertyGroup>
+
+		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend to the consuming project if it is a transitive dependency. -->
+		<CallTarget Targets="TprFrontendUmbraco_CopyFromTprGovUkFrontend" Condition="$(TprFrontendUmbraco_TargetProjectIsWebOrRclProject) == true" />
+
+		<!-- Copy files from ThePensionsRegulator.Frontend to the consuming project if it is a transitive dependency. -->
+		<CallTarget Targets="TprFrontendUmbraco_CopyFromTprFrontend" Condition="$(TprFrontendUmbraco_TargetProjectIsWebOrRclProject) == true" />
+
+		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend.Umbraco to the consuming project if it is a transitive dependency. -->
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.GovUk.Frontend.Umbraco because the target project is not a web project." Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
+		<CallTarget Targets="TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco" Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) == true" />
+
+		<!-- Copy files from this project to the consuming project. It's important to do this AFTER copying files for 
+		     ThePensionsRegulator.GovUk.Frontend.Umbraco so that we can overwrite them with TPR customisations.
+		-->
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.Frontend.Umbraco because the target project is not a web project." Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
+		<CallTarget Targets="TprFrontendUmbraco_CopyFiles" Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) == true" />
+
+		<!-- Always clean up obsolete files from previous versions where they would cause a conflict. -->
+		<CallTarget Targets="TprFrontendUmbraco_Cleanup" />
+	</Target>
+
+	<Target Name="TprFrontendUmbraco_CopyFromTprGovUkFrontend">
 		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
 		     Get the version, which we can use to find the paths to transitive packages. -->
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontendUmbracoVersion" />
+			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion" />
 		</XmlPeek>
+
 		<PropertyGroup>
-			<TprFrontendUmbracoVersion>@(TprFrontendUmbracoVersion)</TprFrontendUmbracoVersion>
+			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion>
 		</PropertyGroup>
 
 		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend to get the current version. If it's missing then 
-		     ThePensionsRegulator.GovUk.Frontend is a transitive dependency of this package, and will have been unable to copy 
-			 govuk-frontend SASS files to the Styles folder of the consuming project.
+		    ThePensionsRegulator.GovUk.Frontend is a transitive dependency of this package, and will have been unable to copy 
+			govuk-frontend SASS files to the Styles folder of the consuming project.
 			 
-			 If ThePensionsRegulator.GovUk.Frontend is a transitive dependency find its version in the metadata of ThePensionsRegulator.Frontend.Umbraco. 
-			 Use the version of ThePensionsRegulator.GovUk.Frontend to find its NuGet package folder, and copy govuk-frontend SASS files to the 
-			 Styles folder in the consuming project.
+			If ThePensionsRegulator.GovUk.Frontend is a transitive dependency find its version in the metadata of ThePensionsRegulator.Frontend.Umbraco. 
+			Use the version of ThePensionsRegulator.GovUk.Frontend to find its NuGet package folder, and copy govuk-frontend SASS files to the 
+			Styles folder in the consuming project.
 		-->
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
 			<Output TaskParameter="Result" ItemName="BaseTprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
-			<HasPackageReferenceForTprGovUkFrontend Condition="@(BaseTprGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForTprGovUkFrontend>
+			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend Condition="@(BaseTprGovUkFrontendVersion->Count() )==0">false</TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend>
+			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists>
+			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) == true">true</TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles>
+			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
+			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
 		</PropertyGroup>
-		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
+		
+		<XmlPeek XmlInputPath="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
 			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(HasPackageReferenceForTprGovUkFrontend) == false">
+			 Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true">
 			<Output TaskParameter="Result" ItemName="BaseTprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<BaseTprGovUkFrontendVersion>@(BaseTprGovUkFrontendVersion)</BaseTprGovUkFrontendVersion>
-			<BaseTprGovUkFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(BaseTprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprGovUkFrontendSassFolder>
+			<BaseTprGovUkFrontendSassFolder>$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(BaseTprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<BaseTprGovUkFrontendSassFiles Include="$(BaseTprGovUkFrontendSassFolder)**\*.scss" />
 		</ItemGroup>
-		<Message Text="Detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying govuk-frontend SASS files from $(BaseTprGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(HasPackageReferenceForTprGovUkFrontend) == false" />
+		
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
+			     Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying SASS files from $(BaseTprGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
+			     Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
 		<Copy SourceFiles="@(BaseTprGovUkFrontendSassFiles)"
 		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(HasPackageReferenceForTprGovUkFrontend) == false" />
+			  Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
+	</Target>
 
+	<Target Name="TprFrontendUmbraco_CopyFromTprFrontend">
+		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
+		     Get the version, which we can use to find the paths to transitive packages. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
+			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion" />
+		</XmlPeek>
+
+		<PropertyGroup>
+			<TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion>
+		</PropertyGroup>
+		
 		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend to get the current version. If it's missing then 
 		     ThePensionsRegulator.Frontend is a transitive dependency of this package, and will have been unable to copy 
 			 its files to the consuming project.
@@ -72,27 +119,46 @@
 		</XmlPeek>
 		<PropertyGroup>
 			<HasPackageReferenceForTprFrontend Condition="@(BaseTprFrontendVersion->Count() )==0">false</HasPackageReferenceForTprFrontend>
+			<TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists>
+			<TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles Condition="$(HasPackageReferenceForTprFrontend) == false And $(TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists) == true">true</TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles>
+			<TprFrontendUmbraco_CopyFromTprFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFromTprFrontend_UserProfile>
+			<TprFrontendUmbraco_CopyFromTprFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFromTprFrontend_UserProfile>
 		</PropertyGroup>
-		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
+		<XmlPeek XmlInputPath="$(TprFrontendUmbraco_CopyFromTprFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
 			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(HasPackageReferenceForTprFrontend) == false">
+			 Condition="$(TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles) == true">
 			<Output TaskParameter="Result" ItemName="BaseTprFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
 			<BaseTprFrontendVersion>@(BaseTprFrontendVersion)</BaseTprFrontendVersion>
-			<BaseTprFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(BaseTprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprFrontendSassFolder>
-		
-	</PropertyGroup>
+			<BaseTprFrontendSassFolder>$(TprFrontendUmbraco_CopyFromTprFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(BaseTprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprFrontendSassFolder>
+		</PropertyGroup>
 		<ItemGroup>
 			<BaseTprFrontendSassFiles Include="$(BaseTprFrontendSassFolder)**\*.scss" />
 		</ItemGroup>
-		<Message Text="Detected ThePensionsRegulator.Frontend as a transitive dependency. Copying files from $(BaseTprFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(HasPackageReferenceForTprFrontend) == false" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
+			 Condition="$(HasPackageReferenceForTprFrontend) == false And $(TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.Frontend as a transitive dependency. Copying SASS files from $(BaseTprFrontendSassFolder) to $(ProjectDir)." Importance="high"
+			     Condition="$(TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles) == true" />
 		<Copy SourceFiles="@(BaseTprFrontendSassFiles)"
 		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(HasPackageReferenceForTprFrontend) == false" />
+			  Condition="$(TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles) == true" />
+	</Target>
 
+	<Target Name="TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco">
+		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
+		     Get the version, which we can use to find the paths to transitive packages. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
+			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion" />
+		</XmlPeek>
+
+		<PropertyGroup>
+			<TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion>
+			<TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile>
+			<TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile>
+		</PropertyGroup>
+		
 		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend.Umbraco to get the current version. If it's missing then 
 		     ThePensionsRegulator.GovUk.Frontend.Umbraco is a transitive dependency of this package, and will have been unable to copy 
 			 its files to the consuming project.
@@ -106,7 +172,8 @@
 		<PropertyGroup>
 			<HasPackageReferenceForGovUkFrontendUmbraco Condition="@(GovUkFrontendUmbracoVersion->Count() )==0">false</HasPackageReferenceForGovUkFrontendUmbraco>
 		</PropertyGroup>
-		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
+
+		<XmlPeek XmlInputPath="$(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
 			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend.Umbraco']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
 			 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false">
@@ -114,13 +181,13 @@
 		</XmlPeek>
 		<PropertyGroup>
 			<GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbracoVersion)</GovUkFrontendUmbracoVersion>
-			<GovUkFrontendUmbracoContentFiles>$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbracoContentFiles>
+			<GovUkFrontendUmbracoContentFiles>$(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbracoContentFiles>
 		</PropertyGroup>
 		<ItemGroup>
 			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbracoContentFiles)uSync\**" />
 			<WwwrootFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbracoContentFiles)Content\**" />
 		</ItemGroup>
-		<Message Text="Detected ThePensionsRegulator.GovUk.Frontend.Umbraco as a transitive dependency. Copying files from $(GovUkFrontendUmbracoContentFiles) to $(ProjectDir)." Importance="high"
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend.Umbraco as a transitive dependency. Copying uSync/wwwroot files from $(GovUkFrontendUmbracoContentFiles) to $(ProjectDir)." Importance="high"
 			     Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false" />
 		<Copy SourceFiles="@(uSyncFilesFromGovUkFrontendUmbraco)"
 		      DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)"
@@ -128,30 +195,30 @@
 		<Copy SourceFiles="@(WwwrootFilesFromGovUkFrontendUmbraco)"
 		      DestinationFiles="$(ProjectDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)"
 			  Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false" />
+	</Target>
 
-		<!-- Copy files from this project to the consuming project. It's important to do this AFTER copying files for 
-		     ThePensionsRegulator.GovUk.Frontend.Umbraco so that we can overwrite them with TPR customisations.
-		-->
+	<Target Name="TprFrontendUmbraco_CopyFiles">
+		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
+		     Get the version, which we can use to find the paths to transitive packages. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
+			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion" />
+		</XmlPeek>
+		
 		<PropertyGroup>
-			<ContentFilesPath>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</ContentFilesPath>
+			<TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion>
+			<TprFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFiles_UserProfile>
+			<TprFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFiles_UserProfile>
+			<ContentFilesPath>$(TprFrontendUmbraco_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</ContentFilesPath>
 		</PropertyGroup>
 		<ItemGroup>
 			<uSyncFilesFromTprFrontendUmbraco Include="$(ContentFilesPath)uSync\**" />
 			<WwwrootFilesFromTprFrontendUmbraco Include="$(ContentFilesPath)Content\**" />
 		</ItemGroup>
-		<Message Text="Copying files from $(ContentFilesPath) to $(ProjectDir)" Importance="high" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco copying uSync/wwwroot files from $(ContentFilesPath) to $(ProjectDir)" Importance="high" />
 		<Copy SourceFiles="@(uSyncFilesFromTprFrontendUmbraco)"
 			DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)" />
 		<Copy SourceFiles="@(WwwrootFilesFromTprFrontendUmbraco)"
 			DestinationFiles="$(ProjectDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)" />
-
-		<!-- Clean up obsolete files from previous versions where they would cause a conflict. -->
-		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardDescriptionRichTextEditor.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardDescriptionRichTextEditor.config')" />
-		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardTextarea.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardTextarea.config')" />
-		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsAutoplayToggle.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsAutoplayToggle.config')" />
-		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPlaysInLineToggle.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPlaysInLineToggle.config')" />
-		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPreloadDropdown.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPreloadDropdown.config')" />
-		<Delete Files="$(ProjectDir)uSync\v9\ContentTypes\tprsectioncardscard.config" Condition="Exists('$(ProjectDir)uSync\v9\ContentTypes\tprsectioncardscard.config')" />
 
 		<!-- Generate .gitignore files so that files from the ThePensionsRegulator.Frontend.Umbraco package are not committed to the consuming project's source control. 
 			 There's no need to generate one for wwwroot\css because this package depends on ThePensionsRegulator.GovUk.Frontend.Umbraco, which already did that.
@@ -159,6 +226,7 @@
 		<ItemGroup>
 			<TprFrontendUmbracoUSyncGitIgnoreText Include="TprFrontendUmbracoUSyncGitIgnoreText">
 				<Text>
+# Generated by ThePensionsRegulator.Frontend.Umbraco
 **/govuk*.config
 **/GOVUK*.config
 **/tpr*.config
@@ -167,7 +235,17 @@
 			</TprFrontendUmbracoUSyncGitIgnoreText>
 			<TprFrontendUmbracoUSyncGitIgnore Include="%(TprFrontendUmbracoUSyncGitIgnoreText.Text)" />
 		</ItemGroup>
-		<Message Text="Generating $(ProjectDir)uSync\.gitignore" Importance="high" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco generating $(ProjectDir)uSync\.gitignore to prevent commit of uSync files copied into the project." Importance="high" />
 		<WriteLinesToFile File="$(ProjectDir)uSync\.gitignore" Lines="@(TprFrontendUmbracoUSyncGitIgnore)" Overwrite="True"/>
+	</Target>
+
+	<Target Name="TprFrontendUmbraco_Cleanup">
+		<!-- Clean up obsolete files from previous versions where they would cause a conflict. -->
+		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardDescriptionRichTextEditor.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardDescriptionRichTextEditor.config')" />
+		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardTextarea.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\TPRSectionCardsCardTextarea.config')" />
+		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsAutoplayToggle.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsAutoplayToggle.config')" />
+		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPlaysInLineToggle.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPlaysInLineToggle.config')" />
+		<Delete Files="$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPreloadDropdown.config" Condition="Exists('$(ProjectDir)uSync\v9\DataTypes\YoutubeVideoSettingsPreloadDropdown.config')" />
+		<Delete Files="$(ProjectDir)uSync\v9\ContentTypes\tprsectioncardscard.config" Condition="Exists('$(ProjectDir)uSync\v9\ContentTypes\tprsectioncardscard.config')" />
 	</Target>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
@@ -1,220 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Target Name="ThePensionsRegulatorFrontendUmbraco" AfterTargets="ThePensionsRegulatorFrontend;ThePensionsRegulatorGovUkFrontendUmbraco">
-		<!-- Look for the PackageReference to this package to get the current version.
-			 Use that version to find the NuGet package folder, and copy files to the consuming project.
-			 There will be no PackageReference in the project if it has a project reference to another project that has the PackageReference. 
-			 This would be typical for a unit test project. Detect that and no nothing.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontendUmbracoVersion" />
-		</XmlPeek>
-		<Message Text="No PackageReference to ThePensionsRegulator.Frontend.Umbraco found. Nothing to do." Condition="@(TprFrontendUmbracoVersion->Count() )==0" />
-		<CallTarget Targets="TprFrontendUmbraco_PackageFound" Condition="@(TprFrontendUmbracoVersion->Count() )>0" />
-	</Target>
+	<Import Project="..\build\ThePensionsRegulator.Frontend.Umbraco.generated.props"/>
 
-	<Target Name="TprFrontendUmbraco_PackageFound">
+	<Target Name="ThePensionsRegulatorFrontendUmbraco" AfterTargets="ThePensionsRegulatorFrontend;ThePensionsRegulatorGovUkFrontendUmbraco">
 		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
 			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_TargetProjectSdk" />
 		</XmlPeek>
 		<PropertyGroup>
 			<TprFrontendUmbraco_TargetProjectIsWebProject Condition="@(TprFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web'">true</TprFrontendUmbraco_TargetProjectIsWebProject>
-			<TprFrontendUmbraco_TargetProjectIsWebOrRclProject Condition="@(TprFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(TprFrontendUmbraco_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</TprFrontendUmbraco_TargetProjectIsWebOrRclProject>
 		</PropertyGroup>
-
-		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend to the consuming project if it is a transitive dependency. -->
-		<CallTarget Targets="TprFrontendUmbraco_CopyFromTprGovUkFrontend" Condition="$(TprFrontendUmbraco_TargetProjectIsWebOrRclProject) == true" />
-
-		<!-- Copy files from ThePensionsRegulator.Frontend to the consuming project if it is a transitive dependency. -->
-		<CallTarget Targets="TprFrontendUmbraco_CopyFromTprFrontend" Condition="$(TprFrontendUmbraco_TargetProjectIsWebOrRclProject) == true" />
-
-		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend.Umbraco to the consuming project if it is a transitive dependency. -->
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.GovUk.Frontend.Umbraco because the target project is not a web project." Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
-		<CallTarget Targets="TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco" Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) == true" />
 
 		<!-- Copy files from this project to the consuming project. It's important to do this AFTER copying files for 
 		     ThePensionsRegulator.GovUk.Frontend.Umbraco so that we can overwrite them with TPR customisations.
 		-->
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco not copying uSync/wwwroot files from ThePensionsRegulator.Frontend.Umbraco because the target project is not a web project." Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco not copying uSync and backoffice CSS files from ThePensionsRegulator.Frontend.Umbraco because the target project is not a web project." Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
 		<CallTarget Targets="TprFrontendUmbraco_CopyFiles" Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) == true" />
 
 		<!-- Always clean up obsolete files from previous versions where they would cause a conflict. -->
 		<CallTarget Targets="TprFrontendUmbraco_Cleanup" />
 	</Target>
 
-	<Target Name="TprFrontendUmbraco_CopyFromTprGovUkFrontend">
-		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion" />
-		</XmlPeek>
-
-		<PropertyGroup>
-			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion>
-		</PropertyGroup>
-
-		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend to get the current version. If it's missing then 
-		    ThePensionsRegulator.GovUk.Frontend is a transitive dependency of this package, and will have been unable to copy 
-			govuk-frontend SASS files to the Styles folder of the consuming project.
-			 
-			If ThePensionsRegulator.GovUk.Frontend is a transitive dependency find its version in the metadata of ThePensionsRegulator.Frontend.Umbraco. 
-			Use the version of ThePensionsRegulator.GovUk.Frontend to find its NuGet package folder, and copy govuk-frontend SASS files to the 
-			Styles folder in the consuming project.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="BaseTprGovUkFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend Condition="@(BaseTprGovUkFrontendVersion->Count() )==0">false</TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend>
-			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists>
-			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) == true">true</TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles>
-			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
-			<TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile>
-		</PropertyGroup>
-		
-		<XmlPeek XmlInputPath="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
-			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true">
-			<Output TaskParameter="Result" ItemName="BaseTprGovUkFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<BaseTprGovUkFrontendVersion>@(BaseTprGovUkFrontendVersion)</BaseTprGovUkFrontendVersion>
-			<BaseTprGovUkFrontendSassFolder>$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(BaseTprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprGovUkFrontendSassFolder>
-		</PropertyGroup>
-		<ItemGroup>
-			<BaseTprGovUkFrontendSassFiles Include="$(BaseTprGovUkFrontendSassFolder)**\*.scss" />
-		</ItemGroup>
-		
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
-			     Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontendUmbraco_CopyFromTprGovUkFrontend_StylesFolderExists) != true" />
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying SASS files from $(BaseTprGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
-		<Copy SourceFiles="@(BaseTprGovUkFrontendSassFiles)"
-		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(TprFrontendUmbraco_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
-	</Target>
-
-	<Target Name="TprFrontendUmbraco_CopyFromTprFrontend">
-		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion" />
-		</XmlPeek>
-
-		<PropertyGroup>
-			<TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion>
-		</PropertyGroup>
-		
-		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend to get the current version. If it's missing then 
-		     ThePensionsRegulator.Frontend is a transitive dependency of this package, and will have been unable to copy 
-			 its files to the consuming project.
-			 
-			 If ThePensionsRegulator.Frontend is a transitive dependency find its version in the metadata of ThePensionsRegulator.Frontend.Umbraco. 
-			 Use the version of ThePensionsRegulator.Frontend to find its NuGet package folder, and copy its files to the consuming project.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="BaseTprFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<HasPackageReferenceForTprFrontend Condition="@(BaseTprFrontendVersion->Count() )==0">false</HasPackageReferenceForTprFrontend>
-			<TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists>
-			<TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles Condition="$(HasPackageReferenceForTprFrontend) == false And $(TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists) == true">true</TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles>
-			<TprFrontendUmbraco_CopyFromTprFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFromTprFrontend_UserProfile>
-			<TprFrontendUmbraco_CopyFromTprFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFromTprFrontend_UserProfile>
-		</PropertyGroup>
-		<XmlPeek XmlInputPath="$(TprFrontendUmbraco_CopyFromTprFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFromTprFrontend_TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.Frontend']/@version"
-			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles) == true">
-			<Output TaskParameter="Result" ItemName="BaseTprFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<BaseTprFrontendVersion>@(BaseTprFrontendVersion)</BaseTprFrontendVersion>
-			<BaseTprFrontendSassFolder>$(TprFrontendUmbraco_CopyFromTprFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(BaseTprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</BaseTprFrontendSassFolder>
-		</PropertyGroup>
-		<ItemGroup>
-			<BaseTprFrontendSassFiles Include="$(BaseTprFrontendSassFolder)**\*.scss" />
-		</ItemGroup>
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
-			 Condition="$(HasPackageReferenceForTprFrontend) == false And $(TprFrontendUmbraco_CopyFromTprFrontend_StylesFolderExists) != true" />
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.Frontend as a transitive dependency. Copying SASS files from $(BaseTprFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles) == true" />
-		<Copy SourceFiles="@(BaseTprFrontendSassFiles)"
-		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(TprFrontendUmbraco_CopyFromTprFrontend_CopySassFiles) == true" />
-	</Target>
-
-	<Target Name="TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco">
-		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion" />
-		</XmlPeek>
-
-		<PropertyGroup>
-			<TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion>
-			<TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile>
-			<TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile>
-		</PropertyGroup>
-		
-		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend.Umbraco to get the current version. If it's missing then 
-		     ThePensionsRegulator.GovUk.Frontend.Umbraco is a transitive dependency of this package, and will have been unable to copy 
-			 its files to the consuming project.
-			 
-			 If ThePensionsRegulator.GovUk.Frontend.Umbraco is a transitive dependency find its version in the metadata of ThePensionsRegulator.Frontend.Umbraco. 
-			 Use the version of ThePensionsRegulator.GovUk.Frontend.Umbraco to find its NuGet package folder, and copy its files to the consuming project.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbracoVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<HasPackageReferenceForGovUkFrontendUmbraco Condition="@(GovUkFrontendUmbracoVersion->Count() )==0">false</HasPackageReferenceForGovUkFrontendUmbraco>
-		</PropertyGroup>
-
-		<XmlPeek XmlInputPath="$(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_TprFrontendUmbracoVersion)\thepensionsregulator.frontend.umbraco.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend.Umbraco']/@version"
-			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false">
-			<Output TaskParameter="Result" ItemName="GovUkFrontendUmbracoVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<GovUkFrontendUmbracoVersion>@(GovUkFrontendUmbracoVersion)</GovUkFrontendUmbracoVersion>
-			<GovUkFrontendUmbracoContentFiles>$(TprFrontendUmbraco_CopyFromGovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(GovUkFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbracoContentFiles>
-		</PropertyGroup>
-		<ItemGroup>
-			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbracoContentFiles)uSync\**" />
-			<WwwrootFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbracoContentFiles)Content\**" />
-		</ItemGroup>
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco detected ThePensionsRegulator.GovUk.Frontend.Umbraco as a transitive dependency. Copying uSync/wwwroot files from $(GovUkFrontendUmbracoContentFiles) to $(ProjectDir)." Importance="high"
-			     Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false" />
-		<Copy SourceFiles="@(uSyncFilesFromGovUkFrontendUmbraco)"
-		      DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false" />
-		<Copy SourceFiles="@(WwwrootFilesFromGovUkFrontendUmbraco)"
-		      DestinationFiles="$(ProjectDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(HasPackageReferenceForGovUkFrontendUmbraco) == false" />
-	</Target>
-
 	<Target Name="TprFrontendUmbraco_CopyFiles">
-		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend.Umbraco, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend.Umbraco']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion" />
-		</XmlPeek>
-		
+		<!-- Use the version of this package to find the NuGet package folder, and copy files from the package to the consuming project. -->
 		<PropertyGroup>
-			<TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion>@(TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion)</TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion>
-			<TprFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_CopyFiles_UserProfile>
-			<TprFrontendUmbraco_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_CopyFiles_UserProfile>
-			<ContentFilesPath>$(TprFrontendUmbraco_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbraco_CopyFiles_TprFrontendUmbracoVersion)\contentFiles\any\$(TargetFramework)\</ContentFilesPath>
+			<TprFrontendUmbraco_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_UserProfile>
+			<TprFrontendUmbraco_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_UserProfile>
+			<TprFrontendUmbraco_ContentFilesPath>$(TprFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoPackageVersion)\contentFiles\any\$(TargetFramework)\</TprFrontendUmbraco_ContentFilesPath>
 		</PropertyGroup>
 		<ItemGroup>
-			<uSyncFilesFromTprFrontendUmbraco Include="$(ContentFilesPath)uSync\**" />
-			<WwwrootFilesFromTprFrontendUmbraco Include="$(ContentFilesPath)Content\**" />
+			<uSyncFilesFromTprFrontendUmbraco Include="$(TprFrontendUmbraco_ContentFilesPath)uSync\**" />
+			<WwwrootFilesFromTprFrontendUmbraco Include="$(TprFrontendUmbraco_ContentFilesPath)Content\**" />
 		</ItemGroup>
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco copying uSync/wwwroot files from $(ContentFilesPath) to $(ProjectDir)" Importance="high" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco copying uSync and backoffice CSS files from $(TprFrontendUmbraco_ContentFilesPath) to $(ProjectDir)" Importance="high" />
 		<Copy SourceFiles="@(uSyncFilesFromTprFrontendUmbraco)"
 			DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)" />
 		<Copy SourceFiles="@(WwwrootFilesFromTprFrontendUmbraco)"

--- a/ThePensionsRegulator.Frontend/Directory.Build.targets
+++ b/ThePensionsRegulator.Frontend/Directory.Build.targets
@@ -34,6 +34,27 @@
 		  Overwrite="true" />
 	</Target>
 
+	<Target Name="TprFrontend_GenerateProps" BeforeTargets="BeforeBuild">
+		<!--Generate a .props file so that ThePensionsRegulator.Frontend.targets has access to the package version. -->
+		<Message Text="ThePensionsRegulator.Frontend generating $(ProjectDir)ThePensionsRegulator.Frontend.props" Importance="high" />
+		<ItemGroup>
+			<TprFrontendPropsText Include="TprFrontendPropsText">
+				<Text>
+					<![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<TprFrontendPackageVersion>$(Version)</TprFrontendPackageVersion>
+	</PropertyGroup>
+</Project>
+				]]>
+				</Text>
+			</TprFrontendPropsText>
+			<TprFrontendProps Include="%(TprFrontendPropsText.Text)" />
+		</ItemGroup>
+		<WriteLinesToFile File="$(ProjectDir)ThePensionsRegulator.Frontend.generated.props" Lines="@(TprFrontendProps)" Overwrite="True" />
+	</Target>
+
 	<!-- Clean up obsolete files from previous versions where they would cause a conflict. -->
 	<Target Name="TprFrontend_Clean" Condition="Exists('$(ProjectDir)wwwroot\tpr\')">
 		<ItemGroup>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -88,6 +88,10 @@
 			<Pack>true</Pack>
 			<PackagePath>build;buildTransitive</PackagePath>
 		</Content>
+		<Content Include="ThePensionsRegulator.Frontend.generated.props">
+			<Pack>true</Pack>
+			<PackagePath>build</PackagePath>
+		</Content>
 		<Content Include="Styles\_tpr-variables.scss">
 			<Pack>true</Pack>
 			<PackagePath>contentFiles\any\$(TargetFramework)\Styles\tpr</PackagePath>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
@@ -1,128 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="..\build\ThePensionsRegulator.Frontend.generated.props"/>
+	
 	<Target Name="ThePensionsRegulatorFrontend" AfterTargets="ThePensionsRegulatorGovUkFrontend">
-		<!-- Look for the PackageReference to this package to get the current version.
-			 Use that version to find the NuGet package folder, and copy SASS files to the Styles folder in the consuming project.
-			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontendVersion" />
-		</XmlPeek>
-
 		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
 			<Output TaskParameter="Result" ItemName="TprFrontend_TargetProjectSdk" />
 		</XmlPeek>
 		<PropertyGroup>
-			<TprFrontendVersion>@(TprFrontendVersion)</TprFrontendVersion>
-			<TprFrontend_HasPackageReferenceToTprFrontend Condition="@(TprFrontendVersion->Count() )>0">true</TprFrontend_HasPackageReferenceToTprFrontend>
 			<TprFrontend_TargetProjectIsWebOrRclProject Condition="@(TprFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(TprFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</TprFrontend_TargetProjectIsWebOrRclProject>
 		</PropertyGroup>
 
-		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend to the consuming project if it is a transitive dependency. -->
-		<CallTarget Targets="TprFrontend_CopyFromTprGovUkFrontend" Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true And $(TprFrontend_HasPackageReferenceToTprFrontend) == true" />
-
 		<!-- Copy files from this project to the consuming project. -->
 		<Message Text="ThePensionsRegulator.Frontend not copying SASS files from ThePensionsRegulator.Frontend because the target project is not a web project or Razor class library." Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) != true" Importance="high" />
-		<Message Text="ThePensionsRegulator.Frontend not copying SASS files from ThePensionsRegulator.Frontend because it is a transitive dependency without access to the correct path. These may be copied by the package that references ThePensionsRegulator.Frontend or you may need to add a direct reference to ThePensionsRegulator.Frontend." Importance="high"
-				 Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true And $(TprFrontend_HasPackageReferenceToTprFrontend) != true"/>
-		<CallTarget Targets="TprFrontend_CopyFiles" Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true And $(TprFrontend_HasPackageReferenceToTprFrontend) == true" />
-		<CallTarget Targets="TprFrontend_GenerateFiles" Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true" />
-	</Target>
-
-	<Target Name="TprFrontend_CopyFromTprGovUkFrontend">
-		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion" />
-		</XmlPeek>
-
-		<PropertyGroup>
-			<TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion>@(TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion)</TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion>
-		</PropertyGroup>
-
-		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend to get the current version. If it's missing then 
-		     ThePensionsRegulator.GovUk.Frontend is a transitive dependency of this package, and will have been unable to copy 
-			 govuk-frontend SASS files to the Styles folder of the consuming project.
-			 
-			 If ThePensionsRegulator.GovUk.Frontend is a transitive dependency find its version in the metadata of ThePensionsRegulator.Frontend. 
-			 Use the version of ThePensionsRegulator.GovUk.Frontend to find its NuGet package folder, and copy govuk-frontend SASS files to the 
-			 Styles folder in the consuming project.
-		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="TprGovUkFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<HasPackageReferenceForTprGovUkFrontend Condition="@(TprGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForTprGovUkFrontend>
-			<TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists>
-			<TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles Condition="$(HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists) == true">true</TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles>
-			<TprFrontend_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontend_CopyFromTprGovUkFrontend_UserProfile>
-			<TprFrontend_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontend_CopyFromTprGovUkFrontend_UserProfile>
-		</PropertyGroup>
-		
-		<XmlPeek XmlInputPath="$(TprFrontend_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion)\thepensionsregulator.frontend.nuspec"
-			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
-			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles) == true">
-			<Output TaskParameter="Result" ItemName="TprGovUkFrontendVersion" />
-		</XmlPeek>
-		<PropertyGroup>
-			<TprGovUkFrontendVersion>@(TprGovUkFrontendVersion)</TprGovUkFrontendVersion>
-			<TprGovUkFrontendSassFolder>$(TprFrontend_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(TprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprGovUkFrontendSassFolder>
-		</PropertyGroup>
-		<ItemGroup>
-			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(TprGovUkFrontendSassFolder)**\*.scss" />
-		</ItemGroup>
-		<Message Text="Detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying govuk-frontend SASS files from $(TprGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(HasPackageReferenceForTprGovUkFrontend) == false" />
-
-		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="ThePensionsRegulator.Frontend detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
-				 Condition="$(HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists) != true" />
-		<Message Text="ThePensionsRegulator.Frontend detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying SASS files from $(ThePensionsRegulatorGovUkFrontendSassFiles) to $(ProjectDir)." Importance="high"
-			     Condition="$(TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
-		<Copy SourceFiles="@(ThePensionsRegulatorGovUkFrontendSassFiles)"
-		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
+		<CallTarget Targets="TprFrontend_CopyFiles" Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true" />
 	</Target>
 
 	<Target Name="TprFrontend_CopyFiles">
-		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend, which we know exists because the current target only runs if it does. 
-		     Get the version, which we can use to find the paths to transitive packages. -->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend']/@Version">
-			<Output TaskParameter="Result" ItemName="TprFrontend_CopyFiles_TprFrontendVersion" />
-		</XmlPeek>
-
+		<!-- Use the version of this package to find the NuGet package folder, and copy files from the package to the consuming project. -->
 		<PropertyGroup>
-			<TprFrontend_CopyFiles_TprFrontendVersion>@(TprFrontend_CopyFiles_TprFrontendVersion)</TprFrontend_CopyFiles_TprFrontendVersion>
-			<TprFrontend_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontend_CopyFiles_UserProfile>
-			<TprFrontend_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontend_CopyFiles_UserProfile>
-		</PropertyGroup>
-
-		<PropertyGroup>
-			<TprFrontendSassFolder>$(TprFrontend_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontend_CopyFiles_TprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprFrontendSassFolder>
-			<TprFrontend_CopyFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontend_CopyFiles_StylesFolderExists>
+			<TprFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontend_UserProfile>
+			<TprFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontend_UserProfile>
+			<TprFrontendSassFolder>$(TprFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontendPackageVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprFrontendSassFolder>
+			<TprFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontend_StylesFolderExists>
 		</PropertyGroup>
 		<ItemGroup>
 			<TprFrontendSassFiles Include="$(TprFrontendSassFolder)**\*.scss" />
 		</ItemGroup>
 
 		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="ThePensionsRegulator.Frontend not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high" Condition="$(TprFrontend_CopyFiles_StylesFolderExists) != true" />
-		<Message Text="ThePensionsRegulator.Frontend copying SASS files from $(TprFrontendSassFolder) to $(ProjectDir)" Importance="high" Condition="$(TprFrontend_CopyFiles_StylesFolderExists) == true"/>
+		<Message Text="ThePensionsRegulator.Frontend not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high" Condition="$(TprFrontend_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.Frontend copying SASS files from $(TprFrontendSassFolder) to $(ProjectDir)" Importance="high" Condition="$(TprFrontend_StylesFolderExists) == true"/>
 		<Copy SourceFiles="@(TprFrontendSassFiles)"
 			  DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(TprFrontend_CopyFiles_StylesFolderExists) == true"/>
-	</Target>
+			  Condition="$(TprFrontend_StylesFolderExists) == true"/>
 
-	<Target Name="TprFrontend_GenerateFiles">
 		<!-- Generate a .gitignore so that SASS files from the ThePensionsRegulator.Frontend package are not committed to the consuming project's source control.	 
 			 Only do that if the folder exists, otherwise they'll also get created in a project with no interest in SASS.  -->
-		<PropertyGroup>
-			<TprFrontend_GenerateFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontend_GenerateFiles_StylesFolderExists>
-		</PropertyGroup>
-
-		<Message Text="ThePensionsRegulator.Frontend generating $(ProjectDir)Styles\tpr\.gitignore to prevent commit of SASS files copied into the project." Importance="high" Condition="$(TprFrontend_GenerateFiles_StylesFolderExists) == true" />
+		<Message Text="ThePensionsRegulator.Frontend generating $(ProjectDir)Styles\tpr\.gitignore to prevent commit of SASS files copied into the project." Importance="high" Condition="$(TprFrontend_StylesFolderExists) == true" />
 		<ItemGroup>
 			<ThePensionsRegulatorFrontendGitIgnoreText Include="ThePensionsRegulatorFrontendGitIgnoreText">
 				<Text>
@@ -133,6 +48,6 @@
 			</ThePensionsRegulatorFrontendGitIgnoreText>
 			<ThePensionsRegulatorFrontendGitIgnore Include="%(ThePensionsRegulatorFrontendGitIgnoreText.Text)" />
 		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)Styles\tpr\.gitignore" Lines="@(ThePensionsRegulatorFrontendGitIgnore)" Overwrite="True" Condition="$(TprFrontend_GenerateFiles_StylesFolderExists) == true" />
+		<WriteLinesToFile File="$(ProjectDir)Styles\tpr\.gitignore" Lines="@(ThePensionsRegulatorFrontendGitIgnore)" Overwrite="True" Condition="$(TprFrontend_StylesFolderExists) == true" />
 	</Target>
 	</Project>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.targets
@@ -5,32 +5,41 @@
 			 Use that version to find the NuGet package folder, and copy SASS files to the Styles folder in the consuming project.
 			 If this package is a transitive dependency the PackageReference will not be found, so show a message.
 		-->
-		<PropertyGroup>
-			<UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</UserProfile>
-			<UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</UserProfile>
-		</PropertyGroup>
 		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend']/@Version">
 			<Output TaskParameter="Result" ItemName="TprFrontendVersion" />
 		</XmlPeek>
+
+		<!-- Determine if the consuming project is a web project. If it isn't then skip copying/generating files. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/@Sdk">
+			<Output TaskParameter="Result" ItemName="TprFrontend_TargetProjectSdk" />
+		</XmlPeek>
 		<PropertyGroup>
 			<TprFrontendVersion>@(TprFrontendVersion)</TprFrontendVersion>
-			<HasPackageReferenceForTprFrontend Condition="@(TprFrontendVersion->Count() )==0">false</HasPackageReferenceForTprFrontend>
-			<TprFrontendSassFolder>$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprFrontendSassFolder>
+			<TprFrontend_HasPackageReferenceToTprFrontend Condition="@(TprFrontendVersion->Count() )>0">true</TprFrontend_HasPackageReferenceToTprFrontend>
+			<TprFrontend_TargetProjectIsWebOrRclProject Condition="@(TprFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Web' Or @(TprFrontend_TargetProjectSdk)=='Microsoft.NET.Sdk.Razor'">true</TprFrontend_TargetProjectIsWebOrRclProject>
 		</PropertyGroup>
-		<ItemGroup>
-			<TprFrontendSassFiles Include="$(TprFrontendSassFolder)**\*.scss" />
-		</ItemGroup>
 
-		<Message Text="Not copying files from ThePensionsRegulator.Frontend because it is a transitive dependency. These may be copied by the package that references ThePensionsRegulator.Frontend or you may need to add a direct reference to ThePensionsRegulator.Frontend." Importance="high"
-		         Condition="$(HasPackageReferenceForTprFrontend) == false"/>
+		<!-- Copy files from ThePensionsRegulator.GovUk.Frontend to the consuming project if it is a transitive dependency. -->
+		<CallTarget Targets="TprFrontend_CopyFromTprGovUkFrontend" Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true And $(TprFrontend_HasPackageReferenceToTprFrontend) == true" />
 
-		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
-		<Message Text="Copying SASS files from $(TprFrontendSassFolder) to $(ProjectDir)" Importance="high" 
-				 Condition="$(HasPackageReferenceForTprFrontend) != false"/>
-		<Copy SourceFiles="@(TprFrontendSassFiles)"
-			  DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(HasPackageReferenceForTprFrontend) != false"/>
+		<!-- Copy files from this project to the consuming project. -->
+		<Message Text="ThePensionsRegulator.Frontend not copying SASS files from ThePensionsRegulator.Frontend because the target project is not a web project or Razor class library." Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) != true" Importance="high" />
+		<Message Text="ThePensionsRegulator.Frontend not copying SASS files from ThePensionsRegulator.Frontend because it is a transitive dependency without access to the correct path. These may be copied by the package that references ThePensionsRegulator.Frontend or you may need to add a direct reference to ThePensionsRegulator.Frontend." Importance="high"
+				 Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true And $(TprFrontend_HasPackageReferenceToTprFrontend) != true"/>
+		<CallTarget Targets="TprFrontend_CopyFiles" Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true And $(TprFrontend_HasPackageReferenceToTprFrontend) == true" />
+		<CallTarget Targets="TprFrontend_GenerateFiles" Condition="$(TprFrontend_TargetProjectIsWebOrRclProject) == true" />
+	</Target>
 
+	<Target Name="TprFrontend_CopyFromTprGovUkFrontend">
+		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend, which we know exists because the current target only runs if it does. 
+		     Get the version, which we can use to find the paths to transitive packages. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend']/@Version">
+			<Output TaskParameter="Result" ItemName="TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion" />
+		</XmlPeek>
+
+		<PropertyGroup>
+			<TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion>@(TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion)</TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion>
+		</PropertyGroup>
 
 		<!-- Look for the PackageReference to ThePensionsRegulator.GovUk.Frontend to get the current version. If it's missing then 
 		     ThePensionsRegulator.GovUk.Frontend is a transitive dependency of this package, and will have been unable to copy 
@@ -40,44 +49,90 @@
 			 Use the version of ThePensionsRegulator.GovUk.Frontend to find its NuGet package folder, and copy govuk-frontend SASS files to the 
 			 Styles folder in the consuming project.
 		-->
-		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version"
-				 Condition="$(HasPackageReferenceForTprFrontend) != false">
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.GovUk.Frontend']/@Version">
 			<Output TaskParameter="Result" ItemName="TprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
-			<HasPackageReferenceForTprGovUkFrontend Condition="$(HasPackageReferenceForTprFrontend) != false and @(TprGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForTprGovUkFrontend>
+			<HasPackageReferenceForTprGovUkFrontend Condition="@(TprGovUkFrontendVersion->Count() )==0">false</HasPackageReferenceForTprGovUkFrontend>
+			<TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists>
+			<TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles Condition="$(HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists) == true">true</TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles>
+			<TprFrontend_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontend_CopyFromTprGovUkFrontend_UserProfile>
+			<TprFrontend_CopyFromTprGovUkFrontend_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontend_CopyFromTprGovUkFrontend_UserProfile>
 		</PropertyGroup>
-		<XmlPeek XmlInputPath="$(UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontendVersion)\thepensionsregulator.frontend.nuspec"
+		
+		<XmlPeek XmlInputPath="$(TprFrontend_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontend_CopyFromTprGovUkFrontend_TprFrontendVersion)\thepensionsregulator.frontend.nuspec"
 			 Query="nu:package/nu:metadata/nu:dependencies/nu:group[@targetFramework = '$(TargetFramework)']/nu:dependency[@id = 'ThePensionsRegulator.GovUk.Frontend']/@version"
 			 Namespaces="&lt;Namespace Prefix='nu' Uri='http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd' /&gt;"
-			 Condition="$(HasPackageReferenceForTprFrontend) != false and $(HasPackageReferenceForTprGovUkFrontend) == false">
+			 Condition="$(TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles) == true">
 			<Output TaskParameter="Result" ItemName="TprGovUkFrontendVersion" />
 		</XmlPeek>
 		<PropertyGroup>
-			<TprGovUkFrontendVersion Condition="$(HasPackageReferenceForTprFrontend) != false">@(TprGovUkFrontendVersion)</TprGovUkFrontendVersion>
-			<TprGovUkFrontendSassFolder Condition="$(HasPackageReferenceForTprFrontend) != false">$(UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(TprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprGovUkFrontendSassFolder>
+			<TprGovUkFrontendVersion>@(TprGovUkFrontendVersion)</TprGovUkFrontendVersion>
+			<TprGovUkFrontendSassFolder>$(TprFrontend_CopyFromTprGovUkFrontend_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend\$(TprGovUkFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprGovUkFrontendSassFolder>
 		</PropertyGroup>
 		<ItemGroup>
-			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(TprGovUkFrontendSassFolder)**\*.scss" Condition="$(HasPackageReferenceForTprFrontend) != false" />
+			<ThePensionsRegulatorGovUkFrontendSassFiles Include="$(TprGovUkFrontendSassFolder)**\*.scss" />
 		</ItemGroup>
 		<Message Text="Detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying govuk-frontend SASS files from $(TprGovUkFrontendSassFolder) to $(ProjectDir)." Importance="high"
-			     Condition="$(HasPackageReferenceForTprFrontend) != false and $(HasPackageReferenceForTprGovUkFrontend) == false" />
+			     Condition="$(HasPackageReferenceForTprGovUkFrontend) == false" />
+
+		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
+		<Message Text="ThePensionsRegulator.Frontend detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high"
+				 Condition="$(HasPackageReferenceForTprGovUkFrontend) == false And $(TprFrontend_CopyFromTprGovUkFrontend_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.Frontend detected ThePensionsRegulator.GovUk.Frontend as a transitive dependency. Copying SASS files from $(ThePensionsRegulatorGovUkFrontendSassFiles) to $(ProjectDir)." Importance="high"
+			     Condition="$(TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
 		<Copy SourceFiles="@(ThePensionsRegulatorGovUkFrontendSassFiles)"
 		      DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
-			  Condition="$(HasPackageReferenceForTprFrontend) != false and $(HasPackageReferenceForTprGovUkFrontend) == false" />
+			  Condition="$(TprFrontend_CopyFromTprGovUkFrontend_CopySassFiles) == true" />
+	</Target>
 
+	<Target Name="TprFrontend_CopyFiles">
+		<!-- Look for the PackageReference to ThePensionsRegulator.Frontend, which we know exists because the current target only runs if it does. 
+		     Get the version, which we can use to find the paths to transitive packages. -->
+		<XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="Project/ItemGroup/PackageReference[@Include='ThePensionsRegulator.Frontend']/@Version">
+			<Output TaskParameter="Result" ItemName="TprFrontend_CopyFiles_TprFrontendVersion" />
+		</XmlPeek>
+
+		<PropertyGroup>
+			<TprFrontend_CopyFiles_TprFrontendVersion>@(TprFrontend_CopyFiles_TprFrontendVersion)</TprFrontend_CopyFiles_TprFrontendVersion>
+			<TprFrontend_CopyFiles_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontend_CopyFiles_UserProfile>
+			<TprFrontend_CopyFiles_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontend_CopyFiles_UserProfile>
+		</PropertyGroup>
+
+		<PropertyGroup>
+			<TprFrontendSassFolder>$(TprFrontend_CopyFiles_UserProfile)\.nuget\packages\thepensionsregulator.frontend\$(TprFrontend_CopyFiles_TprFrontendVersion)\contentFiles\any\$(TargetFramework)\Styles\</TprFrontendSassFolder>
+			<TprFrontend_CopyFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontend_CopyFiles_StylesFolderExists>
+		</PropertyGroup>
+		<ItemGroup>
+			<TprFrontendSassFiles Include="$(TprFrontendSassFolder)**\*.scss" />
+		</ItemGroup>
+
+		<!-- The following copy task is also configured in ThePensionsRegulator.Frontend.Umbraco.targets in case this package is referenced as a transitive dependency -->
+		<Message Text="ThePensionsRegulator.Frontend not copying SASS files because $(ProjectDir)Styles does not exist." Importance="high" Condition="$(TprFrontend_CopyFiles_StylesFolderExists) != true" />
+		<Message Text="ThePensionsRegulator.Frontend copying SASS files from $(TprFrontendSassFolder) to $(ProjectDir)" Importance="high" Condition="$(TprFrontend_CopyFiles_StylesFolderExists) == true"/>
+		<Copy SourceFiles="@(TprFrontendSassFiles)"
+			  DestinationFiles="$(ProjectDir)Styles\%(RecursiveDir)%(Filename)%(Extension)"
+			  Condition="$(TprFrontend_CopyFiles_StylesFolderExists) == true"/>
+	</Target>
+
+	<Target Name="TprFrontend_GenerateFiles">
 		<!-- Generate a .gitignore so that SASS files from the ThePensionsRegulator.Frontend package are not committed to the consuming project's source control.	 
-			 Only do that if the folder exists, otherwise they'll also get created in a test project with a project reference to the target project.  -->
-		<Message Text="Generating $(ProjectDir)Styles\tpr\.gitignore" Importance="high" Condition="Exists('$(ProjectDir)Styles')" />
+			 Only do that if the folder exists, otherwise they'll also get created in a project with no interest in SASS.  -->
+		<PropertyGroup>
+			<TprFrontend_GenerateFiles_StylesFolderExists Condition="Exists('$(ProjectDir)Styles')">true</TprFrontend_GenerateFiles_StylesFolderExists>
+		</PropertyGroup>
+
+		<Message Text="ThePensionsRegulator.Frontend generating $(ProjectDir)Styles\tpr\.gitignore to prevent commit of SASS files copied into the project." Importance="high" Condition="$(TprFrontend_GenerateFiles_StylesFolderExists) == true" />
 		<ItemGroup>
 			<ThePensionsRegulatorFrontendGitIgnoreText Include="ThePensionsRegulatorFrontendGitIgnoreText">
 				<Text>
+# Generated by ThePensionsRegulator.Frontend
 *
 !.gitignore
 				</Text>
 			</ThePensionsRegulatorFrontendGitIgnoreText>
 			<ThePensionsRegulatorFrontendGitIgnore Include="%(ThePensionsRegulatorFrontendGitIgnoreText.Text)" />
 		</ItemGroup>
-		<WriteLinesToFile File="$(ProjectDir)Styles\tpr\.gitignore" Lines="@(ThePensionsRegulatorFrontendGitIgnore)" Overwrite="True" Condition="Exists('$(ProjectDir)Styles')" />
+		<WriteLinesToFile File="$(ProjectDir)Styles\tpr\.gitignore" Lines="@(ThePensionsRegulatorFrontendGitIgnore)" Overwrite="True" Condition="$(TprFrontend_GenerateFiles_StylesFolderExists) == true" />
 	</Target>
-</Project>
+	</Project>


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

This PR begins a review of the MSBuild that runs when our packages are installed.

When our packages are installed, most of them include files that need to be part of the consuming project, eg SASS and uSync files. By default NuGet adds these as a reference back to the package folder in the NuGet cache, but software like uSync doesn't expect that, so we copy files from the NuGet cache to the project, and generate `.gitignore` files to avoid committing them.

This is done by the `<project-name>.targets` file in each project, which is included in the package and runs when the consuming project is built. 

However, we've always had some tech debt here because the `<PackageReference>` format only includes NuGet packages that are directly referenced. Where you have transitive references, like `ThePensionsRegulator.Frontend` depending upon `ThePensionsRegulator.GovUk.Frontend`, there is no `<PackageReference>` element for the transitive package. So it's harder to get the name and version to go and find the folder in the NuGet cache to copy the files. Our solution has been to detect if a package is a transitive reference and do nothing, and repeat the logic for every package in all the other packages that may have them as a transitive reference.

This PR introduces a better solution, therefore you see it deleting a lot of MSBuild that was repeated logic.

- Each project generate a .props file and include it in the NuGet package. The .props file includes the package version as an MSBuild variable.
- `<package-name>.targets` files can now read the variable for their package to know the version, and are therefore able to find the folder they need to copy files from.

Another issue we have is that packages designed to be referenced by web projects have sometimes been referenced by class libraries, and the class library projects get the files even though they don't want them. 

This PR introduces a better solution for SASS files included in the package. If the consuming project is not a web project or a Razor class library, SASS files are not copied. If it is a web project or razor class library SASS files are copied _if there is already a Styles folder_. This allows consuming projects that might want SASS files to opt in to getting them.

Lastly this PR removes `npm install` from the .NET build. This was only introduced earlier in this series of PRs, to build components built in the new backoffice tech. However it has to be followed by `npm run build` to be useful, and at TPR that is blocked by policy. Running `npm install` without that is just adding a delay to the .NET build. We already have an npm script to run both backoffice builds, and that's a better solution.

## How to test this PR

Since we are now looking at the behaviour of the script that runs when a package is installed, testing this PR should involve:

1. Change the version number to something like `10.0.0-alpha001` in `Directory.Build.props` at the top of the repo and generate local packages.
2.  Set up one or more local NuGet package sources to point to the alpha packages. 
3 .Create a consuming project and consume the packages. 
4. Verify that expected CSS, SASS and uSync files are copied into the project and are excluded from git for the consuming project.

## Out-of-scope for this PR

Everything else. 

Outside of the backoffice you can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- client-side files are minified and cached

Otherwise you can expect:
- build warnings
- TODO comments in code
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Fix the unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating other namespaces for greater clarity
- Modernising example apps and docs to support top-level statements in Program.cs
- Convert all remaining NUnit tests to XUnit

#535 