### PR TITLE
Fix remaining C# build warnings and TODO comments 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.UnitTests/GovUkTypographyTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.UnitTests/GovUkTypographyTests.cs
@@ -23,7 +23,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result);
-            Assert.Equal(1, doc.DocumentNode.SelectNodes("//a[@class='govuk-link']").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//a[@class='govuk-link']"));
         }
 
         [Fact]
@@ -35,8 +35,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result);
-            Assert.Equal(1, doc.DocumentNode.SelectNodes("//a[contains(@class,'govuk-link')]").Count);
-            Assert.Equal(1, doc.DocumentNode.SelectNodes("//a[contains(@class,'govuk-link--inverse')]").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//a[contains(@class,'govuk-link')]"));
+            Assert.Single(doc.DocumentNode.SelectNodes("//a[contains(@class,'govuk-link--inverse')]"));
         }
 
         [Fact]
@@ -60,8 +60,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result);
-            Assert.Equal(1, doc.DocumentNode.SelectNodes("//h2[@class='govuk-heading-s']").Count);
-            Assert.Equal(1, doc.DocumentNode.SelectNodes("//h2[@class='govuk-heading-m']").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//h2[@class='govuk-heading-s']"));
+            Assert.Single(doc.DocumentNode.SelectNodes("//h2[@class='govuk-heading-m']"));
         }
 
         [Fact]

--- a/GovUk.Frontend.AspNetCore.Extensions.UnitTests/MaxFileSizeAttributeTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.UnitTests/MaxFileSizeAttributeTests.cs
@@ -1,6 +1,5 @@
 using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using Microsoft.AspNetCore.Http;
-using System.IO;
 
 namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 {
@@ -13,7 +12,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
         {
             var file = CreateFormFile(800);
             var result = _sut.IsValid(file);
-            Assert.Equal(true, result);
+            Assert.True(result);
         }
 
         [Fact]
@@ -21,7 +20,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
         {
             var file = CreateFormFile(20_000);
             var result = _sut.IsValid(file);
-            Assert.Equal(false, result);
+            Assert.False(result);
         }
 
         [Fact]

--- a/GovUk.Frontend.AspNetCore.Extensions.UnitTests/ModelPropertyResolverTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.UnitTests/ModelPropertyResolverTests.cs
@@ -4,8 +4,6 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using System;
-using System.Collections.Generic;
 
 namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 {
@@ -118,7 +116,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 
             var modelType = modelPropertyResolver.ResolveModelType(viewContext);
 
-            Assert.Equal(modelType, typeof(DefaultModel));
+            Assert.Equal(typeof(DefaultModel), modelType);
         }
 
         private static ViewDataDictionary CreateViewData()
@@ -140,7 +138,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 
             var modelType = modelPropertyResolver.ResolveModelType(viewContext);
 
-            Assert.Equal(modelType, typeof(ModelFromModelType));
+            Assert.Equal(typeof(ModelFromModelType), modelType);
 
         }
 
@@ -151,8 +149,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 
             var property = modelPropertyResolver.ResolveModelProperty(typeof(DefaultModel), nameof(DefaultModel.DefaultModelProperty));
 
-            Assert.Equal(property.DeclaringType, typeof(DefaultModel));
-            Assert.Equal(property.Name, nameof(DefaultModel.DefaultModelProperty));
+            Assert.Equal(typeof(DefaultModel), property.DeclaringType);
+            Assert.Equal(nameof(DefaultModel.DefaultModelProperty), property.Name);
         }
 
 
@@ -165,12 +163,12 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
             var propertyFromMonthField = modelPropertyResolver.ResolveModelProperty(typeof(DefaultModel), nameof(DefaultModel.DateTimeProperty.Month));
             var propertyFromYearField = modelPropertyResolver.ResolveModelProperty(typeof(DefaultModel), nameof(DefaultModel.DateTimeProperty.Year));
 
-            Assert.Equal(propertyFromDayField.DeclaringType, typeof(DateTime));
-            Assert.Equal(propertyFromDayField.Name, nameof(DefaultModel.DateTimeProperty.Day));
-            Assert.Equal(propertyFromMonthField.DeclaringType, typeof(DateTime));
-            Assert.Equal(propertyFromMonthField.Name, nameof(DefaultModel.DateTimeProperty.Month));
-            Assert.Equal(propertyFromYearField.DeclaringType, typeof(DateTime));
-            Assert.Equal(propertyFromYearField.Name, nameof(DefaultModel.DateTimeProperty.Year));
+            Assert.Equal(typeof(DateTime), propertyFromDayField.DeclaringType);
+            Assert.Equal(nameof(DefaultModel.DateTimeProperty.Day), propertyFromDayField.Name);
+            Assert.Equal(typeof(DateTime), propertyFromMonthField.DeclaringType);
+            Assert.Equal(nameof(DefaultModel.DateTimeProperty.Month), propertyFromMonthField.Name);
+            Assert.Equal(typeof(DateTime), propertyFromYearField.DeclaringType);
+            Assert.Equal(nameof(DefaultModel.DateTimeProperty.Year), propertyFromYearField.Name);
         }
 
         [Fact]
@@ -179,8 +177,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
             var modelPropertyResolver = new ModelPropertyResolver();
 
             var childProperty = modelPropertyResolver.ResolveModelProperty(typeof(ParentModel), nameof(ParentModel.Child.ChildModelProperty));
-            Assert.Equal(childProperty.DeclaringType, typeof(ChildModel));
-            Assert.Equal(childProperty.Name, nameof(ParentModel.Child.ChildModelProperty));
+            Assert.Equal(typeof(ChildModel), childProperty.DeclaringType);
+            Assert.Equal(nameof(ParentModel.Child.ChildModelProperty), childProperty.Name);
 
 
         }
@@ -192,8 +190,8 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
             var modelPropertyResolver = new ModelPropertyResolver();
 
             var childProperty = modelPropertyResolver.ResolveModelProperty(typeof(ParentModel), "Child.ChildModelProperty");
-            Assert.Equal(childProperty.DeclaringType, typeof(ChildModel));
-            Assert.Equal(childProperty.Name, nameof(ParentModel.Child.ChildModelProperty));
+            Assert.Equal(typeof(ChildModel), childProperty.DeclaringType);
+            Assert.Equal(nameof(ParentModel.Child.ChildModelProperty), childProperty.Name);
         }
 
         [Fact]
@@ -202,11 +200,11 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
             var modelPropertyResolver = new ModelPropertyResolver();
 
             var childProperty = modelPropertyResolver.ResolveModelProperty(typeof(IterativeModel), "List[0].ChildModelProperty");
-            Assert.Equal(childProperty.DeclaringType, typeof(ChildModel));
+            Assert.Equal(typeof(ChildModel), childProperty.DeclaringType);
 
             var childType = typeof(IterativeModel).GetProperty("List")!.PropertyType.GenericTypeArguments[0];
             Assert.Equal(typeof(ChildModel), childType);
-            Assert.Equal(childProperty.Name, nameof(ChildModel.ChildModelProperty));
+            Assert.Equal(nameof(ChildModel.ChildModelProperty), childProperty.Name);
         }
 
         [Fact]
@@ -216,7 +214,7 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 
             var childProperty = modelPropertyResolver.ResolveModelProperty(typeof(IterativeModel), "Array[0]");
             Assert.Equal(childProperty.PropertyType, typeof(IterativeModel).GetProperty("Array")!.PropertyType);
-            Assert.Equal(childProperty.Name, nameof(IterativeModel.Array));
+            Assert.Equal(nameof(IterativeModel.Array), childProperty.Name);
         }
 
         [Fact]

--- a/GovUk.Frontend.AspNetCore.Extensions.UnitTests/UkPostcodeModelBinderTests.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions.UnitTests/UkPostcodeModelBinderTests.cs
@@ -1,15 +1,13 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
-using System.Threading.Tasks;
-
 namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
 {
 
     public class UkPostcodeModelBinderTests
     {
         [Theory]
-        [InlineData(null!, "")]
+        [InlineData(null, "")]
         [InlineData("", "")]
         [InlineData("ab01aa", "AB0 1AA")]
         [InlineData("aa2 3aa", "AA2 3AA")]
@@ -33,13 +31,13 @@ namespace GovUk.Frontend.AspNetCore.Extensions.UnitTests
         [InlineData("AA99AA", "AA9 9AA")]
         [InlineData("AA99 9AA", "AA99 9AA")]
         [InlineData("AA999AA", "AA99 9AA")]
-        public async Task Formats_Postcode(string input, string expected)
+        public async Task Formats_Postcode(string? input, string expected)
         {
             // Arrange
             var modelBinder = new UkPostcodeModelBinder();
             var valueProvider = new SimpleValueProvider();
             var propertyName = "test";
-            valueProvider.Add(propertyName, input);
+            valueProvider.Add(propertyName, input!);
 
             // Act
             var context = new DefaultModelBindingContext

--- a/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
+++ b/GovUk.Frontend.AspNetCore.Extensions/Validation/ClientSideValidationHtmlEnhancer.cs
@@ -5,10 +5,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Reflection;
 
 namespace GovUk.Frontend.AspNetCore.Extensions.Validation
@@ -144,9 +141,12 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
                 if (errorMessageAttributes != null)
                 {
                     var targetElementId = targetElement.Attributes["id"]?.Value;
-                    errorMessageAttributes.Add("data-valmsg-for", targetElementId);
-                    errorMessageAttributes.Add("data-valmsg-replace", "false");
-                    errorMessageAttributes.Add("id", targetElementId + "-error");
+                    if (!string.IsNullOrEmpty(targetElementId))
+                    {
+                        errorMessageAttributes.Add("data-valmsg-for", targetElementId);
+                        errorMessageAttributes.Add("data-valmsg-replace", "false");
+                        errorMessageAttributes.Add("id", targetElementId + "-error");
+                    }
                 }
 
                 var modelPropertyName = targetElement.Attributes["name"]?.Value;
@@ -193,88 +193,126 @@ namespace GovUk.Frontend.AspNetCore.Extensions.Validation
                     var compareAttr = modelProperty.GetCustomAttributes<CompareAttribute>().FirstOrDefault();
                     if (compareAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-equalto", SelectBestErrorMessage(errorMessageCompare, compareAttr.ErrorMessage, localizer));
-                        targetElement.Attributes.Add("data-val-equalto-other", compareAttr.OtherProperty);
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageCompare, compareAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("data-val-equalto", errorMessage);
+                            targetElement.Attributes.Add("data-val-equalto-other", compareAttr.OtherProperty);
+                            validateElement = true;
+                        }
                     }
 
                     // Email Address
                     var emailAttr = modelProperty.GetCustomAttributes<EmailAddressAttribute>().FirstOrDefault();
                     if (emailAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-email", SelectBestErrorMessage(errorMessageEmail, emailAttr.ErrorMessage, localizer));
-                        AddOrUpdateHtmlAttribute(targetElement, "autocomplete", "email");
-                        AddOrUpdateHtmlAttribute(targetElement, "type", "email");
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageEmail, emailAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("data-val-email", errorMessage);
+                            AddOrUpdateHtmlAttribute(targetElement, "autocomplete", "email");
+                            AddOrUpdateHtmlAttribute(targetElement, "type", "email");
+                            validateElement = true;
+                        }
                     }
 
                     // Phone
                     var phoneAttr = modelProperty.GetCustomAttributes<PhoneAttribute>().FirstOrDefault();
                     if (phoneAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-phone", SelectBestErrorMessage(errorMessagePhone, phoneAttr.ErrorMessage, localizer));
-                        AddOrUpdateHtmlAttribute(targetElement, "autocomplete", "tel");
-                        AddOrUpdateHtmlAttribute(targetElement, "type", "tel");
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessagePhone, phoneAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("data-val-phone", errorMessage);
+                            AddOrUpdateHtmlAttribute(targetElement, "autocomplete", "tel");
+                            AddOrUpdateHtmlAttribute(targetElement, "type", "tel");
+                            validateElement = true;
+                        }
                     }
 
                     // Max Length
                     var maxLengthAttr = modelProperty.GetCustomAttributes<MaxLengthAttribute>().FirstOrDefault();
                     if (maxLengthAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-maxlength", SelectBestErrorMessage(errorMessageMaxLength, maxLengthAttr.ErrorMessage, localizer));
-                        targetElement.Attributes.Add("data-val-maxlength-max", maxLengthAttr.Length.ToString());
-                        targetElement.Attributes.Add("maxlength", maxLengthAttr.Length.ToString());
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageMaxLength, maxLengthAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("data-val-maxlength", errorMessage);
+                            targetElement.Attributes.Add("data-val-maxlength-max", maxLengthAttr.Length.ToString());
+                            targetElement.Attributes.Add("maxlength", maxLengthAttr.Length.ToString());
+                            validateElement = true;
+                        }
                     }
 
                     //// Min Length
                     var minLengthAttr = modelProperty.GetCustomAttributes<MinLengthAttribute>().FirstOrDefault();
                     if (minLengthAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-minlength", SelectBestErrorMessage(errorMessageMinLength, minLengthAttr.ErrorMessage, localizer));
-                        targetElement.Attributes.Add("data-val-minlength-min", minLengthAttr.Length.ToString());
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageMinLength, minLengthAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("data-val-minlength", errorMessage);
+                            targetElement.Attributes.Add("data-val-minlength-min", minLengthAttr.Length.ToString());
+                            validateElement = true;
+                        }
                     }
 
                     // Range
                     var rangeAttr = modelProperty.GetCustomAttributes<RangeAttribute>().FirstOrDefault();
                     if (rangeAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-range", SelectBestErrorMessage(errorMessageRange, rangeAttr.ErrorMessage, localizer));
-                        targetElement.Attributes.Add("data-val-range-max", rangeAttr.Maximum.ToString());
-                        targetElement.Attributes.Add("data-val-range-min", rangeAttr.Minimum.ToString());
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageRange, rangeAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            var max = rangeAttr.Maximum.ToString();
+                            var min = rangeAttr.Minimum.ToString();
+                            targetElement.Attributes.Add("data-val-range", errorMessage);
+                            if (max is not null) { targetElement.Attributes.Add("data-val-range-max", max); }
+                            if (min is not null) { targetElement.Attributes.Add("data-val-range-min", min); }
+                            validateElement = true;
+                        }
                     }
 
                     // Regex
                     var regexAttr = modelProperty.GetCustomAttributes<RegularExpressionAttribute>().FirstOrDefault();
                     if (regexAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-regex", SelectBestErrorMessage(errorMessageRegex, regexAttr.ErrorMessage, localizer));
-                        targetElement.Attributes.Add("data-val-regex-pattern", regexAttr.Pattern);
-                        AddOrUpdateHtmlAttribute(targetElement, "pattern", regexAttr.Pattern);
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageRegex, regexAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("data-val-regex", errorMessage);
+                            targetElement.Attributes.Add("data-val-regex-pattern", regexAttr.Pattern);
+                            AddOrUpdateHtmlAttribute(targetElement, "pattern", regexAttr.Pattern);
+                            validateElement = true;
+                        }
                     }
 
                     // Required
                     var reqdAttr = modelProperty.GetCustomAttributes<RequiredAttribute>().FirstOrDefault();
                     if (reqdAttr != null)
                     {
-                        targetElement.Attributes.Add("required", "required");
-                        targetElement.Attributes.Add("data-val-required", SelectBestErrorMessage(errorMessageRequired, reqdAttr.ErrorMessage, localizer));
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageRequired, reqdAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("required", "required");
+                            targetElement.Attributes.Add("data-val-required", errorMessage);
+                            validateElement = true;
+                        }
                     }
 
                     // String Length
                     var strLenAttr = modelProperty.GetCustomAttributes<StringLengthAttribute>().FirstOrDefault();
                     if (strLenAttr != null)
                     {
-                        targetElement.Attributes.Add("data-val-length", SelectBestErrorMessage(errorMessageLength, strLenAttr.ErrorMessage, localizer));
-                        targetElement.Attributes.Add("data-val-length-max", strLenAttr.MaximumLength.ToString());
-                        targetElement.Attributes.Add("data-val-length-min", strLenAttr.MinimumLength.ToString());
-                        targetElement.Attributes.Add("maxlength", strLenAttr.MaximumLength.ToString());
-                        validateElement = true;
+                        var errorMessage = SelectBestErrorMessage(errorMessageLength, strLenAttr.ErrorMessage, localizer);
+                        if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            targetElement.Attributes.Add("data-val-length", errorMessage);
+                            targetElement.Attributes.Add("data-val-length-max", strLenAttr.MaximumLength.ToString());
+                            targetElement.Attributes.Add("data-val-length-min", strLenAttr.MinimumLength.ToString());
+                            targetElement.Attributes.Add("maxlength", strLenAttr.MaximumLength.ToString());
+                            validateElement = true;
+                        }
                     }
 
                     // Get anything else that inherits from ValidationAttribute

