### PR TITLE
#253760 ROS-1 The toggle menu buttons on mobile have insufficient colour contrast (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -192,9 +192,14 @@
         border-bottom: $govuk-focus-width solid $tpr-colour-black;
     }
 
-        .tpr-header-menu__nav-menu-item:focus-within button {
+    .tpr-header-menu__nav-menu-item:focus-within button {
         border: solid $tpr-colour-black;
         border-width: 0 3px 3px 0;
+    }
+
+    .tpr-header-menu__nav-sub-menu-item a {
+        font-size: 0.9rem;
+        width: 100%
     }
 
     .tpr-header-menu__nav-sub-menu-item-title {

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -192,9 +192,9 @@
         border-bottom: $govuk-focus-width solid $tpr-colour-black;
     }
 
-    .tpr-header-menu__nav-sub-menu-item a {
-        font-size: 0.9rem;
-        width: 100%
+        .tpr-header-menu__nav-menu-item:focus-within button {
+        border: solid $tpr-colour-black;
+        border-width: 0 3px 3px 0;
     }
 
     .tpr-header-menu__nav-sub-menu-item-title {
@@ -216,8 +216,13 @@
         cursor: pointer;
     }
 
-    .tpr-header-menu_menu-item-arrow--active {
+    .tpr-header-menu_arrow-container--active {
         background-color: transparent;
+    }
+
+    .tpr-header-menu_arrow--active {
+        border: solid $tpr-colour-white;
+        border-width: 0 3px 3px 0;
     }
 }
 
@@ -418,7 +423,7 @@
     color: $tpr-colour-white;
 }
 
-.tpr-header-menu_menu-item-arrow--active {
+.tpr-header-menu_arrow-container--active {
     background: $tpr-colour-violet;
 }
 

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
@@ -100,11 +100,13 @@ function highlightCurrentSection() {
         const anchor = item.querySelector('a');
         let anchorText = anchor.innerHTML.toLowerCase();
 
-        const arrow = item.querySelector(".tpr-header-menu__arrow-container")
+        const arrowContainer = item.querySelector(".tpr-header-menu__arrow-container")
+        const arrow = item.querySelector(".tpr-header-menu__arrow")
 
         if (anchorText.includes(section.toLowerCase())) {
             anchor.classList.toggle("tpr-header-menu__nav-menu-item--active")
-            arrow.classList.toggle("tpr-header-menu_menu-item-arrow--active")
+            arrowContainer.classList.toggle("tpr-header-menu_arrow-container--active")
+            arrow.classList.toggle("tpr-header-menu_arrow--active")
         }
     });
 }


### PR DESCRIPTION
Why:

On mobile, the dropdown toggle icon has insufficient colour contrast when the corresponding page is active.
colour contrast.

<img width="612" height="308" alt="colour contrast" src="https://github.com/user-attachments/assets/a898ca33-8531-4c65-ba94-b7397e1c2efb" />

In this PR:

Added additional styling for dropdown arrows to ensure sufficient colour contrast with active class applied across all states.