### PR TITLE
Bump version to v10.0.0-beta001

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>9.1.0</Version>
+    <Version>10.0.0-beta001</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This bumps the version of the v17 upgrade so that we can publish a pre-release package and use it in applications that are ready to consume it.