### PR TITLE
#253767 ROS-1 The open mobile menu obscures other interactive elements

### DIFF
--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -40,6 +40,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     subMenu.style.display = "none";
                 }
                 m.removeEventListener("keydown", desktopKeyboardNavigation)
+                m.addEventListener("keydown", closeMobileMenuOnFocusLeave)
             });
             arrows.forEach(a => a.addEventListener("keydown", mobileKeyboardNavigation))
         } else {
@@ -60,6 +61,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
                     subMenu.style.display = "none";
                 }
+                m.removeEventListener("keydown", closeMobileMenuOnFocusLeave)
                 m.addEventListener("keydown", desktopKeyboardNavigation)
             });
 
@@ -159,8 +161,8 @@ function observeSubMenuVisibility(item, subMenu, overlay) {
         {
             root: null,
             threshold: 0
-       }
-     
+        }
+
     );
     desktopSubMenuObserver.observe(subMenu);
 }
@@ -395,6 +397,21 @@ function mobileKeyboardNavigation(e) {
 
         expandMobileMenuSubMenu(e);
     }
+}
+
+function closeMobileMenuOnFocusLeave() {
+
+    setTimeout(() => {
+
+        const nav = document.querySelector(".tpr-header-menu__nav");
+        const toggle = document.querySelector(".tpr-header-menu__button");
+
+        const activeElement = document.activeElement;
+
+        if (activeElement !== toggle && !nav.contains(activeElement)) {
+            toggleMobileMenu();
+        }
+    }, 0);
 }
 
 function removeActiveClasses() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3776,9 +3776,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
Why:

Accessibility issue raised by CIVIC:

- The mobile menu remains open when it loses focus. This obscures the view of other interactive elements.

In this PR:

- Added additional functionality to support mobile menu close when user tabs out of the menu. 