### PR TITLE
Update instructions because npm install can no longer be run from MSBuild (v13)

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions.ConformanceTests/Directory.Build.targets
+++ b/GovUk.Frontend.AspNetCore.Extensions.ConformanceTests/Directory.Build.targets
@@ -11,7 +11,6 @@
 			<Output TaskParameter="ConsoleOutput" PropertyName="CheckForNode" />
 		</Exec>
 		<Error Text="Node.js is not installed. Node.js is required to install the govuk-frontend package which contains the conformance tests. See https://nodejs.org" Condition="$(CheckForNode.Contains('Could not find files'))" />
-		<Message Text="govuk-frontend NPM package not found. Running 'npm install'. If you get an error UNABLE_TO_GET_ISSUER_CERT_LOCALLY you need to click the padlock next to any site in the address bar of your browser, and download the CA certificate for your network in .PEM format. Then set the environment variable NODE_EXTRA_CA_CERTS to the path to that certificate, and restart Visual Studio." Condition="!Exists('$(GovUkPackageFolder)')" />
-		<Exec Command="npm install" WorkingDirectory="$(MsBuildThisFileDirectory).." Condition="!Exists('$(GovUkPackageFolder)')" />
+		<Error Text="govuk-frontend NPM package not found. Run 'npm run govuk' in the root of this repo, $(SolutionDir)." Condition="!Exists('$(GovUkPackageFolder)')" />
 </Target>
 </Project>

--- a/docs/aspnet/run-example-application.md
+++ b/docs/aspnet/run-example-application.md
@@ -3,6 +3,13 @@
 This repository includes an example application which demonstrates the validation working both client-side and server-side, and localisation using resource files.
 
 1. Clone this repo
-2. Open `GovUk.Frontend.sln` in Visual Studio 2022 or better, click on the `GovUk.Frontend.ExampleApp` project, and run it.
+2. Run `npm run govuk` to install the `govuk-frontend` npm package.
+3. Open `GovUk.Frontend.sln` in Visual Studio 2022 or better, click on the `GovUk.Frontend.ExampleApp` project, and run it.
 
 By default the example application uses The Pensions Regulator (TPR) branding. To see the GOV.UK branded version set `TPRStyles: false` in `appsettings.json` and re-run the application.
+
+## Troubleshooting
+
+### UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+
+If you get an error `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` when running npm commands you need to click the padlock next to any site in the address bar of your browser, and download the CA certificate for your network in .PEM format. Then set the environment variable NODE_EXTRA_CA_CERTS to the path to that certificate, and restart Visual Studio.

--- a/docs/contributing/run-tests.md
+++ b/docs/contributing/run-tests.md
@@ -12,6 +12,7 @@ npm test
 To run unit tests on the .NET code:
 
 ```cmd
+npm run govuk
 dotnet test
 ```
 
@@ -24,3 +25,9 @@ To run unit tests on the PowerShell scripts:
 ```pwsh
 Invoke-Pester
 ```
+
+## Troubleshooting
+
+### UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+
+If you get an error `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` when running npm commands you need to click the padlock next to any site in the address bar of your browser, and download the CA certificate for your network in .PEM format. Then set the environment variable NODE_EXTRA_CA_CERTS to the path to that certificate, and restart Visual Studio.

--- a/docs/umbraco/run-example-application.md
+++ b/docs/umbraco/run-example-application.md
@@ -4,17 +4,22 @@ This repository includes an example application which demonstrates the validatio
 
 1. Ensure you have .NET 6.0.5 (SDK version 6.0.300) or better installed. Run `dotnet --list-sdks` to check.
 2. Clone this repo.
-3. Open `GovUk.Frontend.sln` in Visual Studio 2022 or better.
-4. Delete the `ConnectionStrings` section from `appsettings.json` (it will get re-generated).
-5. Click on the `GovUk.Frontend.Umbraco.ExampleApp` project, and run it.
-6. When you see the Umbraco installer enter your name, email address and a new password and click 'Install'.
-7. When you see the Umbraco login screen, enter the email address and password you just configured and click 'Login'.
-8. When you are taken to the Umbraco backoffice go to 'Settings > uSync > Everything > Import'
-9. View the example application at https://localhost:44350.
+3. Run `npm run govuk` to install the `govuk-frontend` npm package.
+4. Open `GovUk.Frontend.sln` in Visual Studio 2022 or better.
+5. Delete the `ConnectionStrings` section from `appsettings.json` (it will get re-generated).
+6. Click on the `GovUk.Frontend.Umbraco.ExampleApp` project, and run it.
+7. When you see the Umbraco installer enter your name, email address and a new password and click 'Install'.
+8. When you see the Umbraco login screen, enter the email address and password you just configured and click 'Login'.
+9. When you are taken to the Umbraco backoffice go to 'Settings > uSync > Everything > Import'
+10. View the example application at https://localhost:44350.
 
 By default the example application uses The Pensions Regulator (TPR) branding. To see the GOV.UK branded version set `TPRStyles: false` in `appsettings.json` and re-run the application.
 
 ## Troubleshooting
+
+### UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+
+If you get an error `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` when running npm commands you need to click the padlock next to any site in the address bar of your browser, and download the CA certificate for your network in .PEM format. Then set the environment variable NODE_EXTRA_CA_CERTS to the path to that certificate, and restart Visual Studio.
 
 ### Error during installation: Already initialized
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "govuk-frontend": "^5.13.0"
   },
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --ci --watchAll=false --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --ci --watchAll=false --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura",
+    "govuk": "cd GovUk.Frontend.AspNetCore.Extensions.ConformanceTests && npm install"
   }
 }


### PR DESCRIPTION
We've started getting an error on TPR machines because `npm install` is now blocked by group policy when running from MSBuild. 

This PR updates the documentation to require it to be run manually instead. This chore is somewhat simplified by adding an npm script.

Fixes  #650