--- a/GovUk.Frontend.ExampleApp/Views/Shared/_LanguageSwitcher.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Shared/_LanguageSwitcher.cshtml
@@ -9,14 +9,14 @@
 
 @{
     var requestCulture = Context.Features.Get<IRequestCultureFeature>();
-    var cultureItems = LocOptions.Value.SupportedUICultures
+    var cultureItems = LocOptions.Value.SupportedUICultures?
         .Select(c => (Value: c.Name, Text: c.NativeName ))
         .ToList();
     var returnUrl = string.IsNullOrEmpty(Context.Request.Path) ? "~/" : $"~{Context.Request.Path.Value}";
     var currentLanguage = requestCulture != null ? requestCulture.RequestCulture.UICulture.Name : Thread.CurrentThread.CurrentUICulture.Name;
 }
 
-@if (cultureItems.Count > 1) {
+@if (cultureItems is not null && cultureItems.Count > 1) {
     <div class="govuk-width-container">
         <ul class="govuk-list language-switcher">
             @foreach (var culture in cultureItems)

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
@@ -5,8 +5,6 @@ using GovUk.Frontend.Umbraco.Services;
 using GovUk.Frontend.Umbraco.Validation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
-using Microsoft.Extensions.Logging;
-using System;
 using System.Globalization;
 using System.Web;
 using ThePensionsRegulator.Umbraco.Core;
@@ -91,11 +89,11 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
                 }
                 viewModel.Page.Blocks!.Filter = filter;
                 viewModel.Page.Blocks.FindBlockByContentTypeAlias(GovukPagination.ModelTypeAlias)?
-                    .Settings.OverrideValue(nameof(GovukPaginationSettings.TotalItems), pagination.TotalItems);
+                    .Settings?.OverrideValue(nameof(GovukPaginationSettings.TotalItems), pagination.TotalItems);
 
                 viewModel.Page.Grid!.Filter = filter;
                 viewModel.Page.Grid.FindBlockByContentTypeAlias(GovukPagination.ModelTypeAlias)?
-                    .Settings.OverrideValue(nameof(GovukPaginationSettings.TotalItems), pagination.TotalItems);
+                    .Settings?.OverrideValue(nameof(GovukPaginationSettings.TotalItems), pagination.TotalItems);
 
                 ModelState.SetInitialValue(nameof(viewModel.Items), pagination.TotalItems.ToString(CultureInfo.InvariantCulture));
 

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
@@ -3,7 +3,6 @@ using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using GovUk.Frontend.Umbraco.Blocks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
-using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -25,8 +24,8 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
             var target = viewModel.Blocks!.FindBlockByClass("yet-another-thing");
             if (target != null)
             {
-                target.Settings.OverrideValue(nameof(GovukTaskSettings.Status), TaskListTaskStatus.Completed.ToString());
-                target.Settings.OverrideValue(nameof(GovukTaskSettings.StatusText), "Done");
+                target.Settings?.OverrideValue(nameof(GovukTaskSettings.Status), TaskListTaskStatus.Completed.ToString());
+                target.Settings?.OverrideValue(nameof(GovukTaskSettings.StatusText), "Done");
             }
 
             return CurrentTemplate(viewModel);

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TextInputController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TextInputController.cs
@@ -1,12 +1,9 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions.Validation;
 using GovUk.Frontend.Umbraco.ExampleApp.Models;
 using GovUk.Frontend.Umbraco.Validation;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
-using Microsoft.Extensions.Logging;
-using System;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -26,7 +23,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
             {
                 Response.Cookies.Append(
                     CookieRequestCultureProvider.DefaultCookieName,
-                    CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(Request.Query["culture"])),
+                    CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(Request.Query["culture"]!)),
                     new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1) }
                 );
 

--- a/GovUk.Frontend.Umbraco.Tests/Blocks/TaskListTaskStatusProviderTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Blocks/TaskListTaskStatusProviderTests.cs
@@ -125,7 +125,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
         {
             // Arrange
             var blockList = CreateBlockListWithTaskListSummaryAndTaskList(CreateBlockListOfTasks());
-            blockList.Filter = x => x.Content.ContentType.Alias != ElementTypeAliases.Task || x.Settings.Value<string>(PropertyAliases.TaskListTaskStatus) == TaskListTaskStatus.Completed.ToString();
+            blockList.Filter = x => x.Content.ContentType.Alias != ElementTypeAliases.Task || x.Settings?.Value<string>(PropertyAliases.TaskListTaskStatus) == TaskListTaskStatus.Completed.ToString();
 
             var content = UmbracoContentFactory.CreateContent<IPublishedContent>()
                 .SetupUmbracoBlockListPropertyValue(nameof(ExampleModelsBuilderModel.BlockList), blockList);
@@ -145,7 +145,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
         {
             // Arrange
             var blockGrid = CreateBlockGridWithTaskListSummaryAndTaskList(CreateBlockListOfTasks());
-            blockGrid.Filter = x => x.Content.ContentType.Alias != ElementTypeAliases.Task || x.Settings.Value<string>(PropertyAliases.TaskListTaskStatus) == TaskListTaskStatus.Completed.ToString();
+            blockGrid.Filter = x => x.Content.ContentType.Alias != ElementTypeAliases.Task || x.Settings?.Value<string>(PropertyAliases.TaskListTaskStatus) == TaskListTaskStatus.Completed.ToString();
 
             var content = UmbracoContentFactory.CreateContent<IPublishedContent>()
                 .SetupUmbracoBlockGridPropertyValue(nameof(ExampleModelsBuilderModel.BlockGrid), blockGrid);
@@ -173,7 +173,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                     .Object
                 )
             });
-            blockListOfTasks[0].Settings.OverrideValue(PropertyAliases.TaskListTaskStatus, TaskListTaskStatus.NotStarted.ToString());
+            blockListOfTasks[0].Settings?.OverrideValue(PropertyAliases.TaskListTaskStatus, TaskListTaskStatus.NotStarted.ToString());
 
             var blockList = CreateBlockListWithTaskListSummaryAndTaskList(blockListOfTasks);
 

--- a/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TinyMCEValueFormattersTestHelper.cs
+++ b/GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TinyMCEValueFormattersTestHelper.cs
@@ -32,7 +32,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//p").Count);
         }
 
@@ -43,7 +43,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//ol").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
         }
@@ -55,7 +55,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//ol").Count);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//ol[contains(@class,'govuk-list--{listStyleType}')]").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
@@ -68,7 +68,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//ul").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//ul[@style]"));
         }
@@ -80,7 +80,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//ul").Count);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//ul[contains(@class,'govuk-list--{listStyleType}')]").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//ul[@style]"));
@@ -93,7 +93,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//p").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//p[@style]"));
         }
@@ -105,7 +105,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//p").Count);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//p[contains(@class,'{expectedClass}')]").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//p[@style]"));
@@ -118,7 +118,7 @@ namespace GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
             var doc = new HtmlDocument();
-            doc.LoadHtml(result.ToHtmlString());
+            doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//h2").Count);
             Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//li").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//*[@style]"));

--- a/GovUk.Frontend.Umbraco/Blocks/BlockViewService.cs
+++ b/GovUk.Frontend.Umbraco/Blocks/BlockViewService.cs
@@ -1,8 +1,6 @@
 ﻿using GovUk.Frontend.Umbraco.Services;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
