### PR TITLE
Move example app connection string back to appsettings.json

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/appsettings.Development.json
+++ b/GovUk.Frontend.Umbraco.ExampleApp/appsettings.Development.json
@@ -37,9 +37,5 @@
         "Debug": true
       }
     }
-  },
-  "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   }
 }

--- a/GovUk.Frontend.Umbraco.ExampleApp/appsettings.json
+++ b/GovUk.Frontend.Umbraco.ExampleApp/appsettings.json
@@ -109,5 +109,9 @@
       "paste_webkit_styles": "all",
       "paste_remove_styles_if_webkit": false
     }
+  },
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   }
 }


### PR DESCRIPTION
When you first run the Umbraco example app you have to remove the connection string from config, then Umbraco puts it back. 

It seemed to make sense to put it in appsettings.Development.json since a SQLLite database is always for development only, but it turns out that was a bad idea as Umbraco puts it back in appsettings.json regardless.

#535