### PR TITLE
#253767 ROS-1 The open mobile menu obscures other interactive elements (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
@@ -40,6 +40,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     subMenu.style.display = "none";
                 }
                 m.removeEventListener("keydown", desktopKeyboardNavigation)
+                m.addEventListener("keydown", closeMobileMenuOnFocusLeave)
             });
             arrows.forEach(a => a.addEventListener("keydown", mobileKeyboardNavigation))
         } else {
@@ -60,6 +61,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
                     subMenu.style.display = "none";
                 }
+                m.removeEventListener("keydown", closeMobileMenuOnFocusLeave)
                 m.addEventListener("keydown", desktopKeyboardNavigation)
             });
 
@@ -395,6 +397,21 @@ function mobileKeyboardNavigation(e) {
 
         expandMobileMenuSubMenu(e);
     }
+}
+
+function closeMobileMenuOnFocusLeave() {
+
+    setTimeout(() => {
+
+        const nav = document.querySelector(".tpr-header-menu__nav");
+        const toggle = document.querySelector(".tpr-header-menu__button");
+
+        const activeElement = document.activeElement;
+
+        if (activeElement !== toggle && !nav.contains(activeElement)) {
+            toggleMobileMenu();
+        }
+    }, 0);
 }
 
 function removeActiveClasses() {


### PR DESCRIPTION
Duplicate PR #660 for v17

Why:

Accessibility issue raised by CIVIC:

- The mobile menu remains open when it loses focus. This obscures the view of other interactive elements.

In this PR:

- Added additional functionality to support mobile menu close when user tabs out of the menu.