-using System.Collections.Generic;
-using System.Linq;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -36,7 +34,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
 
             for (var i = 0; i < blocks.Count; i++)
             {
-                if (blocks[i]?.ContentUdi == null) { continue; }
+                if (blocks[i]?.ContentKey is null) { continue; }
 
                 var hasGridAreas = blocks[i].Areas.Any();
                 string rowClass = _gridClassBuilder.BuildGridRowClasses(blocks[i].Settings?.Value<string>(PropertyAliases.CssClassesForRow));
@@ -162,7 +160,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
 
             for (var i = 0; i < blocks.Count; i++)
             {
-                if (blocks[i]?.ContentUdi == null) { continue; }
+                if (blocks[i]?.ContentKey is null) { continue; }
 
                 var isGridRowBlock = blocks[i].Content.ContentType.Alias == ElementTypeAliases.GridRow;
                 string rowClass = _gridClassBuilder.BuildGridRowClasses(blocks[i].Settings?.Value<string>(PropertyAliases.CssClassesForRow));

--- a/GovUk.Frontend.Umbraco/Blocks/TaskListTaskStatusProvider.cs
+++ b/GovUk.Frontend.Umbraco/Blocks/TaskListTaskStatusProvider.cs
@@ -1,7 +1,4 @@
 ﻿using GovUk.Frontend.AspNetCore.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -44,7 +41,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
             var tasks = blocks.FindBlocksByContentTypeAlias(ElementTypeAliases.Task)
                 .Where(blockFilter).Select(blockSelector).OfType<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>();
             var taskStatuses = tasks
-                .Select(x => x.Settings.Value<string>(PropertyAliases.TaskListTaskStatus))
+                .Select(x => x.Settings?.Value<string>(PropertyAliases.TaskListTaskStatus))
                 .Where(x => !string.IsNullOrEmpty(x))
                 .Select(x => Enum.Parse<TaskListTaskStatus>(x!.Replace(" ", string.Empty), true));
 

--- a/GovUk.Frontend.Umbraco/Services/GovUkFieldsetErrorFinder.cs
+++ b/GovUk.Frontend.Umbraco/Services/GovUkFieldsetErrorFinder.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using Umbraco.Extensions;
@@ -20,14 +17,14 @@ namespace GovUk.Frontend.Umbraco.Services
         {
             if (fieldsetBlock?.Content?.ContentType?.Alias != ElementTypeAliases.Fieldset) { return Array.Empty<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>(); }
 
-            bool.TryParse(fieldsetBlock.Settings.GetProperty(PropertyAliases.FieldsetErrorsEnabled)?.GetValue()?.ToString(), out var fieldsetErrorsEnabled);
+            bool.TryParse(fieldsetBlock.Settings?.GetProperty(PropertyAliases.FieldsetErrorsEnabled)?.GetValue()?.ToString(), out var fieldsetErrorsEnabled);
             var blocksWithinFieldset = fieldsetBlock.Content.Value<OverridableBlockListModel>(PropertyAliases.FieldsetBlocks);
             if (fieldsetErrorsEnabled && blocksWithinFieldset != null)
             {
                 var invalidFields = modelState.Where(x => x.Value?.ValidationState == ModelValidationState.Invalid && !string.IsNullOrEmpty(x.Key)).Select(x => x.Key);
                 return blocksWithinFieldset.Where(x => x.Content.ContentType.Alias == ElementTypeAliases.ErrorMessage
-                                                       && !string.IsNullOrEmpty(x.Settings.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString())
-                                                       && invalidFields.Contains(x.Settings.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString()));
+                                                       && !string.IsNullOrEmpty(x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString())
+                                                       && invalidFields.Contains(x.Settings?.GetProperty(PropertyAliases.ModelProperty)?.GetValue()?.ToString()));
             }
             return Array.Empty<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>();
         }

--- a/GovUk.Frontend.Umbraco/Services/UmbracoPaginationFactory.cs
+++ b/GovUk.Frontend.Umbraco/Services/UmbracoPaginationFactory.cs
@@ -47,7 +47,7 @@ namespace GovUk.Frontend.Umbraco.Services
 
         private static int FromUmbracoSettingsOrDefault(IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement> block, string propertyName, int defaultValue)
         {
-            var value = block.Settings.Value<int?>(propertyName);
+            var value = block.Settings?.Value<int?>(propertyName);
             if (value.HasValue)
             {
                 return value.Value;
@@ -60,7 +60,7 @@ namespace GovUk.Frontend.Umbraco.Services
 
         private static string FromUmbracoSettingsOrDefault(IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement> block, string propertyName, string defaultValue)
         {
-            var value = block.Settings.Value<string>(propertyName);
+            var value = block.Settings?.Value<string>(propertyName);
             if (!string.IsNullOrEmpty(value))
             {
                 return value;

--- a/GovUk.Frontend.Umbraco/Validation/DependentFieldsActionFilter.cs
+++ b/GovUk.Frontend.Umbraco/Validation/DependentFieldsActionFilter.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using Umbraco.Cms.Core.Web;
@@ -66,7 +62,7 @@ namespace GovUk.Frontend.Umbraco.Validation
             foreach (var parentBlock in parentBlocks)
             {
                 // If the parent component (eg 'Radios') is not bound to a property, it's not ready for validation.
-                var parentBoundProperty = parentBlock.Settings.Value<string>(PropertyAliases.ModelProperty);
+                var parentBoundProperty = parentBlock.Settings?.Value<string>(PropertyAliases.ModelProperty);
                 if (string.IsNullOrEmpty(parentBoundProperty) || !modelState.ContainsKey(parentBoundProperty)) { continue; }
 
                 // Establish whether the parent component (eg 'Radios') is valid.
@@ -93,7 +89,7 @@ namespace GovUk.Frontend.Umbraco.Validation
                         {
                             foreach (var conditionalBlock in conditionalBlocks)
                             {
-                                var blockBoundProperty = conditionalBlock.Settings.Value<string>(PropertyAliases.ModelProperty);
+                                var blockBoundProperty = conditionalBlock.Settings?.Value<string>(PropertyAliases.ModelProperty);
                                 if (!string.IsNullOrEmpty(blockBoundProperty) && modelState.ContainsKey(blockBoundProperty))
                                 {
                                     modelState[blockBoundProperty]!.ValidationState = ModelValidationState.Skipped;

--- a/GovUk.Frontend.Umbraco/Validation/UmbracoBlockValidationMetadataProvider.cs
+++ b/GovUk.Frontend.Umbraco/Validation/UmbracoBlockValidationMetadataProvider.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -86,7 +83,7 @@ namespace GovUk.Frontend.Umbraco.Validation
                 }
                 else
                 {
-                    customError = block.Settings.GetProperty(errorMessagePropertyAlias)?.GetValue()?.ToString();
+                    customError = block.Settings?.GetProperty(errorMessagePropertyAlias)?.GetValue()?.ToString();
                 }
                 if (!string.IsNullOrEmpty(customError))
                 {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkAccordion.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkAccordion.cshtml
@@ -28,7 +28,7 @@
             RenderWidthContainer = false        
         };
 
-        <govuk-accordion-item class="@(section.Settings.Value<string>(PropertyAliases.CssClasses))" expanded="@(section.Settings.Value<bool>(PropertyAliases.AccordionSectionExpanded))">
+        <govuk-accordion-item class="@(section.Settings?.Value<string>(PropertyAliases.CssClasses))" expanded="@(section.Settings?.Value<bool>(PropertyAliases.AccordionSectionExpanded) ?? false)">
             <govuk-accordion-item-heading>@(section.Content.Value<string>(PropertyAliases.AccordionSectionHeading))</govuk-accordion-item-heading>
             @if (!string.IsNullOrWhiteSpace(section.Content.Value<string>(PropertyAliases.AccordionSectionSummary)))
             {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkButton.cshtml
@@ -9,21 +9,21 @@
 @using Umbraco.Extensions
 @{
     var text = Model.Content.Value<string>(PropertyAliases.ButtonText);
-    var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var cssClasses = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
-    var buttonType = Model.Settings.Value<string>(PropertyAliases.ButtonType) == "Secondary" ? "button" : "submit";
-    var buttonStyle = Model.Settings.Value<string[]>(PropertyAliases.ButtonStyle) ?? Array.Empty<string>();
+    var buttonType = Model.Settings?.Value<string>(PropertyAliases.ButtonType) == "Secondary" ? "button" : "submit";
+    var buttonStyle = Model.Settings?.Value<string[]>(PropertyAliases.ButtonStyle) ?? Array.Empty<string>();
     if (buttonStyle.Contains("Secondary")) { buttonStyle[buttonStyle.IndexOf("Secondary")] = "govuk-button--secondary"; }
     if (buttonStyle.Contains("Warning")) { buttonStyle[buttonStyle.IndexOf("Warning")] = "govuk-button--warning"; }
     if (buttonStyle.Contains("Reversed")) { buttonStyle[buttonStyle.IndexOf("Reversed")] = "govuk-button--inverse"; }
     if (buttonStyle.Length > 0 && !string.IsNullOrEmpty(cssClasses)) { cssClasses = " " + cssClasses; }
-    var disabled = Model.Settings.Value<bool>(PropertyAliases.ButtonDisabled).ToString().ToLower();
-    var preventDoubleClick = Model.Settings.Value<bool>(PropertyAliases.ButtonPreventDoubleClick).ToString().ToLower();
+    var disabled = (Model.Settings?.Value<bool>(PropertyAliases.ButtonDisabled) ?? false).ToString().ToLower();
+    var preventDoubleClick = (Model.Settings?.Value<bool>(PropertyAliases.ButtonPreventDoubleClick) ?? false).ToString().ToLower();
 
     <govuk-button class="@string.Join(' ', buttonStyle)@cssClasses" type="@buttonType" name="@modelPropertyName" id="@Model.Content.Key" value="@text" aria-disabled="@disabled" data-prevent-double-click="@preventDoubleClick">@text</govuk-button>
 }

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkCheckbox.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkCheckbox.cshtml
@@ -13,20 +13,20 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
-    var cssClass = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var cssClass = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
     var value = Model.Content.Value<string>(PropertyAliases.CheckboxValue);
     var checkboxHint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
     var conditional = Model.Content.Value<OverridableBlockListModel>(PropertyAliases.CheckboxConditionalBlocks)!;
     var invalid = (modelStateEntry is not null && modelStateEntry.ValidationState == ModelValidationState.Invalid && modelStateEntry.Errors.Any()).ToString().ToLowerInvariant();
 }
 
-<govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+<govuk-client-side-validation error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-checkboxes name="@modelPropertyName" class="@cssClass">
         @if (modelStateEntry != null && modelStateEntry.Errors.Any(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR))
         {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkCheckboxes.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkCheckboxes.cshtml
@@ -16,16 +16,16 @@
 @using Umbraco.Extensions
 @{
     var checkboxes = Model.Content.Value<OverridableBlockListModel>(PropertyAliases.Checkboxes)!;
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
-    var cssClasses = (" " + Model.Settings.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
+    var cssClasses = (" " + Model.Settings?.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
     var fieldsetHint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
     var fieldsetDescribedBy = string.IsNullOrWhiteSpace(fieldsetHint?.ToHtmlString()) ? null : modelPropertyName + "-hint";
-    var legendIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading);
+    var legendIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading) ?? false;
     var legendClass = legendIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LegendAsHeading1 : "govuk-fieldset__legend--for-field";
     var legend = Model.Content.Value<string>(PropertyAliases.Legend)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
     var selectedValues = new List<string>();
@@ -40,7 +40,7 @@
     }
 }
 <div class="@(GovUkClassNames.FormGroup)@(invalidClass)@(cssClasses)">
-    <govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+    <govuk-client-side-validation error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))">
         <govuk-fieldset described-by="@fieldsetDescribedBy" class="govuk-checkboxes__fieldset">
             <govuk-fieldset-legend is-page-heading="@legendIsPageHeading" class="@legendClass">@legend</govuk-fieldset-legend>
             @if (blocks != null && blocks.Any())
@@ -72,11 +72,11 @@
                         }
                         else
                         {
-                            if (block.Settings.Value<bool>(PropertyAliases.CheckboxesUncheckOthers))
+                            if (block.Settings?.Value<bool>(PropertyAliases.CheckboxesUncheckOthers) ?? false)
                             {
                                 var value = block.Content.Value<string>(PropertyAliases.CheckboxValue) ?? string.Empty;
                                 var checkboxHint = block.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
-                                <govuk-checkboxes-item value="@value" checked="@(selectedValues.Contains(value.ToUpperInvariant()))" class="@(block.Settings.Value<string>(PropertyAliases.CssClasses))" input-data-behaviour="exclusive" input-aria-invalid="@ariaInvalid">
+                                <govuk-checkboxes-item value="@value" checked="@(selectedValues.Contains(value.ToUpperInvariant()))" class="@(block.Settings?.Value<string>(PropertyAliases.CssClasses))" input-data-behaviour="exclusive" input-aria-invalid="@ariaInvalid">
                                     @(block.Content.Value<string>(PropertyAliases.CheckboxLabel))
                                     @{
                                         if (!string.IsNullOrWhiteSpace(checkboxHint?.ToHtmlString()))
@@ -101,7 +101,7 @@
                             {
                                 var value = block.Content.Value<string>(PropertyAliases.CheckboxValue) ?? string.Empty;
                                 var checkboxHint = block.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
-                                <govuk-checkboxes-item value="@value" checked="@(selectedValues.Contains(value.ToUpperInvariant()))" class="@(block.Settings.Value<string>(PropertyAliases.CssClasses))" input-aria-invalid="@ariaInvalid">
+                                <govuk-checkboxes-item value="@value" checked="@(selectedValues.Contains(value.ToUpperInvariant()))" class="@(block.Settings?.Value<string>(PropertyAliases.CssClasses))" input-aria-invalid="@ariaInvalid">
                                     @(block.Content.Value<string>(PropertyAliases.CheckboxLabel))
                                     @{
                                         if (!string.IsNullOrWhiteSpace(checkboxHint?.ToHtmlString()))

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkDateInput.cshtml
@@ -16,7 +16,7 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     int? attemptedDay = null, attemptedMonth = null, attemptedYear = null;
     string? errorMessage = null;
@@ -63,8 +63,8 @@
         }
     }
     var hasErrorMessage = !string.IsNullOrEmpty(errorMessage);
-    var cssClass = (" " + Model.Settings.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
-    var legendIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading);
+    var cssClass = (" " + Model.Settings?.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
+    var legendIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading) ?? false;
     var legend = Model.Content.Value<string>(PropertyAliases.Legend)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
     var legendClass = legendIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LegendAsHeading1 : "govuk-fieldset__legend--for-field";
     var hint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
@@ -78,13 +78,13 @@
     {
         fieldsetDescribedBy = $"{modelPropertyName}-blocks {fieldsetDescribedBy}".TrimEnd();
     }
-    var readOnly = Model.Settings.Value<bool>(PropertyAliases.ReadOnly);
-    var showDay = Model.Settings.Value<bool?>(PropertyAliases.DateInputShowDay) ?? true;
-    var showYear = Model.Settings.Value<bool?>(PropertyAliases.DateInputShowYear) ?? true;
+    var readOnly = Model.Settings?.Value<bool>(PropertyAliases.ReadOnly) ?? false;
+    var showDay = Model.Settings?.Value<bool?>(PropertyAliases.DateInputShowDay) ?? true;
+    var showYear = Model.Settings?.Value<bool?>(PropertyAliases.DateInputShowYear) ?? true;
 }
 <div class="@(GovUkClassNames.FormGroup)@(invalidClass)@(cssClass)">
-    <govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
-                                  error-message-range="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRange))">
+    <govuk-client-side-validation error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))"
+                                  error-message-range="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRange))">
         <govuk-fieldset described-by="@fieldsetDescribedBy" class="govuk-date-input__fieldset" role="group">
             <govuk-fieldset-legend is-page-heading="@legendIsPageHeading" class="@legendClass">@legend</govuk-fieldset-legend>
             @if (blocks != null && blocks.Any())

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkErrorMessage.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkErrorMessage.cshtml
@@ -9,9 +9,9 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    var cssClass = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var cssClass = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
     var showError = true;
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     var id = Model.Content.Key.ToString();
     if (!string.IsNullOrEmpty(modelPropertyName))

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkErrorSummary.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkErrorSummary.cshtml
@@ -11,7 +11,7 @@
     var title = Model.Content.Value<string>(PropertyAliases.ErrorSummaryTitle);
     if (string.IsNullOrWhiteSpace(title)) { title = "There is a problem"; }
     var visibleClass = ViewContext.ModelState.ErrorCount > 0 ? "govuk-!-display-block " : "govuk-!-display-none ";
-    var cssClasses = (" " + Model.Settings.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
+    var cssClasses = (" " + Model.Settings?.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
 }
 <govuk-error-summary class="@(visibleClass)@(cssClasses)">
     <govuk-error-summary-title>@title</govuk-error-summary-title>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkFieldset.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkFieldset.cshtml
@@ -23,8 +23,8 @@
             RenderWidthContainer = false
         };
     }
-    var cssClass = Model.Settings.Value<string>(PropertyAliases.CssClasses);
-    var legendIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading);
+    var cssClass = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
+    var legendIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading) ?? false;
     var legendClass = legendIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LegendAsHeading1 : "govuk-fieldset__legend--for-fieldset";
     var legend = Model.Content.Value<string>(PropertyAliases.Legend)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
 
@@ -33,7 +33,7 @@
     var fieldsetErrors = fieldsetErrorFinder.FindErrors(Model, ViewContext.ModelState);
     var hasFieldsetError = fieldsetErrors.Any();
     var fieldsetErrorClasses = hasFieldsetError && legendIsPageHeading ? $"{GovUkClassNames.FormGroup} {GovUkClassNames.FormGroupError}" : null;
-    var describedBy = hasFieldsetError ? string.Join(' ', fieldsetErrors.Select(x => x.Settings.Value<string>(PropertyAliases.ModelProperty)).ToArray()) : null;
+    var describedBy = hasFieldsetError ? string.Join(' ', fieldsetErrors.Select(x => x.Settings?.Value<string>(PropertyAliases.ModelProperty)).ToArray()) : null;
 
     // Add an error to ModelState so that we can communicate the presence of a fieldset error to each field within it
     if (blocks is not null && hasFieldsetError) {
@@ -46,7 +46,7 @@
                                                          x.Content.ContentType.Alias == ElementTypeAliases.TextInput || 
                                                          x.Content.ContentType.Alias == ElementTypeAliases.Textarea);
         foreach (var field in allDescendentFields) {
-            var modelPropertyName = field.Settings.Value<string>(PropertyAliases.ModelProperty);
+            var modelPropertyName = field.Settings?.Value<string>(PropertyAliases.ModelProperty);
             if (!string.IsNullOrEmpty(modelPropertyName)) {
                 ViewContext.ModelState.AddModelError(modelPropertyName, ValidationConstants.FIELDSET_ERROR);
             }

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkFileUpload.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkFileUpload.cshtml
@@ -14,24 +14,24 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
-    var cssClass = Model.Settings.Value<string>(PropertyAliases.CssClasses);
-    var labelIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.LabelIsPageHeading);
+    var cssClass = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
+    var labelIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.LabelIsPageHeading) ?? false;
     var labelClass = labelIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LabelAsHeading1 : null;
     var label = Model.Content.Value<string>(PropertyAliases.FileUploadLabel)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
     var hint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
-    var fileTypes = Model.Settings.Value<string>(PropertyAliases.FileUploadFileTypes);
-    var errorMessagePrefix = Model.Settings.Value<string>(PropertyAliases.ErrorMessagePrefix);
+    var fileTypes = Model.Settings?.Value<string>(PropertyAliases.FileUploadFileTypes);
+    var errorMessagePrefix = Model.Settings?.Value<string>(PropertyAliases.ErrorMessagePrefix);
     if (string.IsNullOrEmpty(errorMessagePrefix)) { errorMessagePrefix = "Error"; }
-    var allowMultiple = Model.Settings.Value<bool>(PropertyAliases.FileUploadAllowMultiple);
+    var allowMultiple = Model.Settings?.Value<bool>(PropertyAliases.FileUploadAllowMultiple) ?? false;
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+    error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))">
 
     <govuk-file-upload name="@modelPropertyName" class="@cssClass" input-accept="@fileTypes" javascript-enhancements="true" multiple="@allowMultiple">
         <govuk-file-upload-label is-page-heading="@labelIsPageHeading" class="@labelClass">@label</govuk-file-upload-label>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridFourEqualColumns.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridFourEqualColumns.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         @foreach (var area in Model.Areas)
         {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridFullWidth.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridFullWidth.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnFullWidth@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="Model.Areas[0]" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneHalf.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneHalf.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnHalf@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="Model.Areas[0]" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneQuarter.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneQuarter.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnOneQuarter@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="Model.Areas[0]" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneQuarterThreeQuarters.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneQuarterThreeQuarters.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Count() == 2)
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnOneQuarter@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="@(Model.Areas[0])" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneThird.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneThird.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnOneThird@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="Model.Areas[0]" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneThirdTwoThirds.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridOneThirdTwoThirds.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Count() == 2)
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnOneThird@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="@(Model.Areas[0])" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridThreeEqualColumns.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridThreeEqualColumns.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         @foreach (var area in Model.Areas)
         {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridThreeQuarters.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridThreeQuarters.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnThreeQuarters@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="Model.Areas[0]" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridThreeQuartersOneQuarter.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridThreeQuartersOneQuarter.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Count() == 2)
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnThreeQuarters@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="@(Model.Areas[0])" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridTwoEqualColumns.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridTwoEqualColumns.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         @foreach (var area in Model.Areas)
         {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridTwoThirds.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridTwoThirds.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnTwoThirds@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="Model.Areas[0]" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridTwoThirdsOneThird.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkGridTwoThirdsOneThird.cshtml
@@ -7,8 +7,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Count() == 2)
 {
-    var breakpointClass = Model.Settings.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
-    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
+    var breakpointClass = Model.Settings?.Value<string>(PropertyAliases.StackColumns) == "Mobile and tablet" ? "-from-desktop" : string.Empty;
+    var rowClasses = $"{GovUkClassNames.Row} {Model.Settings?.Value<string>(PropertyAliases.CssClassesForRow)}".TrimEnd();
     <div class="@rowClasses">
         <div class="@GovUkClassNames.Column @GovUkClassNames.ColumnTwoThirds@(breakpointClass)">
             <partial name="GOVUK/BlockGrid" model="@(Model.Areas[0])" />

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkHidden.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkHidden.cshtml
@@ -7,7 +7,7 @@
 @using ThePensionsRegulator.Umbraco.Core.Blocks
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkInsetText.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkInsetText.cshtml
@@ -8,6 +8,6 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    var cssClass = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var cssClass = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
 }
 <govuk-inset-text id="@Model.Content.Key" class="@cssClass">@(Model.Content.Value<IHtmlEncodedString>(PropertyAliases.InsetText))</govuk-inset-text>

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkLinkAsButton.cshtml
@@ -12,9 +12,9 @@
     var link = Model.Content.Value<Link>(PropertyAliases.Link);
     var openInNewTab = link?.Target?.Equals("_blank") ?? false;
 
