### PR TITLE
#256775 Updating heading level in accordion doesn't reduce visible font size

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.2.2</Version>
+    <Version>9.2.3</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRAccordion.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRAccordion.cshtml
@@ -1,2 +1,45 @@
-﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-<partial name="GOVUK/GovUkAccordion" />
+﻿@using GovUk.Frontend.Umbraco
+@using GovUk.Frontend.Umbraco.Blocks
+@using ThePensionsRegulator.Umbraco
+@using ThePensionsRegulator.Umbraco.Blocks
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IOverridableBlockReference<IOverridablePublishedElement,IOverridablePublishedElement>>;
+@addTagHelper *, GovUk.Frontend.AspNetCore
+
+@{
+    var cssClasses = Model.Settings?.Value<string>(PropertyAliases.CssClasses);
+    var sections = Model.Content.Value<OverridableBlockListModel>(PropertyAliases.AccordionSections)!;
+    if (!Int32.TryParse(Model.Settings?.Value<string>(PropertyAliases.HeadingLevel)?.Replace("Heading ", string.Empty), out var headingLevel))
+    {
+        headingLevel = 2;
+    }
+    var headingClass = headingLevel switch
+    {
+        1 => "govuk-heading-l",
+        2 => "govuk-heading-m",
+        3 => "govuk-heading-s",
+        4 => "govuk-heading-s",
+        _ => "govuk-heading-m"
+    };
+}
+<govuk-accordion id="@Model.Content.Key" class="@cssClasses" heading-level="@headingLevel">
+    @foreach (var section in sections.FilteredBlocks())
+    {
+        var grid = section.Content.Value<OverridableBlockGridModel>(PropertyAliases.AccordionSectionBlocks)!;
+        var childBlocks = new BlockGridViewModel(grid)
+        {
+            ChildColumnsDefaultToFullWidth = true,
+            RenderWidthContainer = false
+        };
+
+        <govuk-accordion-item class="@(section.Settings.Value<string>(PropertyAliases.CssClasses))" expanded="@(section.Settings.Value<bool>(PropertyAliases.AccordionSectionExpanded))">
+            <govuk-accordion-item-heading class="@headingClass">@(section.Content.Value<string>(PropertyAliases.AccordionSectionHeading))</govuk-accordion-item-heading>
+            @if (!string.IsNullOrWhiteSpace(section.Content.Value<string>(PropertyAliases.AccordionSectionSummary)))
+            {
+                <govuk-accordion-item-summary>@(section.Content.Value<string>(PropertyAliases.AccordionSectionSummary))</govuk-accordion-item-summary>
+            }
+            <govuk-accordion-item-content>
+                @await Html.PartialAsync("GOVUK/BlockGrid", childBlocks)
+            </govuk-accordion-item-content>
+        </govuk-accordion-item>
+    }
+</govuk-accordion>

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-accordion.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-accordion.scss
@@ -1,15 +1,7 @@
 
 @media (min-width: 40.0625em)  {
 
-    h2 .govuk-accordion__section-button {
-        font-size: 1.5rem;
-    }
-
-    h3 .govuk-accordion__section-button {
-        font-size: 1.3125rem;
-    }
-
-    h4 .govuk-accordion__section-button {
-        font-size: 1.1875rem;
+    .govuk-accordion__section-button {
+        font-size: inherit;
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-accordion.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-accordion.scss
@@ -1,0 +1,15 @@
+
+@media (min-width: 40.0625em)  {
+
+    h2 .govuk-accordion__section-button {
+        font-size: 1.5rem;
+    }
+
+    h3 .govuk-accordion__section-button {
+        font-size: 1.3125rem;
+    }
+
+    h4 .govuk-accordion__section-button {
+        font-size: 1.1875rem;
+    }
+}

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -47,6 +47,7 @@
 @import '_open-sans.scss';
 
 // Override compiled GOV.UK styles to apply differences from the TPR UI Kit
+@import '_tpr-accordion.scss';
 @import '_tpr-back.scss';
 @import '_tpr-button.scss';
 @import '_tpr-button-group.scss';


### PR DESCRIPTION
In this PR:
- Created a `_tpr-accordion.scss` file;
- Populated the `_tpr-accordion.scss` file with styles that change the font size of the heading within the accordion depending on which `<h2-4>` element is generated by the gov-uk accordion tag helper.

Before these changes were applied, the font size attribute was being overridden by the default `.govuk-accordion__section-button` class, so no matter which heading level was inputted into the tag helper, the actual font size for the heading would never change.

This is related to the work item: https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/256775