### PR TITLE
#257064 Table of contents lists are not labelled within the side navigation

### DIFF
--- a/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
@@ -23,13 +23,13 @@
                 <a class="govuk-link govuk-link--no-visited-state tpr-side-nav__desktop-link" href="@Model.TitleLink.Url">@Model.TitleLink.Name</a>
             </h2>
         }
-        await RenderNavListLayer(Model.NavigationLinks, level, isMobileExpanded ? "tpr-side-nav__list--expanded" : null);
+        await RenderNavListLayer(Model.NavigationLinks, null, level, isMobileExpanded ? "tpr-side-nav__list--expanded" : null);
     }
 </nav>
 @{
-    async Task RenderNavListLayer(List<TprSideNavigationLink> navigationLinks, int level, string? listClass)
+    async Task RenderNavListLayer(List<TprSideNavigationLink> navigationLinks, TprSideNavigationLink? parent, int level, string? listClass)
     {
-        <ul class="tpr-side-nav__list @listClass" id="@(id)__list" data-level="@level">
+        <ul class="tpr-side-nav__list @listClass" id="@(id)__list" data-level="@level" @Html.Raw(parent is not null ? $"aria-labelledby='Child links of {parent.Name}'" : string.Empty)>
             @foreach (var child in navigationLinks)
             {
                 var childId = $"{id}-{Guid.NewGuid().ToString().Substring(0, 8)}";
@@ -45,7 +45,7 @@
                     </div>
                     @if (child.Children is not null && child.Children.Any())
                     {
-                        await RenderNavListLayer(child.Children, ++level, null);
+                        await RenderNavListLayer(child.Children, child, ++level, null);
                     }
                 </li>
             }

--- a/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
@@ -29,7 +29,7 @@
 @{
     async Task RenderNavListLayer(List<TprSideNavigationLink> navigationLinks, TprSideNavigationLink? parent, int level, string? listClass)
     {
-        <ul class="tpr-side-nav__list @listClass" id="@(id)__list" data-level="@level" @Html.Raw(parent is not null ? $"aria-labelledby='Child links of {parent.Name}'" : string.Empty)>
+        <ul class="tpr-side-nav__list @listClass" id="@(id)__list" data-level="@level" @Html.Raw(parent is not null ? $"aria-label='Child links of {parent.Name}'" : string.Empty)>
             @foreach (var child in navigationLinks)
             {
                 var childId = $"{id}-{Guid.NewGuid().ToString().Substring(0, 8)}";

--- a/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
@@ -27,15 +27,16 @@
     }
 </nav>
 @{
-    async Task RenderNavListLayer(List<TprSideNavigationLink> navigationLinks, TprSideNavigationLink? parent, int level, string? listClass)
+    async Task RenderNavListLayer(List<TprSideNavigationLink> navigationLinks, string? parentLinkId, int level, string? listClass)
     {
-        <ul class="tpr-side-nav__list @listClass" id="@(id)__list" data-level="@level" @Html.Raw(parent is not null ? $"aria-label='Child links of {parent.Name}'" : string.Empty)>
+        <ul class="tpr-side-nav__list @listClass" id="@(id)__list" data-level="@level" @(string.IsNullOrWhiteSpace(parentLinkId) ? string.Empty : $"aria-labelledby={parentLinkId}")>
             @foreach (var child in navigationLinks)
             {
                 var childId = $"{id}-{Guid.NewGuid().ToString().Substring(0, 8)}";
+                var childLinkId = childId + "__link";
                 <li id="@childId" @(child.IsCurrentPage && !child.IsExpanded ? "class=tpr-side-nav__list-item--active" : string.Empty) @(child.IsExpanded && !child.IsCurrentPage ? "class=tpr-side-nav__list-item--expanded" : string.Empty) @Html.Raw(child.IsCurrentPage && child.IsExpanded ? "class='tpr-side-nav__list-item--active tpr-side-nav__list-item--expanded'" : string.Empty)>
                     <div class="tpr-side-nav__list-item-wrapper">
-                        <a class="govuk-link govuk-link--no-visited-state" @(child.IsCurrentPage ? "aria-current=page" : string.Empty) href="@child.Url">@child.Name</a>
+                        <a id="@(childLinkId)" class="govuk-link govuk-link--no-visited-state" @(child.IsCurrentPage ? "aria-current=page" : string.Empty) href="@child.Url">@child.Name</a>
                         @if (child.Children is not null && child.Children.Any())
                         {
                             var arrowNoJsAlternative = string.Format(child.IsExpanded ? Model.ExpandedItemLabel : Model.CollapsedItemLabel, child.Name);
@@ -45,7 +46,7 @@
                     </div>
                     @if (child.Children is not null && child.Children.Any())
                     {
-                        await RenderNavListLayer(child.Children, child, ++level, null);
+                        await RenderNavListLayer(child.Children, childLinkId, ++level, null);
                     }
                 </li>
             }


### PR DESCRIPTION
In this PR:
- Added an ID to the `<a>` tag of each list item within in the side navigation;
- Included the `aria-labelledby` attribute on each sub-list, attaching it to its parent link. This should make the hierarchy easier to identify for people using assistive technologies.

This is related to the work item: https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/257064.