-    var isStartButton = Model.Settings.Value<bool>(PropertyAliases.LinkAsStartButton);
-    var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
-    var buttonStyle = Model.Settings.Value<string[]>(PropertyAliases.ButtonStyle) ?? Array.Empty<string>();
+    var isStartButton = Model.Settings?.Value<bool>(PropertyAliases.LinkAsStartButton) ?? false;
+    var cssClasses = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
+    var buttonStyle = Model.Settings?.Value<string[]>(PropertyAliases.ButtonStyle) ?? Array.Empty<string>();
 
     if (buttonStyle.Contains("Secondary")) { buttonStyle[buttonStyle.IndexOf("Secondary")] = "govuk-button--secondary"; }
     if (buttonStyle.Contains("Warning")) { buttonStyle[buttonStyle.IndexOf("Warning")] = "govuk-button--warning"; }

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkNotificationBanner.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkNotificationBanner.cshtml
@@ -10,7 +10,7 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    if (!Enum.TryParse(typeof(NotificationBannerType), Model.Settings.Value<string>(PropertyAliases.NotificationBannerType), out var bannerType))
+    if (!Enum.TryParse(typeof(NotificationBannerType), Model.Settings?.Value<string>(PropertyAliases.NotificationBannerType), out var bannerType))
     {
         bannerType = NotificationBannerType.Default;
     }
@@ -25,12 +25,12 @@
             RenderWidthContainer = false
         };
     }
-    var classNames = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var classNames = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
 }
 <govuk-notification-banner type="@((NotificationBannerType)bannerType!)" class="@classNames">
-    @if (!string.IsNullOrEmpty(Model.Settings.Value<string>(PropertyAliases.NotificationBannerTitle)))
+    @if (!string.IsNullOrEmpty(Model.Settings?.Value<string>(PropertyAliases.NotificationBannerTitle)))
     {
-        <govuk-notification-banner-title>@(Model.Settings.Value<string>(PropertyAliases.NotificationBannerTitle))</govuk-notification-banner-title>
+        <govuk-notification-banner-title>@(Model.Settings?.Value<string>(PropertyAliases.NotificationBannerTitle))</govuk-notification-banner-title>
     }
     @if (string.IsNullOrWhiteSpace(text?.ToHtmlString()) && !string.IsNullOrWhiteSpace(heading?.ToHtmlString()))
     {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkPanel.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkPanel.cshtml
@@ -8,7 +8,7 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    if (!Int32.TryParse(Model.Settings.Value<string>(PropertyAliases.HeadingLevel)?.Replace("Heading ", string.Empty), out var headingLevel))
+    if (!Int32.TryParse(Model.Settings?.Value<string>(PropertyAliases.HeadingLevel)?.Replace("Heading ", string.Empty), out var headingLevel))
     {
         headingLevel = 1;
     }

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkRadios.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkRadios.cshtml
@@ -16,18 +16,18 @@
 @using Umbraco.Extensions
 @{
     var radioButtons = Model.Content.Value<OverridableBlockListModel>(PropertyAliases.RadioButtons)!;
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
     var attemptedValue = modelStateEntry?.AttemptedValue?.ToUpperInvariant();
-    var cssClasses = (" " + Model.Settings.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
-    var cssClassesForRadios = (Model.Settings.Value<string>(PropertyAliases.RadiosLayout) == "Horizontal") ? "govuk-radios--inline" : null;
+    var cssClasses = (" " + Model.Settings?.Value<string>(PropertyAliases.CssClasses)).TrimEnd();
+    var cssClassesForRadios = (Model.Settings?.Value<string>(PropertyAliases.RadiosLayout) == "Horizontal") ? "govuk-radios--inline" : null;
     var fieldsetHint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
     var fieldsetDescribedBy = string.IsNullOrWhiteSpace(fieldsetHint?.ToHtmlString()) ? null : modelPropertyName + "-hint";
-    var legendIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading);
+    var legendIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.FieldsetLegendIsPageHeading) ?? false;
     var legendClass = legendIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LegendAsHeading1 : "govuk-fieldset__legend--for-field";
     var legend = Model.Content.Value<string>(PropertyAliases.Legend)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
     var isInvalid = (modelStateEntry is not null && modelStateEntry.ValidationState == ModelValidationState.Invalid && modelStateEntry.Errors.Any());
@@ -41,7 +41,7 @@
 
 }
 <div class="@(GovUkClassNames.FormGroup)@(invalidClass)@(cssClasses)">
-    <govuk-client-side-validation error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+    <govuk-client-side-validation error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))">
         <govuk-fieldset described-by="@fieldsetDescribedBy" class="govuk-radios__fieldset">
             <govuk-fieldset-legend is-page-heading="@legendIsPageHeading" class="@legendClass">@legend</govuk-fieldset-legend>
             @if (blocks != null && blocks.Any())
@@ -76,7 +76,7 @@
                         var radioHint = block.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
                         var conditional = block.Content.Value<OverridableBlockListModel>(PropertyAliases.RadioConditionalBlocks)!;
 
