### PR TITLE
Refactor packaging of uSync files to avoid creating an unwanted uSync folder

### DIFF
--- a/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
+++ b/GovUk.Frontend.Umbraco/GovUk.Frontend.Umbraco.csproj
@@ -30,6 +30,13 @@
 
 		<!-- Dont include the Backoffice folder as part of packaging nuget build -->
 		<Content Remove="Backoffice\**" />
+		
+		<!-- Dont include the uSync folder as part of packaging nuget build. Instead pack it in a different folder. -->
+		<Content Remove="uSync\**" />
+		<None Include="uSync\**\*">
+			<PackagePath>uSync</PackagePath>
+			<Pack>true</Pack>
+		</None>
 
 		<!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
 		<None Include="Backoffice\public\umbraco-package.json" Pack="false" />

--- a/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
+++ b/GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
@@ -24,15 +24,15 @@
 		<PropertyGroup>
 			<GovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</GovUkFrontendUmbraco_UserProfile>
 			<GovUkFrontendUmbraco_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</GovUkFrontendUmbraco_UserProfile>
-			<GovUkFrontendUmbraco_ContentFilesPath>$(GovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(TprGovUkFrontendUmbracoPackageVersion)\contentFiles\any\$(TargetFramework)\</GovUkFrontendUmbraco_ContentFilesPath>
+			<GovUkFrontendUmbraco_uSyncFilesPath>$(GovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(TprGovUkFrontendUmbracoPackageVersion)\uSync\</GovUkFrontendUmbraco_uSyncFilesPath>
 			<GovUkFrontendUmbraco_StaticWebAssetsPath>$(GovUkFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.govuk.frontend.umbraco\$(TprGovUkFrontendUmbracoPackageVersion)\staticwebassets\ThePensionsRegulator.GovUk.Frontend.Umbraco\</GovUkFrontendUmbraco_StaticWebAssetsPath>
 		</PropertyGroup>
 		<ItemGroup>
-			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_ContentFilesPath)uSync\**" />
+			<uSyncFilesFromGovUkFrontendUmbraco Include="$(GovUkFrontendUmbraco_uSyncFilesPath)**" />
 			<GovUkFrontendUmbraco_BackofficeCss Include="$(GovUkFrontendUmbraco_StaticWebAssetsPath)css\govuk-umbraco-backoffice.*" />
 		</ItemGroup>
 
-		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco copying uSync files from $(GovUkFrontendUmbraco_ContentFilesPath) to $(ProjectDir)" Importance="high" />
+		<Message Text="ThePensionsRegulator.GovUk.Frontend.Umbraco copying uSync files from $(GovUkFrontendUmbraco_uSyncFilesPath) to $(ProjectDir)" Importance="high" />
 		<Copy SourceFiles="@(uSyncFilesFromGovUkFrontendUmbraco)"
 			  DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)" />
 

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -26,24 +26,24 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <Compile Remove="Backoffice\node_modules\**" />
-	  <Content Remove="Backoffice\node_modules\**" />
-	  <EmbeddedResource Remove="Backoffice\node_modules\**" />
-	  <None Remove="Backoffice\node_modules\**" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<Content Remove="Backoffice\package-lock.json" />
 		<Content Remove="Backoffice\package.json" />
 		<Content Remove="Backoffice\public\umbraco-package.json" />
 		<Content Remove="Backoffice\tsconfig.json" />
 		<Content Remove="sasscompiler.json" />
+
+		<!-- Dont include the uSync folder as part of packaging nuget build. Instead pack it in a different folder. -->
+		<Content Remove="uSync\**" />
+		<None Include="uSync\**\*">
+			<PackagePath>uSync</PackagePath>
+			<Pack>true</Pack>
+		</None>
 	</ItemGroup>
 
 	<ItemGroup>
 		<Content Include="ThePensionsRegulator.Frontend.Umbraco.targets">
-		  <PackagePath>build;buildTransitive</PackagePath>
-		  <Pack>true</Pack>
+			<PackagePath>build;buildTransitive</PackagePath>
+			<Pack>true</Pack>
 		</Content>
 		<Content Include="ThePensionsRegulator.Frontend.Umbraco.generated.props">
 			<PackagePath>build</PackagePath>
@@ -68,41 +68,41 @@
 
 	<ItemGroup>
 		<None Include="..\tpr-nuget.png">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
 		</None>
 		<None Include="Backoffice\package-lock.json" />
 		<None Include="Backoffice\package.json">
-		  <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</None>
 		<None Include="Backoffice\public\umbraco-package.json">
-		  <Pack>false</Pack>
+			<Pack>false</Pack>
 		</None>
 		<None Include="Backoffice\tsconfig.json" />
 		<None Include="sasscompiler.json" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Update="Backoffice\src\blocks\helpers\media-helper.ts">
-	    <SubType>Code</SubType>
-	  </None>
-	  <None Update="NuGetReadme.md">
-	    <Pack>True</Pack>
-	    <PackagePath>\</PackagePath>
-	  </None>
-	  <None Update="Styles\tpr.scss">
-	    <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-	  </None>
-	  <None Update="Styles\govuk-umbraco-backoffice.scss">
-	    <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-	  </None>
+		<None Update="Backoffice\src\blocks\helpers\media-helper.ts">
+			<SubType>Code</SubType>
+		</None>
+		<None Update="NuGetReadme.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+		<None Update="Styles\tpr.scss">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+		</None>
+		<None Update="Styles\govuk-umbraco-backoffice.scss">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+		</None>
 	</ItemGroup>
 
 	<ItemGroup>
-	  <UpToDateCheckInput Remove="Styles\tpr.scss" />
+		<UpToDateCheckInput Remove="Styles\tpr.scss" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <UpToDateCheckInput Remove="Backoffice\node_modules\**" />
+		<UpToDateCheckInput Remove="Backoffice\node_modules\**" />
 	</ItemGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
@@ -26,15 +26,15 @@
 		<PropertyGroup>
 			<TprFrontendUmbraco_UserProfile Condition=" '$(OS)' == 'Windows_NT' ">$(UserProfile)</TprFrontendUmbraco_UserProfile>
 			<TprFrontendUmbraco_UserProfile Condition=" '$(OS)' != 'Windows_NT' ">$(HOME)</TprFrontendUmbraco_UserProfile>
-			<TprFrontendUmbraco_ContentFilesPath>$(TprFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoPackageVersion)\contentFiles\any\$(TargetFramework)\</TprFrontendUmbraco_ContentFilesPath>
+			<TprFrontendUmbraco_uSyncFilesPath>$(TprFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoPackageVersion)\uSync\</TprFrontendUmbraco_uSyncFilesPath>
 			<TprFrontendUmbraco_StaticWebAssetsPath>$(TprFrontendUmbraco_UserProfile)\.nuget\packages\thepensionsregulator.frontend.umbraco\$(TprFrontendUmbracoPackageVersion)\staticwebassets\ThePensionsRegulator.Frontend.Umbraco\</TprFrontendUmbraco_StaticWebAssetsPath>
 		</PropertyGroup>
 		<ItemGroup>
-			<uSyncFilesFromTprFrontendUmbraco Include="$(TprFrontendUmbraco_ContentFilesPath)uSync\**" />
+			<uSyncFilesFromTprFrontendUmbraco Include="$(TprFrontendUmbraco_uSyncFilesPath)**" />
 			<TprFrontendUmbraco_BackofficeCss Include="$(TprFrontendUmbraco_StaticWebAssetsPath)css\govuk-umbraco-backoffice.*" />
 		</ItemGroup>
 		
-		<Message Text="ThePensionsRegulator.Frontend.Umbraco copying uSync files from $(TprFrontendUmbraco_ContentFilesPath) to $(ProjectDir)" Importance="high" />
+		<Message Text="ThePensionsRegulator.Frontend.Umbraco copying uSync files from $(TprFrontendUmbraco_uSyncFilesPath) to $(ProjectDir)" Importance="high" />
 		<Copy SourceFiles="@(uSyncFilesFromTprFrontendUmbraco)"
 			DestinationFiles="$(ProjectDir)uSync\%(RecursiveDir)%(Filename)%(Extension)" />
 


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

This PR continues a review of the MSBuild that runs when our packages are installed.

Packages designed to be referenced by web projects have sometimes been referenced by class libraries, and the class library projects get the files even though they don't want them. One example of this is uSync files shared in the `uSync` folder (see screenshot in #353).

This happens because the project file has configuration to pack it inside the `contentFiles` folder in the package, and this is how `contentFiles` behave.

When our packages are installed, the `<project-name>.targets` file for that project is run when the consuming project is built. This PR uses that mechanism to avoid having the folder appear:

1. instead of including the uSync data inside the package in the `contentFiles` folder, it's included in a custom `uSync` folder
2. uSync needs them to be files on disk, so our `.targets` file finds the package folder, and copies the files into the project under the `uSync` folder
4. gitignore already ignores them there

## How to test this PR

Since we are now looking at the behaviour of the script that runs when a package is installed, testing this PR should involve:

1. Change the version number to something like `10.0.0-alpha001` in `Directory.Build.props` at the top of the repo and generate local packages.
6.  Set up one or more local NuGet package sources to point to the alpha packages. 
3 .Create a consuming project and consume the packages. 
7. Verify that the `uSync` folder only appears if the consuming project is a web project

## Out-of-scope for this PR

Everything else. You can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- the backoffice works
- client-side files are minified and cached
- consuming the package works, but is not fully optimised

Otherwise you can expect:
- outdated documentation

These will all be addressed in later PRs.

Also coming later: 

- Use uSync Roots feature to separate packaged uSync files from the consuming application's uSync files
- Updating other namespaces for greater clarity
- Convert all remaining NUnit tests to XUnit

Fixes #353