-                        <govuk-radios-item value="@value" class="@(block.Settings.Value<string>(PropertyAliases.CssClasses))" checked="@(value.ToUpperInvariant() == attemptedValue)" input-aria-invalid="@ariaInvalid">
+                        <govuk-radios-item value="@value" class="@(block.Settings?.Value<string>(PropertyAliases.CssClasses))" checked="@(value.ToUpperInvariant() == attemptedValue)" input-aria-invalid="@ariaInvalid">
                             @(block.Content.Value<string>(PropertyAliases.RadioButtonLabel))
                             @if (!string.IsNullOrWhiteSpace(radioHint?.ToHtmlString()))
                             {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSelect.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSelect.cshtml
@@ -16,16 +16,16 @@
 @{
     var options = Model.Content.Value<OverridableBlockListModel>(PropertyAliases.SelectOptions)!;
 
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
-    var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var cssClasses = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
     var attemptedValue = modelStateEntry?.AttemptedValue?.ToUpperInvariant();
     var label = Model.Content.Value<string>(PropertyAliases.SelectLabel)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
-    var labelIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.LabelIsPageHeading);
+    var labelIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.LabelIsPageHeading) ?? false;
     var labelClass = labelIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LabelAsHeading1 : null;
     var hint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
     var hasHint = !string.IsNullOrWhiteSpace(hint?.ToHtmlString());
@@ -34,7 +34,7 @@
     var errorMessage = hasErrorMessage ? string.Join(". ", modelStateEntry!.Errors.Where(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR).Select(x => x.ErrorMessage)) : null;
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))">
+    error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))">
     <govuk-select name="@modelPropertyName" class="@cssClasses" select-aria-invalid="@invalid">
         <govuk-select-label is-page-heading="@labelIsPageHeading" class="@labelClass">@label</govuk-select-label>
         @if (hasHint)

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryCard.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryCard.cshtml
@@ -46,7 +46,7 @@
     <govuk-summary-list>
         @foreach (var listItem in listItems.FilteredBlocks())
         {
-            <govuk-summary-list-row class="@(listItem.Settings.Value<string>(PropertyAliases.CssClasses))">
+            <govuk-summary-list-row class="@(listItem.Settings?.Value<string>(PropertyAliases.CssClasses))">
                 <govuk-summary-list-row-key>@(listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey))</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@(listItem.Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue))</govuk-summary-list-row-value>
                 @{

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryList.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkSummaryList.cshtml
@@ -15,7 +15,7 @@
 <govuk-summary-list id="@Model.Content.Key" class="@cssClasses">
     @foreach (var listItem in listItems.FilteredBlocks())
     {
-        <govuk-summary-list-row class="@(listItem.Settings.Value<string>(PropertyAliases.CssClasses))">
+        <govuk-summary-list-row class="@(listItem.Settings?.Value<string>(PropertyAliases.CssClasses))">
             <govuk-summary-list-row-key>@(listItem.Content.Value<string>(PropertyAliases.SummaryListItemKey))</govuk-summary-list-row-key>
             <govuk-summary-list-row-value>@(listItem.Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue))</govuk-summary-list-row-value>
             @{

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTaskList.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTaskList.cshtml
@@ -24,9 +24,9 @@
         {
             var hint = task.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
             var link = task.Content.Value<Link>(PropertyAliases.TaskListTaskLink)?.Url;
-            var statusText = task.Settings.Value<string>(PropertyAliases.TaskListTaskStatusText);
-            var status = task.Settings.Value<string>(PropertyAliases.TaskListTaskStatus)?.Replace(" ", string.Empty);
-            <govuk-task-list-task href="@link" class="@(task.Settings.Value<string>(PropertyAliases.CssClasses))">
+            var statusText = task.Settings?.Value<string>(PropertyAliases.TaskListTaskStatusText);
+            var status = task.Settings?.Value<string>(PropertyAliases.TaskListTaskStatus)?.Replace(" ", string.Empty);
+            <govuk-task-list-task href="@link" class="@(task.Settings?.Value<string>(PropertyAliases.CssClasses))">
                 <govuk-task-list-task-name>@(task.Content.Value<string>(PropertyAliases.TaskListTaskName))</govuk-task-list-task-name>
                 @if (!string.IsNullOrEmpty(hint?.ToHtmlString()))
                 {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTaskListSummary.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTaskListSummary.cshtml
@@ -17,7 +17,7 @@
     var totalActionableTasks = taskStatuses.Count(x => x != TaskListTaskStatus.NotApplicable);
     var completedTasks = taskStatuses.Count(x => x == TaskListTaskStatus.Completed);
 
-    if (!Int32.TryParse(Model.Settings.Value<string>(PropertyAliases.HeadingLevel)?.Replace("Heading ", string.Empty), out var headingLevel))
+    if (!Int32.TryParse(Model.Settings?.Value<string>(PropertyAliases.HeadingLevel)?.Replace("Heading ", string.Empty), out var headingLevel))
     {
         headingLevel = 2;
     }
@@ -31,7 +31,7 @@
 
 <govuk-task-list-summary 
     id="@Model.Content.Key"
-    class="@(Model.Settings.Value<string>(PropertyAliases.CssClasses))"
+    class="@(Model.Settings?.Value<string>(PropertyAliases.CssClasses))"
     heading-level="@headingLevel"
     incomplete-status="@(incompleteStatus)"
     completed-status="@(completedStatus)"

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTextInput.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTextInput.cshtml
@@ -13,21 +13,21 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     var elementName = modelPropertyName;
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
-    var prefix = Model.Settings.Value<string>(PropertyAliases.TextInputPrefix);
-    var suffix = Model.Settings.Value<string>(PropertyAliases.TextInputSuffix);
+    var prefix = Model.Settings?.Value<string>(PropertyAliases.TextInputPrefix);
+    var suffix = Model.Settings?.Value<string>(PropertyAliases.TextInputSuffix);
     var label = Model.Content.Value<string>(PropertyAliases.TextInputLabel)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
-    var labelIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.LabelIsPageHeading);
+    var labelIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.LabelIsPageHeading) ?? false;
     var labelClass = labelIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LabelAsHeading1 : null;
-    var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var cssClasses = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
     string? inputClass = null;
-    var inputWidth = Model.Settings.Value<string>(PropertyAliases.TextInputWidth);
+    var inputWidth = Model.Settings?.Value<string>(PropertyAliases.TextInputWidth);
     if (!string.IsNullOrEmpty(inputWidth))
     {
         switch (inputWidth)
@@ -56,7 +56,7 @@
         }
     }
 
-    var extraLetterSpacing = Model.Settings.Value<bool>(PropertyAliases.ExtraLetterSpacing);
+    var extraLetterSpacing = Model.Settings?.Value<bool>(PropertyAliases.ExtraLetterSpacing) ?? false;
     if (extraLetterSpacing)
     {
         inputClass = (inputClass + " govuk-input--extra-letter-spacing").TrimStart();
@@ -66,20 +66,20 @@
     var invalid = (modelStateEntry is not null && modelStateEntry.ValidationState == ModelValidationState.Invalid && modelStateEntry.Errors.Any()).ToString().ToLowerInvariant();
     var hasErrorMessage = (modelStateEntry is not null && modelStateEntry.ValidationState == ModelValidationState.Invalid && modelStateEntry.Errors.Any(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR));
     var errorMessage = hasErrorMessage ? string.Join(". ", modelStateEntry!.Errors.Where(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR).Select(x => x.ErrorMessage)) : null;
-    var readOnly = Model.Settings.Value<bool>(PropertyAliases.ReadOnly);
+    var readOnly = Model.Settings?.Value<bool>(PropertyAliases.ReadOnly) ?? false;
     var hasPrefix = !string.IsNullOrEmpty(prefix);
     var hasSuffix = !string.IsNullOrEmpty(suffix);
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
-    error-message-regex="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRegex))"
-    error-message-email="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageEmail))"
-    error-message-phone="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessagePhone))"
-    error-message-length="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageLength))"
-    error-message-minlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMinLength))"
-    error-message-maxlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
-    error-message-range="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRange))"
-    error-message-compare="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageCompare))"
+    error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))"
+    error-message-regex="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRegex))"
+    error-message-email="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageEmail))"
+    error-message-phone="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessagePhone))"
+    error-message-length="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageLength))"
+    error-message-minlength="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageMinLength))"
+    error-message-maxlength="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
+    error-message-range="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRange))"
+    error-message-compare="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageCompare))"
 >
     @if (readOnly)
     {

--- a/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTextarea.cshtml
+++ b/GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkTextarea.cshtml
@@ -17,42 +17,42 @@
 @using Umbraco.Cms.Core.Strings;
 @using Umbraco.Extensions
 @{
-    var modelPropertyName = Model.Settings.Value<string>(PropertyAliases.ModelProperty);
+    var modelPropertyName = Model.Settings?.Value<string>(PropertyAliases.ModelProperty);
     ModelStateEntry? modelStateEntry = null;
     if (!string.IsNullOrEmpty(modelPropertyName))
     {
         ViewContext.ModelState.TryGetValue(modelPropertyName, out modelStateEntry);
     }
-    Int32.TryParse(Model.Settings.Value<string>(PropertyAliases.TextareaRows), out var rows);
+    Int32.TryParse(Model.Settings?.Value<string>(PropertyAliases.TextareaRows), out var rows);
     if (rows < 2) { rows = 5; }
     var label = Model.Content.Value<string>(PropertyAliases.TextareaLabel)?.Replace("{{name}}", Umbraco.AssignedContentItem.Name);
-    var labelIsPageHeading = Model.Settings.Value<bool>(PropertyAliases.LabelIsPageHeading);
+    var labelIsPageHeading = Model.Settings?.Value<bool>(PropertyAliases.LabelIsPageHeading) ?? false;
     var labelClass = labelIsPageHeading ? headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem).LabelAsHeading1 : null;
     var hint = Model.Content.Value<IHtmlEncodedString>(PropertyAliases.Hint);
     var hasHint = !string.IsNullOrWhiteSpace(hint?.ToHtmlString());
     var invalid = (modelStateEntry is not null && modelStateEntry.ValidationState == ModelValidationState.Invalid && modelStateEntry.Errors.Any()).ToString().ToLowerInvariant();
     var hasErrorMessage = (modelStateEntry is not null && modelStateEntry.ValidationState == ModelValidationState.Invalid && modelStateEntry.Errors.Any(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR));
     var errorMessage = hasErrorMessage ? string.Join(". ", modelStateEntry!.Errors.Where(x => x.ErrorMessage != ValidationConstants.FIELDSET_ERROR).Select(x => x.ErrorMessage)) : null;
-    var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
-    var readOnly = Model.Settings.Value<bool>(PropertyAliases.ReadOnly);
+    var cssClasses = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
+    var readOnly = Model.Settings?.Value<bool>(PropertyAliases.ReadOnly) ?? false;
 }
 <govuk-client-side-validation
-    error-message-required="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRequired))"
-    error-message-regex="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRegex))"
-    error-message-email="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageEmail))"
-    error-message-length="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageLength))"
-    error-message-minlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMinLength))"
-    error-message-maxlength="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
-    error-message-range="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageRange))"
-    error-message-compare="@(Model.Settings.Value<string>(PropertyAliases.ErrorMessageCompare))"
+    error-message-required="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRequired))"
+    error-message-regex="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRegex))"
+    error-message-email="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageEmail))"
+    error-message-length="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageLength))"
+    error-message-minlength="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageMinLength))"
+    error-message-maxlength="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageMaxLength))"
+    error-message-range="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageRange))"
+    error-message-compare="@(Model.Settings?.Value<string>(PropertyAliases.ErrorMessageCompare))"
 >
-    @if (Model.Settings.Value<bool>(PropertyAliases.TextareaShowCharacterCount))
+    @if (Model.Settings?.Value<bool>(PropertyAliases.TextareaShowCharacterCount) ?? false)
     {
         var modelProperty = !string.IsNullOrEmpty(modelPropertyName) ? propertyResolver.ResolveModelProperty(propertyResolver.ResolveModelType(ViewContext), modelPropertyName) : null;
         var maxLengthAttr = modelProperty?.GetCustomAttributes<MaxLengthAttribute>().FirstOrDefault();
         var stringLengthAttr = modelProperty?.GetCustomAttributes<StringLengthAttribute>().FirstOrDefault();
         int? maxLength = maxLengthAttr != null ? maxLengthAttr.Length : stringLengthAttr != null ? stringLengthAttr.MaximumLength : null;
-        var threshold = Model.Settings.Value<int?>(PropertyAliases.TextareaCharacterCountThreshold);
+        var threshold = Model.Settings?.Value<int?>(PropertyAliases.TextareaCharacterCountThreshold);
         <govuk-character-count name="@modelPropertyName" form-group-class="@cssClasses" rows="@rows" max-length="@maxLength" threshold="@threshold" textarea-aria-invalid="@invalid">
             <govuk-character-count-label is-page-heading="@labelIsPageHeading" class="@labelClass">@label</govuk-character-count-label>
             @if (hasHint)

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprDividerViewInterceptorTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprDividerViewInterceptorTests.cs
@@ -101,7 +101,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             var dividerClass = isFieldset ? TprClassNames.DividerForFieldsetWithLegendAsPageHeading : TprClassNames.DividerForFormComponentWithLabelAsPageHeading;
 
             var blockViewModel = CreateBlockView(contentAlias, settingsAlias, classWasAlreadyPresent, classWasAlreadyPresent ? dividerClass : null);
-            Mock.Get(blockViewModel.CurrentBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, legendIsPageHeading);
+            Mock.Get(blockViewModel.CurrentBlock.Settings!).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, legendIsPageHeading);
 
             var interceptor = new TprDividerViewInterceptor();
 
@@ -150,7 +150,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             blockViewModel.PreviousBlock = CreateBlock(contentAlias, settingsAlias);
             if (isPageHeadingProperty is not null)
             {
-                Mock.Get(blockViewModel.PreviousBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
+                Mock.Get(blockViewModel.PreviousBlock.Settings!).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
             }
 
             var interceptor = new TprDividerViewInterceptor();
@@ -189,7 +189,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             blockViewModel.NextBlock = CreateBlock(contentAlias, settingsAlias);
             if (isPageHeadingProperty is not null)
             {
-                Mock.Get(blockViewModel.NextBlock.Settings).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
+                Mock.Get(blockViewModel.NextBlock.Settings!).SetupUmbracoBooleanPropertyValue(isPageHeadingProperty, true);
             }
 
             var interceptor = new TprDividerViewInterceptor();

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprGlobalNavigationTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprGlobalNavigationTests.cs
@@ -48,13 +48,13 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
                 Assert.Equal(2, result.Count);
                 Assert.Equal("Test", result[0].LinkText);
                 Assert.Equal("/test", result[0].LinkUrl);
-                
+
                 Assert.Equal(2, result[0]?.HeaderMenuChildItems?.Count);
                 Assert.Equal("ChildTest", childItems?[0].LinkText);
                 Assert.Equal("/childTest", childItems?[0]?.LinkUrl);
                 Assert.Equal("ChildTest1", childItems?[1]?.LinkText);
                 Assert.Equal("/childTest1", childItems?[1]?.LinkUrl);
-              
+
                 Assert.Equal("Test1", result[1].LinkText);
                 Assert.Equal("/test1", result[1].LinkUrl);
                 Assert.Equal(0, result[1]?.HeaderMenuChildItems?.Count);
@@ -65,7 +65,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         public void GetMenuItems_WhenSettingsNodeIsNull_ReturnsEmptyList()
         {
             //Act
-            var result = _sut.GetMenuItems(null, _menuViewModel);
+            var result = _sut.GetMenuItems(null!, _menuViewModel);
 
             //Arrange
             Assert.Empty(result);
@@ -75,7 +75,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         public void GetMenuItems_WhenHeaderMenuBlockListAliasIsNull_ReturnsEmptyList()
         {
             //Act
-            var result = _sut.GetMenuItems(_settingsNode.Object, null);
+            var result = _sut.GetMenuItems(_settingsNode.Object, null!);
 
             //Arrange
             Assert.Empty(result);

--- a/ThePensionsRegulator.Frontend.Umbraco/Services/TprBoxViewInterceptor.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Services/TprBoxViewInterceptor.cs
@@ -43,7 +43,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Services
         private static bool BlockIsFullWidthBox(IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement> block)
         {
             return block.Content.ContentType.Alias == TprElementTypeAliases.Box &&
-                   block.Settings.Value<string>(TprPropertyAliases.BoxStyle) == TprBoxStyles.FullWidth;
+                   block.Settings?.Value<string>(TprPropertyAliases.BoxStyle) == TprBoxStyles.FullWidth;
         }
     }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco/Services/TprDividerViewInterceptor.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Services/TprDividerViewInterceptor.cs
@@ -1,6 +1,4 @@
 ﻿using GovUk.Frontend.Umbraco.Blocks;
-using System.Collections.Generic;
-using System.Linq;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using GovUkElementTypeAliases = GovUk.Frontend.Umbraco.ElementTypeAliases;
@@ -8,65 +6,65 @@ using GovUkPropertyAliases = GovUk.Frontend.Umbraco.PropertyAliases;
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Services
 {
-	/// <summary>
-	/// Adds a decorative horizontal divider after the main heading on a page.
-	/// </summary>
-	public class TprDividerViewInterceptor : IBlockViewInterceptor
-	{
-		private List<string> _fieldsetAliases = [GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.Radios];
-		private List<string> _labelAliases = [GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.Select, GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextInput];
+    /// <summary>
+    /// Adds a decorative horizontal divider after the main heading on a page.
+    /// </summary>
+    public class TprDividerViewInterceptor : IBlockViewInterceptor
+    {
+        private List<string> _fieldsetAliases = [GovUkElementTypeAliases.Checkboxes, GovUkElementTypeAliases.DateInput, GovUkElementTypeAliases.Fieldset, GovUkElementTypeAliases.Radios];
+        private List<string> _labelAliases = [GovUkElementTypeAliases.FileUpload, GovUkElementTypeAliases.Select, GovUkElementTypeAliases.Textarea, GovUkElementTypeAliases.TextInput];
 
-		/// <inheritdoc/>
-		public void InterceptBlockView(BlockViewModel blockViewModel)
-		{
-			if (IsLayoutBlock(blockViewModel.CurrentBlock)) { return; }
+        /// <inheritdoc/>
+        public void InterceptBlockView(BlockViewModel blockViewModel)
+        {
+            if (IsLayoutBlock(blockViewModel.CurrentBlock)) { return; }
 
-			var blockAlias = blockViewModel.CurrentBlock.Content.ContentType.Alias;
-			if (blockAlias == GovUkElementTypeAliases.PageHeading)
-			{
-				ApplyClassToRowAndForceRowToRender(blockViewModel, TprClassNames.Divider);
-			}
+            var blockAlias = blockViewModel.CurrentBlock.Content.ContentType.Alias;
+            if (blockAlias == GovUkElementTypeAliases.PageHeading)
+            {
+                ApplyClassToRowAndForceRowToRender(blockViewModel, TprClassNames.Divider);
+            }
 
-			if (_fieldsetAliases.Contains(blockAlias) && blockViewModel.CurrentBlock!.Settings.Value<bool>(GovUkPropertyAliases.FieldsetLegendIsPageHeading))
-			{
-				ApplyClassToRowAndForceRowToRender(blockViewModel, TprClassNames.DividerForFieldsetWithLegendAsPageHeading);
-			}
+            if (_fieldsetAliases.Contains(blockAlias) && blockViewModel.CurrentBlock!.Settings?.Value<bool>(GovUkPropertyAliases.FieldsetLegendIsPageHeading) == true)
+            {
+                ApplyClassToRowAndForceRowToRender(blockViewModel, TprClassNames.DividerForFieldsetWithLegendAsPageHeading);
+            }
 
-			if (_labelAliases.Contains(blockAlias) && blockViewModel.CurrentBlock!.Settings.Value<bool>(GovUkPropertyAliases.LabelIsPageHeading))
-			{
-				ApplyClassToRowAndForceRowToRender(blockViewModel, TprClassNames.DividerForFormComponentWithLabelAsPageHeading);
-			}
+            if (_labelAliases.Contains(blockAlias) && blockViewModel.CurrentBlock!.Settings?.Value<bool>(GovUkPropertyAliases.LabelIsPageHeading) == true)
+            {
+                ApplyClassToRowAndForceRowToRender(blockViewModel, TprClassNames.DividerForFormComponentWithLabelAsPageHeading);
+            }
 
-			if (AdjacentBlockRequiresClass(blockViewModel.PreviousBlock)) { blockViewModel.OpenGridRowAndColumn = true; }
-			if (AdjacentBlockRequiresClass(blockViewModel.NextBlock)) { blockViewModel.CloseGridRowAndColumn = true; }
-		}
+            if (AdjacentBlockRequiresClass(blockViewModel.PreviousBlock)) { blockViewModel.OpenGridRowAndColumn = true; }
+            if (AdjacentBlockRequiresClass(blockViewModel.NextBlock)) { blockViewModel.CloseGridRowAndColumn = true; }
+        }
 
-		private bool AdjacentBlockRequiresClass(IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>? adjacentBlock)
-		{
-			var aliasOfAdjacentBlock = adjacentBlock?.Content.ContentType.Alias ?? string.Empty;
-			return (aliasOfAdjacentBlock == GovUkElementTypeAliases.PageHeading
-				|| (_fieldsetAliases.Contains(aliasOfAdjacentBlock) && adjacentBlock!.Settings.Value<bool>(GovUkPropertyAliases.FieldsetLegendIsPageHeading))
-				|| (_labelAliases.Contains(aliasOfAdjacentBlock) && adjacentBlock!.Settings.Value<bool>(GovUkPropertyAliases.LabelIsPageHeading))
-				);
-		}
+        private bool AdjacentBlockRequiresClass(IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>? adjacentBlock)
+        {
+            var aliasOfAdjacentBlock = adjacentBlock?.Content.ContentType.Alias ?? string.Empty;
+            return (aliasOfAdjacentBlock == GovUkElementTypeAliases.PageHeading
+                || (_fieldsetAliases.Contains(aliasOfAdjacentBlock) && adjacentBlock!.Settings?.Value<bool>(GovUkPropertyAliases.FieldsetLegendIsPageHeading) == true)
+                || (_labelAliases.Contains(aliasOfAdjacentBlock) && adjacentBlock!.Settings?.Value<bool>(GovUkPropertyAliases.LabelIsPageHeading) == true)
+                );
+        }
 
-		/// <summary>
-		/// Layout blocks are those which take control of rendering width containers, grid rows and columns in a block grid.
-		/// </summary>
-		private static bool IsLayoutBlock(IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement> block)
-		{
-			return (block is OverridableBlockGridItem gridBlock) && gridBlock.Areas.Any();
-		}
+        /// <summary>
+        /// Layout blocks are those which take control of rendering width containers, grid rows and columns in a block grid.
+        /// </summary>
+        private static bool IsLayoutBlock(IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement> block)
+        {
+            return (block is OverridableBlockGridItem gridBlock) && gridBlock.Areas.Any();
+        }
 
-		private static void ApplyClassToRowAndForceRowToRender(BlockViewModel blockViewModel, string className)
-		{
-			var classList = blockViewModel.CurrentBlock.GridRowClassList();
-			if (!classList.Contains(className))
-			{
-				blockViewModel.RowClasses += $" {className}";
-				blockViewModel.OpenGridRowAndColumn = true;
-				blockViewModel.CloseGridRowAndColumn = true;
-			}
-		}
-	}
+        private static void ApplyClassToRowAndForceRowToRender(BlockViewModel blockViewModel, string className)
+        {
+            var classList = blockViewModel.CurrentBlock.GridRowClassList();
+            if (!classList.Contains(className))
+            {
+                blockViewModel.RowClasses += $" {className}";
+                blockViewModel.OpenGridRowAndColumn = true;
+                blockViewModel.CloseGridRowAndColumn = true;
+            }
+        }
+    }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRBox.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRBox.cshtml
@@ -11,14 +11,14 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @if (Model.Areas is not null && Model.Areas.Any())
 {
-    var styleOfBox = Model.Settings.Value<string>(TprPropertyAliases.BoxStyle);
+    var styleOfBox = Model.Settings?.Value<string>(TprPropertyAliases.BoxStyle);
     var isSolid = string.IsNullOrEmpty(styleOfBox) || styleOfBox == TprBoxStyles.Solid;
     var isFullWidth = styleOfBox == TprBoxStyles.FullWidth;
     var boxClass = (string.IsNullOrEmpty(styleOfBox) || isSolid) ? null : " tpr-box--" + styleOfBox.ToLowerInvariant();
-    var cssClasses = (" " + Model.Settings.Value<string>(GovUkPropertyAliases.CssClasses)).TrimEnd();
+    var cssClasses = (" " + Model.Settings?.Value<string>(GovUkPropertyAliases.CssClasses)).TrimEnd();
     if (isSolid || isFullWidth)
     {
-        cssClasses += Model.Settings.Value<ColorPickerValueConverter.PickedColor>(TprPropertyAliases.BoxBackgroundColour)?.Label == "Blue" ? " tpr-box--blue" : null;
+        cssClasses += Model.Settings?.Value<ColorPickerValueConverter.PickedColor>(TprPropertyAliases.BoxBackgroundColour)?.Label == "Blue" ? " tpr-box--blue" : null;
     }
     <div class="tpr-box@(boxClass)@(cssClasses)">
         @if (isFullWidth)

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRFeaturedImage.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRFeaturedImage.cshtml
@@ -28,8 +28,8 @@
             ChildColumnsDefaultToFullWidth = true,
             RenderWidthContainer = false        
         };
-        var horizontal = Model.Settings.Value<bool>(GovUkPropertyAliases.FeaturedImageHorizontalLayout);
-        var decorativeImage = Model.Settings.Value<bool>(GovUkPropertyAliases.DecorativeImage);
+        var horizontal = Model.Settings?.Value<bool>(GovUkPropertyAliases.FeaturedImageHorizontalLayout) ?? false;
+        var decorativeImage = Model.Settings?.Value<bool>(GovUkPropertyAliases.DecorativeImage) ?? false;
         <tpr-featured-image image-url="@typedMediaPickerSingle.MediaUrl()" image-alt="@altText" horizontal="@horizontal" decorative-image="@decorativeImage">
             @await Html.PartialAsync("GOVUK/BlockGrid", childBlocks)
         </tpr-featured-image>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSectionCards.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRSectionCards.cshtml
@@ -18,16 +18,16 @@
         return;
     }
 
-    var nameFieldName = Model.Settings.Value<string>(TprPropertyAliases.SectionCardNameProperty);
-    var descFieldName = Model.Settings.Value<string>(TprPropertyAliases.SectionCardDescriptionProperty);
+    var nameFieldName = Model.Settings?.Value<string>(TprPropertyAliases.SectionCardNameProperty);
+    var descFieldName = Model.Settings?.Value<string>(TprPropertyAliases.SectionCardDescriptionProperty);
     if (string.IsNullOrWhiteSpace(descFieldName))
     {
         descFieldName = TprPropertyAliases.SectionCardDescriptionPropertyDefault;
     }
 
-    var cssClasses = Model.Settings.Value<string>(GovUkPropertyAliases.CssClasses);
+    var cssClasses = Model.Settings?.Value<string>(GovUkPropertyAliases.CssClasses);
 
-    var headingClass = Model.Settings.Value<string?>(TprPropertyAliases.SectionCardsTitleHeadingClass);
+    var headingClass = Model.Settings?.Value<string?>(TprPropertyAliases.SectionCardsTitleHeadingClass);
     if (string.IsNullOrEmpty(headingClass))
     {
         headingClass = "govuk-heading-m";

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRYouTubeVideo.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRYouTubeVideo.cshtml
@@ -35,7 +35,7 @@
     }
     string id = Model.Content.Key.ToString();
     var title = Model.Content.Value<string>(TprPropertyAliases.VideoTitle);
-    var cssClasses = Model.Settings.Value<string>(PropertyAliases.CssClasses);
+    var cssClasses = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
     var transcriptLink = Model.Content.Value<Link>(TprPropertyAliases.VideoTranscriptUrl);
     var transcriptUrl = string.Empty;
     var transcriptTarget = string.Empty;
@@ -51,8 +51,8 @@
     }
     transcriptTitle = transcriptTitle.Replace("{{title}}", title);
 
-    var autoplay = Model.Settings.Value<bool>(TprPropertyAliases.VideoAutoplay);
-    bool playsInline = Model.Settings.Value<bool>(TprPropertyAliases.VideoPlaysInline)!;
+    var autoplay = Model.Settings?.Value<bool>(TprPropertyAliases.VideoAutoplay) ?? false;
+    bool playsInline = Model.Settings?.Value<bool>(TprPropertyAliases.VideoPlaysInline) ?? true;
 }
 <tpr-youtube-video
     id="@id" 

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
@@ -1,12 +1,7 @@
 using GovUk.Frontend.AspNetCore;
 using GovUk.Frontend.AspNetCore.Extensions;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using ThePensionsRegulator.Frontend.TagHelpers;
 
 namespace ThePensionsRegulator.Frontend.HtmlGeneration
 {
@@ -21,7 +16,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             IEnumerable<TprTimelineItem> items,
             bool hideTail,
             int headingLevel,
-            string ariaTitle)
+            string? ariaTitle)
         {
             Guard.ArgumentNotNull(nameof(items), items);
             Guard.ArgumentValid(nameof(items), "A Timeline must contain at least one item", items.Any());
@@ -30,12 +25,12 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             if (attributes is not null) { timelineTagBuilder.MergeAttributes(attributes); }
             timelineTagBuilder.MergeCssClass("tpr-timeline");
             var accessibleTitle = "Timeline";
-            if(!string.IsNullOrWhiteSpace(ariaTitle))
+            if (!string.IsNullOrWhiteSpace(ariaTitle))
             {
-               accessibleTitle = ariaTitle; 
+                accessibleTitle = ariaTitle;
             }
-            timelineTagBuilder.Attributes.Add("aria-label",accessibleTitle);
-            
+            timelineTagBuilder.Attributes.Add("aria-label", accessibleTitle);
+
             if (hideTail)
             {
                 timelineTagBuilder.AddCssClass("tpr-timeline--hide-tail");
@@ -49,7 +44,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 var itemBuilder = new TagBuilder(TimelineItemElement);
                 var itemContentBuilder = new TagBuilder(TimelineItemContentElement);
                 itemContentBuilder.AddCssClass("tpr-timeline__item-content");
-                
+
                 if (item.Attributes is not null) { itemBuilder.MergeAttributes(item.Attributes); }
 
                 itemBuilder.MergeCssClass("tpr-timeline__item");
@@ -57,7 +52,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 timelineTagBuilder.InnerHtml.AppendHtml(itemBuilder);
 
                 itemContentBuilder.InnerHtml.AppendHtml(BuildDateTime(item));
-                if(!string.IsNullOrWhiteSpace(item.Heading))
+                if (!string.IsNullOrWhiteSpace(item.Heading))
                 {
                     itemContentBuilder.InnerHtml.AppendHtml(BuildHeading(item, headingLevel));
                 }

--- a/ThePensionsRegulator.Frontend/ITprHtmlGenerator.cs
+++ b/ThePensionsRegulator.Frontend/ITprHtmlGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using System.Collections.Generic;
 using ThePensionsRegulator.Frontend.HtmlGeneration;
 
 namespace ThePensionsRegulator.Frontend
@@ -18,7 +17,7 @@ namespace ThePensionsRegulator.Frontend
         TagBuilder GenerateTprSectionCards(TprSectionCards tprSectionCards);
         TagBuilder GenerateTprAblePlayer(TprYouTubeVideo video);
         TagBuilder GenerateTprYouTubeNoCookiesEmbeddedPlayer(TprYouTubeVideo video);
-        TagBuilder GenerateTprTimeline(AttributeDictionary? attributes, IEnumerable<TprTimelineItem> items, bool hideTail, int headingLevel, string ariaTitle);
+        TagBuilder GenerateTprTimeline(AttributeDictionary? attributes, IEnumerable<TprTimelineItem> items, bool hideTail, int headingLevel, string? ariaTitle);
         TagBuilder GenerateTprSearchResults(string popularContentUrl, string searchContentUrl, string contentByIdUrl);
         TagBuilder GenerateTprSearchResultsFooterLinks(TprSearchFooterLinks tprSearchFooterLinks);
         TagBuilder GenerateTprSearchResultsInput(int headingLevel, string headingClass, string? label = null);

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprTimelineContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprTimelineContext.cs
@@ -1,64 +1,18 @@
-﻿using GovUk.Frontend.AspNetCore.Extensions.TagHelpers;
+﻿using GovUk.Frontend.AspNetCore;
 using GovUk.Frontend.AspNetCore.Extensions;
-using GovUk.Frontend.AspNetCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using ThePensionsRegulator.Frontend.HtmlGeneration;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
 {
     public class TprTimelineContext
     {
-        private readonly List<TprTimelineItem> _items;
-
-        private int _headingLevel;
-        // private string _dateSize;
-        private bool _hideTail;
-        private string? _ariaTitle;
+        private readonly List<TprTimelineItem> _items = [];
 
         public IReadOnlyList<TprTimelineItem> Tasks => _items;
 
-        public int HeadingLevel
-        {
-            get
-            {
-                return _headingLevel;
-            }
-            set
-            {
-                _headingLevel = value;
-            }
-        }        
-        public bool HideTail
-        {
-            get
-            {
-                return _hideTail;
-            }
-            set
-            {
-                _hideTail = value;
-            }
-        }
-
-        public string AriaTitle
-        {
-            get
-            {
-                return _ariaTitle;
-            }
-            set
-            {
-                _ariaTitle = value;
-            }
-        }
-        public TprTimelineContext()
-        {
-            _items = new List<TprTimelineItem>();
-        }
+        public int HeadingLevel { get; set; }
+        public bool HideTail { get; set; }
+        public string? AriaTitle { get; set; }
 
         public void AddItem(TprTimelineItem item)
         {

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprTimelineItemContentTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprTimelineItemContentTagHelper.cs
@@ -2,7 +2,6 @@
 using GovUk.Frontend.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using System.Threading.Tasks;
 using ComponentGenerator = ThePensionsRegulator.Frontend.HtmlGeneration.ComponentGenerator;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
@@ -25,10 +24,10 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                 if (!string.IsNullOrEmpty(content))
                 {
                     htmlContent = new HtmlString(content);
+                    taskContext.HtmlContent = htmlContent;
                 }
             }
 
-            taskContext.HtmlContent = htmlContent;
             output.SuppressOutput();
         }
 

--- a/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockListModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockListModelTests.cs
@@ -215,7 +215,7 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.Blocks
 
             // Assert
             Assert.Equal(1, ((OverridablePublishedElement)blockList[0].Content).PropertyValueFormatters?.Count());
-            Assert.Equal(1, ((OverridablePublishedElement)blockList[0].Settings).PropertyValueFormatters?.Count());
+            Assert.Equal(1, ((OverridablePublishedElement?)blockList[0].Settings)?.PropertyValueFormatters?.Count());
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.Blocks
                     .Object)
                 );
             replacementChildBlock.Content.OverrideValue(CONTENT_PROPERTY_ALIAS_TO_OVERRIDE, CONTENT_PROPERTY_VALUE);
-            replacementChildBlock.Settings.OverrideValue(SETTINGS_PROPERTY_ALIAS_TO_OVERRIDE, SETTINGS_PROPERTY_VALUE);
+            replacementChildBlock.Settings?.OverrideValue(SETTINGS_PROPERTY_ALIAS_TO_OVERRIDE, SETTINGS_PROPERTY_VALUE);
 
             var replacementChildBlockList = new OverridableBlockListModel(new[] { replacementChildBlock });
             parentBlockList[0].Content.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, replacementChildBlockList);

--- a/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockModelExtensionsTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockModelExtensionsTests.cs
@@ -2,7 +2,6 @@
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
 using ThePensionsRegulator.Umbraco.Testing;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -360,18 +359,14 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.Blocks
             matchingBlockContent1.Setup(x => x.GetProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS)).Returns(UmbracoPropertyFactory.CreateTextboxProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS, "contentTypeAlias", "value"));
 
             var matchingBlock1 = new OverridableBlockListItem(
-#nullable disable            
-                new BlockListItem(Udi.Create(Constants.UdiEntityType.Element, Guid.NewGuid()), matchingBlockContent1.Object, null, null),
-#nullable enable
+                new BlockListItem(Guid.NewGuid(), matchingBlockContent1.Object, null, null),
                             OverridableBlockListItem.NoopPublishedElementFactory
                         );
             var matchingBlockContent2 = new Mock<IOverridablePublishedElement>();
             matchingBlockContent1.Setup(x => x.GetProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS)).Returns(UmbracoPropertyFactory.CreateTextboxProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS, "contentTypeAlias", "value"));
 
             var matchingBlock2 = new OverridableBlockListItem(
-#nullable disable            
-                        new BlockListItem(Udi.Create(Constants.UdiEntityType.Element, Guid.NewGuid()), matchingBlockContent1.Object, null, null),
-#nullable enable
+                        new BlockListItem(Guid.NewGuid(), matchingBlockContent1.Object, null, null),
                         OverridableBlockListItem.NoopPublishedElementFactory
                     );
             var grandChildBlockList = new OverridableBlockListModel(new[] { matchingBlock1, matchingBlock2 }, null, OverridableBlockListItem.NoopPublishedElementFactory);

--- a/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverterTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverterTests.cs
@@ -4,18 +4,13 @@ using Moq;
 using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
 using ThePensionsRegulator.Umbraco.Core.PropertyEditors.ValueConverters;
 using ThePensionsRegulator.Umbraco.Testing;
-using Umbraco.Cms.Core.Blocks;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
-using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Templates;
 
@@ -30,7 +25,7 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.PropertyEditors.ValueConverter
             // Arrange
             var testContext = new UmbracoTestContext();
             var propertyType = UmbracoPropertyFactory.CreateRichTextProperty("myAlias", "contentTypeAlias", new HtmlEncodedString(string.Empty)).PropertyType;
-            var urlProvider = Mock.Of<IPublishedUrlProvider>();
+            var urlProvider = testContext.PublishedUrlProvider.Object;
 
             const string INITIAL_VALUE = "<p>Some html</p>";
             const string EXPECTED_VALUE = "<p>Expected</p>";
@@ -49,13 +44,13 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.PropertyEditors.ValueConverter
                 new HtmlUrlParser(contentSettings.Object, Mock.Of<ILogger<HtmlUrlParser>>(), Mock.Of<IProfilingLogger>(), Mock.Of<IIOHelper>()),
                 new HtmlImageSourceParser(urlProvider),
                 new List<IPropertyValueFormatter> { formatter.Object },
-                Mock.Of<IApiRichTextElementParser>(),
-                Mock.Of<IApiRichTextMarkupParser>(),
-                Mock.Of<IPartialViewBlockEngine>(),
-                new BlockEditorConverter(testContext.PublishedContentTypeCache.Object, Mock.Of<ICacheManager>(), testContext.PublishedModelFactory.Object, testContext.VariationContextAccessor.Object, blockEditorVarianceHandler), // TODO : Add types to UmbracoTestContext 
-                Mock.Of<IJsonSerializer>(),
-                Mock.Of<IApiElementBuilder>(),
-                Mock.Of<RichTextBlockPropertyValueConstructorCache>(),
+                testContext.ApiRichTextElementParser.Object,
+                testContext.ApiRichTextMarkupParser.Object,
+                testContext.PartialViewBlockEngine.Object,
+                new BlockEditorConverter(testContext.PublishedContentTypeCache.Object, testContext.CacheManager.Object, testContext.PublishedModelFactory.Object, testContext.VariationContextAccessor.Object, blockEditorVarianceHandler),
+                testContext.JsonSerializer,
+                testContext.ApiElementBuilder.Object,
+                testContext.RichTextBlockPropertyValueConstructorCache.Object,
                 Mock.Of<ILogger<RteBlockRenderingValueConverter>>(),
                 blockEditorVarianceHandler,
                 testContext.VariationContextAccessor.Object,

--- a/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockGridItem.cs
+++ b/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockGridItem.cs
@@ -28,7 +28,7 @@ namespace ThePensionsRegulator.Umbraco.Core.Blocks
         public new IOverridablePublishedElement Content { get => (IOverridablePublishedElement)base.Content; }
 
         /// <inheritdoc/>
-        public new IOverridablePublishedElement Settings { get => (IOverridablePublishedElement)base.Settings; }
+        public new IOverridablePublishedElement? Settings { get => (IOverridablePublishedElement?)base.Settings; }
 
         /// <inheritdoc/>
         public new IList<OverridableBlockGridArea> Areas

--- a/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockListItem.cs
+++ b/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockListItem.cs
@@ -20,6 +20,6 @@ namespace ThePensionsRegulator.Umbraco.Core.Blocks
 
         public new IOverridablePublishedElement Content { get => (IOverridablePublishedElement)base.Content; }
 
-        public new IOverridablePublishedElement Settings { get => (IOverridablePublishedElement)base.Settings; }
+        public new IOverridablePublishedElement? Settings { get => (IOverridablePublishedElement?)base.Settings; }
     }
 }

--- a/ThePensionsRegulator.Umbraco.Testing/LocalizationServiceExtensions.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/LocalizationServiceExtensions.cs
@@ -6,7 +6,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
 {
     public static class LocalizationServiceExtensions
     {
-        public static Mock<ILocalizationService> SetupUmbracoDictionaryItem(this Mock<ILocalizationService> localizationService, string key, string value, string languageIsoCode)
+        public static Mock<IDictionaryItemService> SetupUmbracoDictionaryItem(this Mock<IDictionaryItemService> dictionaryItemService, string key, string value, string languageIsoCode)
         {
             var dictionaryTranslation = new Mock<IDictionaryTranslation>();
             dictionaryTranslation
@@ -20,18 +20,19 @@ namespace ThePensionsRegulator.Umbraco.Testing
             var dictionaryItem = new Mock<IDictionaryItem>();
             dictionaryItem
                 .Setup(x => x.Translations)
-                .Returns(new[] { dictionaryTranslation.Object });
+                .Returns([dictionaryTranslation.Object]);
 
-            localizationService
-               .Setup(x => x.GetDictionaryItemByKey(key))
-               .Returns(dictionaryItem.Object);
 
-            return localizationService;
+            dictionaryItemService
+               .Setup(x => x.GetAsync(key))
+               .ReturnsAsync(dictionaryItem.Object);
+
+            return dictionaryItemService;
         }
 
-        public static Mock<ILocalizationService> SetupUmbracoDictionaryItem(this ILocalizationService localizationService, string key, string value, string languageIsoCode)
+        public static Mock<IDictionaryItemService> SetupUmbracoDictionaryItem(this IDictionaryItemService dictionaryItemService, string key, string value, string languageIsoCode)
         {
-            return Mock.Get(localizationService).SetupUmbracoDictionaryItem(key, value, languageIsoCode);
+            return Mock.Get(dictionaryItemService).SetupUmbracoDictionaryItem(key, value, languageIsoCode);
         }
     }
 }

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoPropertyFactory.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoPropertyFactory.cs
@@ -65,7 +65,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
             contentType.Setup(x => x.CompositionAliases).Returns(compositionAliases is not null ? [.. compositionAliases] : []);
 
             var contentTypeFactory = new Mock<IPublishedContentTypeFactory>();
-            contentTypeFactory.Setup(x => x.GetDataType(dataTypeId)).Returns(new PublishedDataType(dataTypeId, propertyEditorAlias, "TODO", new Lazy<object?>(configuration)));
+            contentTypeFactory.Setup(x => x.GetDataType(dataTypeId)).Returns(new PublishedDataType(dataTypeId, propertyEditorAlias, propertyEditorAlias, new Lazy<object?>(configuration)));
             var publishedPropertyType = new PublishedPropertyType(contentType.Object, propertyType.Object, propertyValueConverters, Mock.Of<IPublishedModelFactory>(), contentTypeFactory.Object);
 
             converter.Setup(x => x.IsConverter(publishedPropertyType)).Returns(true);

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoPublishedElementExtensions.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoPublishedElementExtensions.cs
@@ -72,7 +72,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
             var overridablePublishedElement = publishedElement as Mock<IOverridablePublishedElement>;
             if (overridablePublishedElement != null)
             {
-                overridablePublishedElement.Setup(x => x.Value<string?>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value.ToString());
+                overridablePublishedElement.Setup(x => x.Value<string?>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value?.ToString());
             }
 
             return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateRichTextProperty);

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
@@ -16,17 +16,23 @@ using System.Collections.ObjectModel;
 using System.Security.Claims;
 using System.Security.Principal;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Blocks;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Templates;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Infrastructure.Serialization;
 using Umbraco.Cms.Web.Common;
 using Umbraco.Cms.Web.Common.Routing;
 using DI = Umbraco.Cms.Core.DependencyInjection;
@@ -144,6 +150,16 @@ namespace ThePensionsRegulator.Umbraco.Testing
         public Mock<IPublishedRequest> PublishedRequest { get; private init; } = new();
 
         /// <summary>
+        /// Provides access to Umbraco's caches of current published content.
+        /// </summary>
+        public Mock<ICacheManager> CacheManager { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the service used to cache blocks in rich text editors.
+        /// </summary>
+        public Mock<RichTextBlockPropertyValueConstructorCache> RichTextBlockPropertyValueConstructorCache { get; private init; } = new();
+
+        /// <summary>
         /// Provides access to Umbraco's cache of current published content.
         /// </summary>
         public Mock<IPublishedContentCache> PublishedContentCache { get; private init; } = new();
@@ -152,6 +168,25 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// Provides access to Umbraco's cache of current published media.
         /// </summary>
         public Mock<IPublishedMediaCache> PublishedMediaCache { get; private init; } = new();
+
+        /// <summary>
+        /// Provides access to Umbraco's cache of current members.
+        /// </summary>
+        public Mock<IPublishedMemberCache> PublishedMemberCache { get; private init; } = new();
+
+        /// <summary>
+        /// The elements-level cache is shared by all snapshots relying on the same elements, ie all snapshots built on top of unchanging content / media / etc.
+        /// </summary>
+        public Mock<IAppCache> ElementsCache { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the engine used to render partial views in block editors.
+        /// </summary>
+        public Mock<IPartialViewBlockEngine> PartialViewBlockEngine { get; private init; } = new();
+
+        public IJsonSerializer JsonSerializer { get; private init; }
+
+        public IJsonSerializerEncoderFactory JsonSerializerEncoderFactory { get; private init; } = new DefaultJsonSerializerEncoderFactory();
 
         private readonly Dictionary<string, Mock<IPublishedContentType>> _contentTypes = new();
 
@@ -275,6 +310,8 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <summary>
         /// Provides easy access to operations involving Languages and Dictionary.
         /// </summary>
+        /// <remarks>Obsolete service retained because <c>ServiceContext.CreatePartial()</c> expects it.</remarks>
+        [Obsolete]
         public Mock<ILocalizationService> LocalizationService { get; private init; } = new();
 
         /// <summary>
@@ -382,6 +419,20 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// </summary>
         public Mock<ITempDataDictionaryFactory> TempDataDictionaryFactory { get; private init; } = new();
 
+        /// <summary>
+        /// Gets the service used to build API elements for the Delivery API.
+        /// </summary>
+        public Mock<IApiElementBuilder> ApiElementBuilder { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the parser used to parse rich text editor elements for the Delivery API.
+        /// </summary>
+        public Mock<IApiRichTextElementParser> ApiRichTextElementParser { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the parser used to parse rich text editor markup for the Delivery API.
+        /// </summary>
+        public Mock<IApiRichTextMarkupParser> ApiRichTextMarkupParser { get; private init; } = new();
 
         // Disable 'Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.'
         // so that we can use the CurrentPrincipal setter to assign _currentPrincipal.
@@ -416,7 +467,9 @@ namespace ThePensionsRegulator.Umbraco.Testing
                 MediaTypeService.Object,
                 DataTypeService.Object,
                 FileService.Object,
+#pragma warning disable CS0612 // Type or member is obsolete
                 LocalizationService.Object,
+#pragma warning restore CS0612 
                 PackagingService.Object,
                 EntityService.Object,
                 RelationService.Object,
@@ -439,6 +492,12 @@ namespace ThePensionsRegulator.Umbraco.Testing
                 WebhookService.Object
             );
 
+            CacheManager.Setup(x => x.ElementsCache).Returns(ElementsCache.Object);
+            CacheManager.Setup(x => x.Content).Returns(PublishedContentCache.Object);
+            CacheManager.Setup(x => x.Domains).Returns(DomainCache.Object);
+            CacheManager.Setup(x => x.Media).Returns(PublishedMediaCache.Object);
+            CacheManager.Setup(x => x.Members).Returns(PublishedMemberCache.Object);
+
             CurrentIdentity.SetupGet(x => x.IsAuthenticated).Returns(false);
             CurrentPrincipal = new GenericPrincipal(CurrentIdentity.Object, Array.Empty<string>());
 
@@ -447,6 +506,8 @@ namespace ThePensionsRegulator.Umbraco.Testing
 
             CultureDictionaryFactory.Setup(x => x.CreateDictionary()).Returns(CultureDictionaryForCurrentUICulture.Object);
             CultureDictionaryFactory.Setup(x => x.CreateDictionary(Thread.CurrentThread.CurrentUICulture)).Returns(CultureDictionaryForCurrentUICulture.Object);
+
+            JsonSerializer = new SystemTextJsonSerializer(JsonSerializerEncoderFactory);
 
             VariationContextAccessor.Setup(x => x.VariationContext).Returns(VariationContext);
 
@@ -460,9 +521,12 @@ namespace ThePensionsRegulator.Umbraco.Testing
         {
             DI.StaticServiceProvider.Instance = ServiceProvider.Object;
             HttpContext.Setup(x => x.RequestServices).Returns(ServiceProvider.Object);
+            SetupService(ApiElementBuilder.Object);
+            SetupService(ApiRichTextElementParser.Object);
+            SetupService(ApiRichTextMarkupParser.Object);
             SetupService(AuditService.Object);
             SetupService(CompositeViewEngine.Object);
-            SetupService(UmbracoComponentRenderer.Object);
+            SetupService(CacheManager.Object);
             SetupService(ConsentService.Object);
             SetupService(ContentService.Object);
             SetupService(ContentTypeBaseServiceProvider.Object);
@@ -473,13 +537,18 @@ namespace ThePensionsRegulator.Umbraco.Testing
             SetupService(DocumentNavigationQueryService.Object);
             SetupService(DomainCache.Object);
             SetupService(DomainService.Object);
+            SetupService(ElementsCache.Object);
             SetupService(EntityService.Object);
             SetupService(ExternalLoginWithKeyService.Object);
             SetupService(ExamineManager.Object);
             SetupService(FileService.Object);
+            SetupService(JsonSerializer);
+            SetupService(JsonSerializerEncoderFactory);
             SetupService(KeyValueService.Object);
             SetupService(LanguageService.Object);
+#pragma warning disable CS0612 // Type or member is obsolete
             SetupService(LocalizationService.Object);
+#pragma warning restore CS0612 
             SetupService(LocalizedTextService.Object);
             SetupService(MediaService.Object);
             SetupService(MediaNavigationQueryService.Object);
@@ -489,9 +558,11 @@ namespace ThePensionsRegulator.Umbraco.Testing
             SetupService(MemberTypeService.Object);
             SetupService(NotificationService.Object);
             SetupService(PackagingService.Object);
+            SetupService(PartialViewBlockEngine.Object);
             SetupService(PublicAccessService.Object);
             SetupService(PublishedContentCache.Object);
             SetupService(PublishedMediaCache.Object);
+            SetupService(PublishedMemberCache.Object);
             SetupService(PublishedModelFactory.Object);
             SetupService(PublishedContentQuery.Object);
             SetupService(PublishedContentTypeCache.Object);
@@ -499,10 +570,12 @@ namespace ThePensionsRegulator.Umbraco.Testing
             SetupService(PublishedValueFallback.Object);
             SetupService(RedirectUrlService.Object);
             SetupService(RelationService.Object);
+            SetupService(RichTextBlockPropertyValueConstructorCache.Object);
             SetupService(ServerRegistrationService.Object);
             SetupService(SiteDomainMapper.Object);
             SetupService(TagService.Object);
             SetupService(TempDataDictionaryFactory.Object);
+            SetupService(UmbracoComponentRenderer.Object);
             SetupService(UmbracoContextAccessor.Object);
             SetupService(UmbracoHelperAccessor.Object);
             SetupService(UserService.Object);


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

This PR addresses some tech debt by resolving remaining C# build warnings and TODO comments.

It also adds some more mocks to `UmbracoTestContext` for better testing support, and uses the new mocks in an existing test.

## Out-of-scope for this PR

Everything else. 

Outside of the backoffice you can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- client-side files are minified and cached
- consuming the package works but still creates unwanted folders in some cases

Otherwise you can expect:
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Fix unwanted extra files included when referencing packages outside of the main web project
- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating other namespaces for greater clarity
- Convert all remaining NUnit tests to XUnit
