### PR TITLE
Convert ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests from NUnit to XUnit

### DIFF
--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/BlockViewServiceTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/BlockViewServiceTests.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
 using Moq;
-using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Services;
 using ThePensionsRegulator.Umbraco.Core;
@@ -10,7 +9,6 @@ using ThePensionsRegulator.Umbraco.Testing;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
 {
-    [TestFixture]
     public class BlockViewServiceTests
     {
 # nullable disable
@@ -18,14 +16,13 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         private Mock<IGovUkFieldsetErrorFinder> _fieldsetErrorFinder;
 #nullable enable
 
-        [SetUp]
-        public void SetupMocks()
+        public BlockViewServiceTests()
         {
             _gridClassBuilder = new();
             _fieldsetErrorFinder = new();
         }
 
-        [Test]
+        [Fact]
         public void OverridableBlockGridModel_applies_filter()
         {
             // Arrange
@@ -44,11 +41,11 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Count(), Is.EqualTo(1));
-            Assert.That(result.First().CurrentBlock.Content.ContentType.Alias, Is.EqualTo(ALLOWED));
+            Assert.Single(result);
+            Assert.Equal(ALLOWED, result.First().CurrentBlock.Content.ContentType.Alias);
         }
 
-        [Test]
+        [Fact]
         public void OverridableBlockAreaModel_applies_filter()
         {
             // Arrange
@@ -67,11 +64,11 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Count(), Is.EqualTo(1));
-            Assert.That(result.First().CurrentBlock.Content.ContentType.Alias, Is.EqualTo(ALLOWED));
+            Assert.Single(result);
+            Assert.Equal(ALLOWED, result.First().CurrentBlock.Content.ContentType.Alias);
         }
 
-        [Test]
+        [Fact]
         public void OverridableBlockListModel_applies_filter()
         {
             // Arrange
@@ -90,11 +87,11 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Count(), Is.EqualTo(1));
-            Assert.That(result.First().CurrentBlock.Content.ContentType.Alias, Is.EqualTo(ALLOWED));
+            Assert.Single(result);
+            Assert.Equal(ALLOWED, result.First().CurrentBlock.Content.ContentType.Alias);
         }
 
-        [Test]
+        [Fact]
         public void Grid_with_no_blocks_returns_empty_list()
         {
             // Arrange
@@ -106,10 +103,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result, Is.Empty);
+            Assert.Empty(result);
         }
 
-        [Test]
+        [Fact]
         public void Area_with_no_blocks_returns_empty_list()
         {
             // Arrange
@@ -121,10 +118,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result, Is.Empty);
+            Assert.Empty(result);
         }
 
-        [Test]
+        [Fact]
         public void Grid_sets_previous_current_and_next_block()
         {
             // Arrange
@@ -140,18 +137,18 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary()).ToList();
 
             // Assert
-            Assert.That(result[0].PreviousBlock, Is.Null);
-            Assert.That(result[0].CurrentBlock, Is.EqualTo(model[0]));
-            Assert.That(result[0].NextBlock, Is.EqualTo(model[1]));
-            Assert.That(result[1].PreviousBlock, Is.EqualTo(model[0]));
-            Assert.That(result[1].CurrentBlock, Is.EqualTo(model[1]));
-            Assert.That(result[1].NextBlock, Is.EqualTo(model[2]));
-            Assert.That(result[2].PreviousBlock, Is.EqualTo(model[1]));
-            Assert.That(result[2].CurrentBlock, Is.EqualTo(model[2]));
-            Assert.That(result[2].NextBlock, Is.Null);
+            Assert.Null(result[0].PreviousBlock);
+            Assert.Equal(model[0], result[0].CurrentBlock);
+            Assert.Equal(model[1], result[0].NextBlock);
+            Assert.Equal(model[0], result[1].PreviousBlock);
+            Assert.Equal(model[1], result[1].CurrentBlock);
+            Assert.Equal(model[2], result[1].NextBlock);
+            Assert.Equal(model[1], result[2].PreviousBlock);
+            Assert.Equal(model[2], result[2].CurrentBlock);
+            Assert.Null(result[2].NextBlock);
         }
 
-        [Test]
+        [Fact]
         public void Area_sets_previous_current_and_next_block()
         {
             // Arrange
@@ -167,18 +164,18 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary()).ToList();
 
             // Assert
-            Assert.That(result[0].PreviousBlock, Is.Null);
-            Assert.That(result[0].CurrentBlock, Is.EqualTo(model[0]));
-            Assert.That(result[0].NextBlock, Is.EqualTo(model[1]));
-            Assert.That(result[1].PreviousBlock, Is.EqualTo(model[0]));
-            Assert.That(result[1].CurrentBlock, Is.EqualTo(model[1]));
-            Assert.That(result[1].NextBlock, Is.EqualTo(model[2]));
-            Assert.That(result[2].PreviousBlock, Is.EqualTo(model[1]));
-            Assert.That(result[2].CurrentBlock, Is.EqualTo(model[2]));
-            Assert.That(result[2].NextBlock, Is.Null);
+            Assert.Null(result[0].PreviousBlock);
+            Assert.Equal(model[0], result[0].CurrentBlock);
+            Assert.Equal(model[1], result[0].NextBlock);
+            Assert.Equal(model[0], result[1].PreviousBlock);
+            Assert.Equal(model[1], result[1].CurrentBlock);
+            Assert.Equal(model[2], result[1].NextBlock);
+            Assert.Equal(model[1], result[2].PreviousBlock);
+            Assert.Equal(model[2], result[2].CurrentBlock);
+            Assert.Null(result[2].NextBlock);
         }
 
-        [Test]
+        [Fact]
         public void List_with_no_blocks_returns_empty_list()
         {
             // Arrange
@@ -190,10 +187,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result, Is.Empty);
+            Assert.Empty(result);
         }
 
-        [Test]
+        [Fact]
         public void List_sets_previous_current_and_next_block()
         {
             // Arrange
@@ -209,25 +206,26 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary()).ToList();
 
             // Assert
-            Assert.That(result[0].PreviousBlock, Is.Null);
-            Assert.That(result[0].CurrentBlock, Is.EqualTo(model[0]));
-            Assert.That(result[0].NextBlock, Is.EqualTo(model[1]));
-            Assert.That(result[1].PreviousBlock, Is.EqualTo(model[0]));
-            Assert.That(result[1].CurrentBlock, Is.EqualTo(model[1]));
-            Assert.That(result[1].NextBlock, Is.EqualTo(model[2]));
-            Assert.That(result[2].PreviousBlock, Is.EqualTo(model[1]));
-            Assert.That(result[2].CurrentBlock, Is.EqualTo(model[2]));
-            Assert.That(result[2].NextBlock, Is.Null);
+            Assert.Null(result[0].PreviousBlock);
+            Assert.Equal(model[0], result[0].CurrentBlock);
+            Assert.Equal(model[1], result[0].NextBlock);
+            Assert.Equal(model[0], result[1].PreviousBlock);
+            Assert.Equal(model[1], result[1].CurrentBlock);
+            Assert.Equal(model[2], result[1].NextBlock);
+            Assert.Equal(model[1], result[2].PreviousBlock);
+            Assert.Equal(model[2], result[2].CurrentBlock);
+            Assert.Null(result[2].NextBlock);
         }
 
-        [TestCase(true, true, true)]
-        [TestCase(true, true, false)]
-        [TestCase(true, false, true)]
-        [TestCase(true, false, false)]
-        [TestCase(false, true, true)]
-        [TestCase(false, true, false)]
-        [TestCase(false, false, true)]
-        [TestCase(false, false, false)]
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, false, false)]
         public void Grid_sets_OpenWidthContainer_to_true_if_RenderWidthContainerForBlocks_enabled_and_RenderWidthContainer_true_and_block_is_not_the_same_as_the_previous_block(bool renderWidthContainerForBlocksEnabled, bool renderWidthContainer, bool sameAsPrevious)
         {
             // Arrange
@@ -262,17 +260,18 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Last().OpenWidthContainer, Is.EqualTo(renderWidthContainerForBlocksEnabled && renderWidthContainer && !sameAsPrevious));
+            Assert.Equal(renderWidthContainerForBlocksEnabled && renderWidthContainer && !sameAsPrevious, result.Last().OpenWidthContainer);
         }
 
-        [TestCase(true, true, true)]
-        [TestCase(true, true, false)]
-        [TestCase(true, false, true)]
-        [TestCase(true, false, false)]
-        [TestCase(false, true, true)]
-        [TestCase(false, true, false)]
-        [TestCase(false, false, true)]
-        [TestCase(false, false, false)]
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, false, false)]
         public void Grid_sets_CloseWidthContainer_to_true_if_RenderWidthContainerForBlocks_enabled_and_RenderWidthContainer_true_and_block_is_not_the_same_as_the_next_block(bool renderWidthContainerForBlocksEnabled, bool renderWidthContainer, bool sameAsNext)
         {
             // Arrange
@@ -308,11 +307,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().CloseWidthContainer, Is.EqualTo(renderWidthContainerForBlocksEnabled && renderWidthContainer && !sameAsNext));
+            Assert.Equal(renderWidthContainerForBlocksEnabled && renderWidthContainer && !sameAsNext, result.First().CloseWidthContainer);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void Area_sets_OpenWidthContainer_to_false_for_any_RenderWidthContainerForBlocks_setting(bool renderWidthContainerForBlocksEnabled)
         {
             // Arrange
@@ -329,11 +329,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().OpenWidthContainer, Is.False);
+            Assert.False(result.First().OpenWidthContainer);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void Area_sets_CloseWidthContainer_to_false_for_any_RenderWidthContainerForBlocks_setting(bool renderWidthContainerForBlocksEnabled)
         {
             // Arrange
@@ -350,25 +351,26 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().CloseWidthContainer, Is.False);
+            Assert.False(result.First().CloseWidthContainer);
         }
 
-        [TestCase(true, true, true, true)]
-        [TestCase(true, true, true, false)]
-        [TestCase(true, true, false, true)]
-        [TestCase(true, false, true, true)]
-        [TestCase(false, true, true, true)]
-        [TestCase(false, true, true, false)]
-        [TestCase(false, false, true, true)]
-        [TestCase(true, false, false, true)]
-        [TestCase(true, true, false, false)]
-        [TestCase(false, true, false, true)]
-        [TestCase(true, false, true, false)]
-        [TestCase(false, false, false, true)]
-        [TestCase(false, false, true, false)]
-        [TestCase(false, true, false, false)]
-        [TestCase(true, false, false, false)]
-        [TestCase(false, false, false, false)]
+        [Theory]
+        [InlineData(true, true, true, true)]
+        [InlineData(true, true, true, false)]
+        [InlineData(true, true, false, true)]
+        [InlineData(true, false, true, true)]
+        [InlineData(false, true, true, true)]
+        [InlineData(false, true, true, false)]
+        [InlineData(false, false, true, true)]
+        [InlineData(true, false, false, true)]
+        [InlineData(true, true, false, false)]
+        [InlineData(false, true, false, true)]
+        [InlineData(true, false, true, false)]
+        [InlineData(false, false, false, true)]
+        [InlineData(false, false, true, false)]
+        [InlineData(false, true, false, false)]
+        [InlineData(true, false, false, false)]
+        [InlineData(false, false, false, false)]
         public void Lists_sets_OpenWidthContainer_to_true_if_RenderWidthContainer_enabled_for_both_site_and_block_list_and_RenderGrid_is_true_and_current_block_is_not_the_same_as_the_previous_block(
                 bool renderWidthContainerForSiteEnabled,
                 bool renderWidthContainerForBlockListEnabled,
@@ -408,25 +410,26 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Last().OpenWidthContainer, Is.EqualTo(renderWidthContainerForSiteEnabled && renderWidthContainerForBlockListEnabled && renderGrid && !sameAsPrevious));
+            Assert.Equal(renderWidthContainerForSiteEnabled && renderWidthContainerForBlockListEnabled && renderGrid && !sameAsPrevious, result.Last().OpenWidthContainer);
         }
 
-        [TestCase(true, true, true, true)]
-        [TestCase(true, true, true, false)]
-        [TestCase(true, true, false, true)]
-        [TestCase(true, false, true, true)]
-        [TestCase(false, true, true, true)]
-        [TestCase(false, true, true, false)]
-        [TestCase(false, false, true, true)]
-        [TestCase(true, false, false, true)]
-        [TestCase(true, true, false, false)]
-        [TestCase(false, true, false, true)]
-        [TestCase(true, false, true, false)]
-        [TestCase(false, false, false, true)]
-        [TestCase(false, false, true, false)]
-        [TestCase(false, true, false, false)]
-        [TestCase(true, false, false, false)]
-        [TestCase(false, false, false, false)]
+        [Theory]
+        [InlineData(true, true, true, true)]
+        [InlineData(true, true, true, false)]
+        [InlineData(true, true, false, true)]
+        [InlineData(true, false, true, true)]
+        [InlineData(false, true, true, true)]
+        [InlineData(false, true, true, false)]
+        [InlineData(false, false, true, true)]
+        [InlineData(true, false, false, true)]
+        [InlineData(true, true, false, false)]
+        [InlineData(false, true, false, true)]
+        [InlineData(true, false, true, false)]
+        [InlineData(false, false, false, true)]
+        [InlineData(false, false, true, false)]
+        [InlineData(false, true, false, false)]
+        [InlineData(true, false, false, false)]
+        [InlineData(false, false, false, false)]
         public void Lists_sets_CloseWidthContainer_to_true_if_RenderWidthContainer_enabled_for_both_site_and_block_list_and_RenderGrid_is_true_and_current_block_not_the_same_as_the_next_block(
                 bool renderWidthContainerForSiteEnabled,
                 bool renderWidthContainerForBlockListEnabled,
@@ -466,13 +469,14 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().CloseWidthContainer, Is.EqualTo(renderWidthContainerForSiteEnabled && renderWidthContainerForBlockListEnabled && renderGrid && !sameAsNext));
+            Assert.Equal(renderWidthContainerForSiteEnabled && renderWidthContainerForBlockListEnabled && renderGrid && !sameAsNext, result.First().CloseWidthContainer);
         }
 
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void Grid_sets_OpenGridRowAndColumn_to_true_for_blocks_with_no_areas_and_block_is_not_the_same_as_the_previous_block(bool hasGridAreas, bool sameAsPrevious)
         {
             // Arrange
@@ -510,13 +514,14 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Last().OpenGridRowAndColumn, Is.EqualTo(!hasGridAreas && !sameAsPrevious));
+            Assert.Equal(!hasGridAreas && !sameAsPrevious, result.Last().OpenGridRowAndColumn);
         }
 
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void Grid_sets_CloseGridRowAndColumn_to_true_for_blocks_with_no_areas_and_block_is_not_the_same_as_the_next_block(bool hasGridAreas, bool sameAsNext)
         {
             // Arrange
@@ -554,13 +559,14 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().CloseGridRowAndColumn, Is.EqualTo(!hasGridAreas && !sameAsNext));
+            Assert.Equal(!hasGridAreas && !sameAsNext, result.First().CloseGridRowAndColumn);
         }
 
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void Area_sets_OpenGridRowAndColumn_to_true_for_blocks_with_no_areas_and_block_is_not_the_same_as_the_previous_block(bool hasGridAreas, bool sameAsPrevious)
         {
             // Arrange
@@ -598,13 +604,14 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Last().OpenGridRowAndColumn, Is.EqualTo(!hasGridAreas && !sameAsPrevious));
+            Assert.Equal(!hasGridAreas && !sameAsPrevious, result.Last().OpenGridRowAndColumn);
         }
 
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void Area_sets_CloseGridRowAndColumn_to_true_for_blocks_with_no_areas_and_block_is_not_the_same_as_the_next_block(bool hasGridAreas, bool sameAsNext)
         {
             // Arrange
@@ -642,17 +649,18 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().CloseGridRowAndColumn, Is.EqualTo(!hasGridAreas && !sameAsNext));
+            Assert.Equal(!hasGridAreas && !sameAsNext, result.First().CloseGridRowAndColumn);
         }
 
-        [TestCase(true, true, true)]
-        [TestCase(true, true, false)]
-        [TestCase(true, false, true)]
-        [TestCase(true, false, false)]
-        [TestCase(false, true, true)]
-        [TestCase(false, true, false)]
-        [TestCase(false, false, true)]
-        [TestCase(false, false, false)]
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, false, false)]
         public void List_sets_OpenGridRowAndColumn_based_on_RenderGrid_if_current_block_is_not_grid_row_and_block_is_not_the_same_as_the_previous_block(
             bool renderGrid,
             bool currentBlockIsGridRow,
@@ -690,17 +698,18 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.Last().OpenGridRowAndColumn, Is.EqualTo(renderGrid && !currentBlockIsGridRow && !sameAsPrevious));
+            Assert.Equal(renderGrid && !currentBlockIsGridRow && !sameAsPrevious, result.Last().OpenGridRowAndColumn);
         }
 
-        [TestCase(true, true, true)]
-        [TestCase(true, true, false)]
-        [TestCase(true, false, true)]
-        [TestCase(true, false, false)]
-        [TestCase(false, true, true)]
-        [TestCase(false, true, false)]
-        [TestCase(false, false, true)]
-        [TestCase(false, false, false)]
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, false, false)]
         public void List_sets_CloseGridRowAndColumn_based_on_RenderGrid_if_current_block_is_not_grid_row_and_block_is_not_the_same_as_the_next_block(
             bool renderGrid,
             bool currentBlockIsGridRow,
@@ -738,12 +747,13 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().CloseGridRowAndColumn, Is.EqualTo(renderGrid && !currentBlockIsGridRow && !sameAsNext));
+            Assert.Equal(renderGrid && !currentBlockIsGridRow && !sameAsNext, result.First().CloseGridRowAndColumn);
         }
 
-        [TestCase(false, false, false)]
-        [TestCase(true, false, true)]
-        [TestCase(true, true, false)]
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(true, false, true)]
+        [InlineData(true, true, false)]
         public void Grid_applies_fieldset_error_classes_and_container_if_there_are_fieldset_errors_and_legend_is_not_page_heading(bool hasErrors, bool legendIsPageHeading, bool expectClasses)
         {
             // Arrange
@@ -769,21 +779,22 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             if (expectClasses)
             {
-                Assert.That(result.First().OpenFieldsetErrorContainer, Is.True);
-                Assert.That(result.First().CloseFieldsetErrorContainer, Is.True);
-                Assert.That(result.First().FieldsetErrorClasses, Is.EqualTo(FIELDSET_ERROR_CLASS));
+                Assert.True(result.First().OpenFieldsetErrorContainer);
+                Assert.True(result.First().CloseFieldsetErrorContainer);
+                Assert.Equal(FIELDSET_ERROR_CLASS, result.First().FieldsetErrorClasses);
             }
             else
             {
-                Assert.That(result.First().OpenFieldsetErrorContainer, Is.False);
-                Assert.That(result.First().CloseFieldsetErrorContainer, Is.False);
-                Assert.That(result.First().FieldsetErrorClasses, Is.Null);
+                Assert.False(result.First().OpenFieldsetErrorContainer);
+                Assert.False(result.First().CloseFieldsetErrorContainer);
+                Assert.Null(result.First().FieldsetErrorClasses);
             }
         }
 
-        [TestCase(false, false, false)]
-        [TestCase(true, false, true)]
-        [TestCase(true, true, false)]
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(true, false, true)]
+        [InlineData(true, true, false)]
         public void List_applies_fieldset_error_classes_and_container_if_there_are_fieldset_errors_and_legend_is_not_page_heading(bool hasErrors, bool legendIsPageHeading, bool expectClasses)
         {
             // Arrange
@@ -809,19 +820,19 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             if (expectClasses)
             {
-                Assert.That(result.First().OpenFieldsetErrorContainer, Is.True);
-                Assert.That(result.First().CloseFieldsetErrorContainer, Is.True);
-                Assert.That(result.First().FieldsetErrorClasses, Is.EqualTo(FIELDSET_ERROR_CLASS));
+                Assert.True(result.First().OpenFieldsetErrorContainer);
+                Assert.True(result.First().CloseFieldsetErrorContainer);
+                Assert.Equal(FIELDSET_ERROR_CLASS, result.First().FieldsetErrorClasses);
             }
             else
             {
-                Assert.That(result.First().OpenFieldsetErrorContainer, Is.False);
-                Assert.That(result.First().CloseFieldsetErrorContainer, Is.False);
-                Assert.That(result.First().FieldsetErrorClasses, Is.Null);
+                Assert.False(result.First().OpenFieldsetErrorContainer);
+                Assert.False(result.First().CloseFieldsetErrorContainer);
+                Assert.Null(result.First().FieldsetErrorClasses);
             }
         }
 
-        [Test]
+        [Fact]
         public void Grid_sets_row_and_column_class_are_set_from_GovUkGridClassBuilder()
         {
             // Arrange
@@ -840,11 +851,11 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().RowClasses, Is.EqualTo(ROW_CLASS));
-            Assert.That(result.First().ColumnClasses, Is.EqualTo(COLUMN_CLASS));
+            Assert.Equal(ROW_CLASS, result.First().RowClasses);
+            Assert.Equal(COLUMN_CLASS, result.First().ColumnClasses);
         }
 
-        [Test]
+        [Fact]
         public void List_sets_row_and_column_class_are_set_from_GovUkGridClassBuilder()
         {
             // Arrange
@@ -863,35 +874,37 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
 
             // Assert
-            Assert.That(result.First().RowClasses, Is.EqualTo(ROW_CLASS));
-            Assert.That(result.First().ColumnClasses, Is.EqualTo(COLUMN_CLASS));
+            Assert.Equal(ROW_CLASS, result.First().RowClasses);
+            Assert.Equal(COLUMN_CLASS, result.First().ColumnClasses);
         }
 
+        [Theory]
+
         // true if everything the same with default row classes
-        [TestCase(true, true, true, true, "", "", "", "", true)]
-        [TestCase(false, false, false, false, "", "", "", "", true)]
+        [InlineData(true, true, true, true, "", "", "", "", true)]
+        [InlineData(false, false, false, false, "", "", "", "", true)]
 
         // false if grid areas different
-        [TestCase(true, false, false, false, "", "", "", "", false)]
-        [TestCase(false, true, false, false, "", "", "", "", false)]
+        [InlineData(true, false, false, false, "", "", "", "", false)]
+        [InlineData(false, true, false, false, "", "", "", "", false)]
 
         // false if one is a grid row block and the other isn't
-        [TestCase(false, false, true, false, "", "", "", "", false)]
-        [TestCase(false, false, false, true, "", "", "", "", false)]
+        [InlineData(false, false, true, false, "", "", "", "", false)]
+        [InlineData(false, false, false, true, "", "", "", "", false)]
 
         // any custom row class should return false
-        [TestCase(false, false, false, false, "custom", "", "", "", false)]
-        [TestCase(false, false, false, false, "", "custom", "", "", false)]
-        [TestCase(false, false, false, false, "custom", "custom", "", "", false)]
-        [TestCase(false, false, false, false, "custom1", "custom2", "", "", false)]
+        [InlineData(false, false, false, false, "custom", "", "", "", false)]
+        [InlineData(false, false, false, false, "", "custom", "", "", false)]
+        [InlineData(false, false, false, false, "custom", "custom", "", "", false)]
+        [InlineData(false, false, false, false, "custom1", "custom2", "", "", false)]
 
         // true if column classes match
-        [TestCase(false, false, false, false, "", "", "custom", "custom", true)]
+        [InlineData(false, false, false, false, "", "", "custom", "custom", true)]
 
         // false if column class different
-        [TestCase(false, false, false, false, "", "", "custom", "", false)]
-        [TestCase(false, false, false, false, "", "", "", "custom", false)]
-        [TestCase(false, false, false, false, "", "", "custom1", "custom2", false)]
+        [InlineData(false, false, false, false, "", "", "custom", "", false)]
+        [InlineData(false, false, false, false, "", "", "", "custom", false)]
+        [InlineData(false, false, false, false, "", "", "custom1", "custom2", false)]
         public void SameAsNext_matches_on_row_class_and_column_class_and_grid_areas_and_grid_row_block(
             bool currentBlockHasAreas,
             bool nextBlockHasAreas,
@@ -914,34 +927,36 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
                                 currentBlockIsGridRow, nextBlockIsGridRow);
 
             // Assert
-            Assert.That(result, Is.EqualTo(expectSameAsNext));
+            Assert.Equal(expectSameAsNext, result);
         }
 
+        [Theory]
+
         // true if everything the same with default row classes
-        [TestCase(true, true, true, true, "", "", "", "", true)]
-        [TestCase(false, false, false, false, "", "", "", "", true)]
+        [InlineData(true, true, true, true, "", "", "", "", true)]
+        [InlineData(false, false, false, false, "", "", "", "", true)]
 
         // false if grid areas different
-        [TestCase(true, false, false, false, "", "", "", "", false)]
-        [TestCase(false, true, false, false, "", "", "", "", false)]
+        [InlineData(true, false, false, false, "", "", "", "", false)]
+        [InlineData(false, true, false, false, "", "", "", "", false)]
 
         // false if one is a grid row block and the other isn't
-        [TestCase(false, false, true, false, "", "", "", "", false)]
-        [TestCase(false, false, false, true, "", "", "", "", false)]
+        [InlineData(false, false, true, false, "", "", "", "", false)]
+        [InlineData(false, false, false, true, "", "", "", "", false)]
 
         // any custom row class should return false
-        [TestCase(false, false, false, false, "custom", "", "", "", false)]
-        [TestCase(false, false, false, false, "", "custom", "", "", false)]
-        [TestCase(false, false, false, false, "custom", "custom", "", "", false)]
-        [TestCase(false, false, false, false, "custom1", "custom2", "", "", false)]
+        [InlineData(false, false, false, false, "custom", "", "", "", false)]
+        [InlineData(false, false, false, false, "", "custom", "", "", false)]
+        [InlineData(false, false, false, false, "custom", "custom", "", "", false)]
+        [InlineData(false, false, false, false, "custom1", "custom2", "", "", false)]
 
         // true if column classes match
-        [TestCase(false, false, false, false, "", "", "custom", "custom", true)]
+        [InlineData(false, false, false, false, "", "", "custom", "custom", true)]
 
         // false if column class different
-        [TestCase(false, false, false, false, "", "", "custom", "", false)]
-        [TestCase(false, false, false, false, "", "", "", "custom", false)]
-        [TestCase(false, false, false, false, "", "", "custom1", "custom2", false)]
+        [InlineData(false, false, false, false, "", "", "custom", "", false)]
+        [InlineData(false, false, false, false, "", "", "", "custom", false)]
+        [InlineData(false, false, false, false, "", "", "custom1", "custom2", false)]
         public void SameAsPrevious_matches_on_row_class_and_column_class_and_grid_areas_and_grid_row_block(
             bool previousBlockHasAreas,
             bool currentBlockHasAreas,
@@ -964,7 +979,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
                 previousBlockIsGridRow, currentBlockIsGridRow);
 
             // Assert
-            Assert.That(result, Is.EqualTo(expectSameAsPrevious));
+            Assert.Equal(expectSameAsPrevious, result);
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
@@ -1,4 +1,3 @@
-﻿using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Models;
 using ThePensionsRegulator.Umbraco.Core;
@@ -11,11 +10,11 @@ using Umbraco.Cms.Core.Strings;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
 {
-    [TestFixture]
     public class IOverridablePublishedElementExtensionsTests
     {
-        [TestCase(ElementTypeAliases.Checkboxes, false)]
-        [TestCase(ElementTypeAliases.Radios, true)]
+        [Theory]
+        [InlineData(ElementTypeAliases.Checkboxes, false)]
+        [InlineData(ElementTypeAliases.Radios, true)]
         public void OverrideCheckboxes_throws_ArgumentException_if_block_is_not_Checkboxes_component(string elementTypeAlias, bool exceptionExpected)
         {
             var testContext = new UmbracoTestContext();
@@ -27,11 +26,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
             else
             {
-                Assert.DoesNotThrow(() => content.Object.OverrideCheckboxes(Array.Empty<Checkbox>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                var exception = Record.Exception(() => content.Object.OverrideCheckboxes(Array.Empty<Checkbox>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                Assert.Null(exception);
             }
         }
 
-        [Test]
+        [Fact]
         public void OverrideCheckboxes_replaces_checkboxes()
         {
             // Arrange
@@ -78,20 +78,21 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             var options = content.Value<OverridableBlockListModel>(PropertyAliases.Checkboxes);
 
-            Assert.That(options, Is.Not.Null);
-            Assert.That(options!.Count(), Is.EqualTo(replacement.Count()));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.CheckboxValue), Is.EqualTo("3"));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.CheckboxLabel), Is.EqualTo("Item 3"));
-            Assert.That(options![0].Content.Value<IHtmlEncodedString>(PropertyAliases.Hint)?.ToHtmlString(), Is.EqualTo("<i>Hint 3</i>"));
-            Assert.That(options![0].Content.Value<OverridableBlockListModel>(PropertyAliases.CheckboxConditionalBlocks), Is.Not.Null);
-            Assert.That(options![0].Settings?.Value<string>(PropertyAliases.CssClasses), Is.EqualTo("item-3"));
-            Assert.That(options[1].Content.Value<string>(PropertyAliases.CheckboxesDividerText), Is.EqualTo("divider"));
-            Assert.That(options[2].Content.Value<string>(PropertyAliases.CheckboxValue), Is.EqualTo("4"));
-            Assert.That(options[2].Content.Value<string>(PropertyAliases.CheckboxLabel), Is.EqualTo("Item 4"));
+            Assert.NotNull(options);
+            Assert.Equal(replacement.Count(), options!.Count());
+            Assert.Equal("3", options![0].Content.Value<string>(PropertyAliases.CheckboxValue));
+            Assert.Equal("Item 3", options![0].Content.Value<string>(PropertyAliases.CheckboxLabel));
+            Assert.Equal("<i>Hint 3</i>", options![0].Content.Value<IHtmlEncodedString>(PropertyAliases.Hint)?.ToHtmlString());
+            Assert.NotNull(options![0].Content.Value<OverridableBlockListModel>(PropertyAliases.CheckboxConditionalBlocks));
+            Assert.Equal("item-3", options![0].Settings?.Value<string>(PropertyAliases.CssClasses));
+            Assert.Equal("divider", options[1].Content.Value<string>(PropertyAliases.CheckboxesDividerText));
+            Assert.Equal("4", options[2].Content.Value<string>(PropertyAliases.CheckboxValue));
+            Assert.Equal("Item 4", options[2].Content.Value<string>(PropertyAliases.CheckboxLabel));
         }
 
-        [TestCase(ElementTypeAliases.Checkboxes, true)]
-        [TestCase(ElementTypeAliases.Radios, false)]
+        [Theory]
+        [InlineData(ElementTypeAliases.Checkboxes, true)]
+        [InlineData(ElementTypeAliases.Radios, false)]
         public void OverrideRadioButtons_throws_ArgumentException_if_block_is_not_Radios_component(string elementTypeAlias, bool exceptionExpected)
         {
             var testContext = new UmbracoTestContext();
@@ -103,11 +104,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
             else
             {
-                Assert.DoesNotThrow(() => content.Object.OverrideRadioButtons(Array.Empty<RadioButton>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                var exception = Record.Exception(() => content.Object.OverrideRadioButtons(Array.Empty<RadioButton>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                Assert.Null(exception);
             }
         }
 
-        [Test]
+        [Fact]
         public void OverrideRadioButtons_replaces_radio_buttons()
         {
             // Arrange
@@ -153,20 +155,21 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             var options = content.Value<OverridableBlockListModel>(PropertyAliases.RadioButtons);
 
-            Assert.That(options, Is.Not.Null);
-            Assert.That(options!.Count(), Is.EqualTo(replacement.Count()));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.RadioButtonValue), Is.EqualTo("3"));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.RadioButtonLabel), Is.EqualTo("Item 3"));
-            Assert.That(options![0].Content.Value<IHtmlEncodedString>(PropertyAliases.Hint)?.ToHtmlString(), Is.EqualTo("<i>Hint 3</i>"));
-            Assert.That(options![0].Content.Value<OverridableBlockListModel>(PropertyAliases.RadioConditionalBlocks), Is.Not.Null);
-            Assert.That(options![0].Settings?.Value<string>(PropertyAliases.CssClasses), Is.EqualTo("item-3"));
-            Assert.That(options[1].Content.Value<string>(PropertyAliases.RadiosDividerText), Is.EqualTo("divider"));
-            Assert.That(options[2].Content.Value<string>(PropertyAliases.RadioButtonValue), Is.EqualTo("4"));
-            Assert.That(options[2].Content.Value<string>(PropertyAliases.RadioButtonLabel), Is.EqualTo("Item 4"));
+            Assert.NotNull(options);
+            Assert.Equal(replacement.Count(), options!.Count());
+            Assert.Equal("3", options![0].Content.Value<string>(PropertyAliases.RadioButtonValue));
+            Assert.Equal("Item 3", options![0].Content.Value<string>(PropertyAliases.RadioButtonLabel));
+            Assert.Equal("<i>Hint 3</i>", options![0].Content.Value<IHtmlEncodedString>(PropertyAliases.Hint)?.ToHtmlString());
+            Assert.NotNull(options![0].Content.Value<OverridableBlockListModel>(PropertyAliases.RadioConditionalBlocks));
+            Assert.Equal("item-3", options![0].Settings?.Value<string>(PropertyAliases.CssClasses));
+            Assert.Equal("divider", options[1].Content.Value<string>(PropertyAliases.RadiosDividerText));
+            Assert.Equal("4", options[2].Content.Value<string>(PropertyAliases.RadioButtonValue));
+            Assert.Equal("Item 4", options[2].Content.Value<string>(PropertyAliases.RadioButtonLabel));
         }
 
-        [TestCase(ElementTypeAliases.Select, false)]
-        [TestCase(ElementTypeAliases.Radios, true)]
+        [Theory]
+        [InlineData(ElementTypeAliases.Select, false)]
+        [InlineData(ElementTypeAliases.Radios, true)]
         public void OverrideSelectOptions_throws_ArgumentException_if_block_is_not_Select_component(string elementTypeAlias, bool exceptionExpected)
         {
             var testContext = new UmbracoTestContext();
@@ -178,11 +181,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
             else
             {
-                Assert.DoesNotThrow(() => content.Object.OverrideSelectOptions(Array.Empty<SelectOption>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                var exception = Record.Exception(() => content.Object.OverrideSelectOptions(Array.Empty<SelectOption>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                Assert.Null(exception);
             }
         }
 
-        [Test]
+        [Fact]
         public void OverrideSelectOptions_replaces_options()
         {
             // Arrange
@@ -220,16 +224,17 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             var options = content.Value<OverridableBlockListModel>(PropertyAliases.SelectOptions);
 
-            Assert.That(options, Is.Not.Null);
-            Assert.That(options!.Count(), Is.EqualTo(replacement.Count()));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.SelectOptionValue), Is.EqualTo("3"));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.SelectOptionLabel), Is.EqualTo("Item 3"));
-            Assert.That(options[1].Content.Value<string>(PropertyAliases.SelectOptionValue), Is.EqualTo("4"));
-            Assert.That(options[1].Content.Value<string>(PropertyAliases.SelectOptionLabel), Is.EqualTo("Item 4"));
+            Assert.NotNull(options);
+            Assert.Equal(replacement.Count(), options!.Count());
+            Assert.Equal("3", options![0].Content.Value<string>(PropertyAliases.SelectOptionValue));
+            Assert.Equal("Item 3", options![0].Content.Value<string>(PropertyAliases.SelectOptionLabel));
+            Assert.Equal("4", options[1].Content.Value<string>(PropertyAliases.SelectOptionValue));
+            Assert.Equal("Item 4", options[1].Content.Value<string>(PropertyAliases.SelectOptionLabel));
         }
 
-        [TestCase(ElementTypeAliases.SummaryCard, false)]
-        [TestCase(ElementTypeAliases.SummaryList, true)]
+        [Theory]
+        [InlineData(ElementTypeAliases.SummaryCard, false)]
+        [InlineData(ElementTypeAliases.SummaryList, true)]
         public void OverrideSummaryCardActions_throws_ArgumentException_if_block_is_not_Summary_card_component(string elementTypeAlias, bool exceptionExpected)
         {
             var testContext = new UmbracoTestContext();
@@ -241,11 +246,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
             else
             {
-                Assert.DoesNotThrow(() => content.Object.OverrideSummaryCardActions(Array.Empty<SummaryListAction>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                var exception = Record.Exception(() => content.Object.OverrideSummaryCardActions(Array.Empty<SummaryListAction>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                Assert.Null(exception);
             }
         }
 
-        [Test]
+        [Fact]
         public void OverrideSummaryCardActions_replaces_actions()
         {
             // Arrange
@@ -283,18 +289,19 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             var options = content.Value<OverridableBlockListModel>(PropertyAliases.SummaryCardActions);
 
-            Assert.That(options, Is.Not.Null);
-            Assert.That(options!.Count(), Is.EqualTo(replacement.Count()));
-            Assert.That(options![0].Content.Value<Link>(PropertyAliases.SummaryListActionLink)?.Url, Is.EqualTo("https://example.org/three"));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.SummaryListActionLinkText), Is.EqualTo("Item 3"));
-            Assert.That(options[1].Content.Value<Link>(PropertyAliases.SummaryListActionLink)?.Url, Is.EqualTo("https://example.org/four"));
-            Assert.That(options[1].Content.Value<string>(PropertyAliases.SummaryListActionLinkText), Is.EqualTo("Item 4"));
+            Assert.NotNull(options);
+            Assert.Equal(replacement.Count(), options!.Count());
+            Assert.Equal("https://example.org/three", options![0].Content.Value<Link>(PropertyAliases.SummaryListActionLink)?.Url);
+            Assert.Equal("Item 3", options![0].Content.Value<string>(PropertyAliases.SummaryListActionLinkText));
+            Assert.Equal("https://example.org/four", options[1].Content.Value<Link>(PropertyAliases.SummaryListActionLink)?.Url);
+            Assert.Equal("Item 4", options[1].Content.Value<string>(PropertyAliases.SummaryListActionLinkText));
         }
 
 
-        [TestCase(ElementTypeAliases.SummaryCard, false)]
-        [TestCase(ElementTypeAliases.SummaryList, false)]
-        [TestCase(ElementTypeAliases.Radios, true)]
+        [Theory]
+        [InlineData(ElementTypeAliases.SummaryCard, false)]
+        [InlineData(ElementTypeAliases.SummaryList, false)]
+        [InlineData(ElementTypeAliases.Radios, true)]
         public void OverrideSummaryListItems_throws_ArgumentException_if_block_is_not_Summary_card_or_Summary_list_component(string elementTypeAlias, bool exceptionExpected)
         {
             var testContext = new UmbracoTestContext();
@@ -306,12 +313,14 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
             else
             {
-                Assert.DoesNotThrow(() => content.Object.OverrideSummaryListItems(Array.Empty<SummaryListItem>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                var exception = Record.Exception(() => content.Object.OverrideSummaryListItems(Array.Empty<SummaryListItem>(), testContext.PublishedContentTypeCache.Object, testContext.VariationContextAccessor.Object));
+                Assert.Null(exception);
             }
         }
 
-        [TestCase(ElementTypeAliases.SummaryList, PropertyAliases.SummaryListItems)]
-        [TestCase(ElementTypeAliases.SummaryCard, PropertyAliases.SummaryCardListItems)]
+        [Theory]
+        [InlineData(ElementTypeAliases.SummaryList, PropertyAliases.SummaryListItems)]
+        [InlineData(ElementTypeAliases.SummaryCard, PropertyAliases.SummaryCardListItems)]
         public void OverrideSummaryListItems_replaces_items(string componentAlias, string listItemsPropertyAlias)
         {
             // Arrange
@@ -352,19 +361,19 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             var options = content.Value<OverridableBlockListModel>(listItemsPropertyAlias);
 
-            Assert.That(options, Is.Not.Null);
-            Assert.That(options!.Count(), Is.EqualTo(replacement.Count()));
-            Assert.That(options![0].Content.Value<string>(PropertyAliases.SummaryListItemKey), Is.EqualTo("3"));
-            Assert.That(options![0].Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue)?.ToHtmlString(), Is.EqualTo("Item 3"));
+            Assert.NotNull(options);
+            Assert.Equal(replacement.Count(), options!.Count());
+            Assert.Equal("3", options![0].Content.Value<string>(PropertyAliases.SummaryListItemKey));
+            Assert.Equal("Item 3", options![0].Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue)?.ToHtmlString());
 
             var actions = options[0].Content.Value<OverridableBlockListModel>(PropertyAliases.SummaryListItemActions);
-            Assert.That(actions, Is.Not.Null);
-            Assert.That(actions!.Count(), Is.EqualTo(replacement[0].Actions.Count));
-            Assert.That(actions![0].Content.Value<Link>(PropertyAliases.SummaryListActionLink)?.Url, Is.EqualTo("https://example.org/test"));
-            Assert.That(actions![0].Content.Value<string>(PropertyAliases.SummaryListActionLinkText), Is.EqualTo("Example"));
+            Assert.NotNull(actions);
+            Assert.Equal(replacement[0].Actions.Count, actions!.Count());
+            Assert.Equal("https://example.org/test", actions![0].Content.Value<Link>(PropertyAliases.SummaryListActionLink)?.Url);
+            Assert.Equal("Example", actions![0].Content.Value<string>(PropertyAliases.SummaryListActionLinkText));
 
-            Assert.That(options[1].Content.Value<string>(PropertyAliases.SummaryListItemKey), Is.EqualTo("4"));
-            Assert.That(options[1].Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue)?.ToHtmlString(), Is.EqualTo("Item 4"));
+            Assert.Equal("4", options[1].Content.Value<string>(PropertyAliases.SummaryListItemKey));
+            Assert.Equal("Item 4", options[1].Content.Value<IHtmlEncodedString>(PropertyAliases.SummaryListItemValue)?.ToHtmlString());
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/OverridableBlockModelExtensionsTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/OverridableBlockModelExtensionsTests.cs
@@ -1,4 +1,3 @@
-﻿using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks;
 using ThePensionsRegulator.Umbraco.Testing;
 
@@ -6,8 +5,9 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
 {
     public class OverridableBlockModelExtensionsTests
     {
-        [TestCase("Field1", true)]
-        [TestCase("Field2", false)]
+        [Theory]
+        [InlineData("Field1", true)]
+        [InlineData("Field2", false)]
         public void Block_is_matched_by_model_property(string propertyName, bool expected)
         {
             var blockList = UmbracoBlockListFactory.CreateOverridableBlockListModel(
@@ -25,7 +25,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             if (expected)
             {
-                Assert.AreEqual(blockList.First(), result);
+                Assert.Equal(blockList.First(), result);
             }
             else
             {
@@ -33,8 +33,9 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
         }
 
-        [TestCase("example-b", true)]
-        [TestCase("example-c", false)]
+        [Theory]
+        [InlineData("example-b", true)]
+        [InlineData("example-c", false)]
         public void Block_is_matched_by_class(string className, bool expected)
         {
             var blockList = UmbracoBlockListFactory.CreateOverridableBlockListModel(
@@ -52,7 +53,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             // Assert
             if (expected)
             {
-                Assert.AreEqual(blockList.First(), result);
+                Assert.Equal(blockList.First(), result);
             }
             else
             {
@@ -60,9 +61,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
         }
 
-        [TestCase("example-b", true)]
-        [TestCase("example-c", true)]
-        [TestCase("example-f", false)]
+        [Theory]
+        [InlineData("example-b", true)]
+        [InlineData("example-c", true)]
+        [InlineData("example-f", false)]
         public void Block_is_matched_by_class_from_multiple_block_lists(string className, bool expected)
         {
             var blockList1 = UmbracoBlockListFactory.CreateOverridableBlockListModel(
@@ -98,8 +100,9 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             }
         }
 
-        [TestCase("example-b", 2)]
-        [TestCase("example-f", 0)]
+        [Theory]
+        [InlineData("example-b", 2)]
+        [InlineData("example-f", 0)]
         public void Multiple_blocks_are_matched_by_class_from_multiple_block_lists(string className, int expected)
         {
             var blockList1 = UmbracoBlockListFactory.CreateOverridableBlockListModel(
@@ -125,7 +128,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = blockLists.FindBlocksByClass(className);
 
             // Assert
-            Assert.That(result.Count(), Is.EqualTo(expected));
+            Assert.Equal(expected, result.Count());
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/PublishedContentModelExtensionsTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/PublishedContentModelExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Moq;
-using NUnit.Framework;
+using Moq;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks;
 using ThePensionsRegulator.Umbraco.Testing;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -9,7 +8,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
 {
     public class PublishedContentModelExtensionsTests
     {
-        [Test]
+        [Fact]
         public void If_PageHeading_block_has_text_PageHeadingOrName_returns_text()
         {
             // Arrange
@@ -30,10 +29,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = model.PageHeadingOrName();
 
             // Assert
-            Assert.That(result, Is.EqualTo("Custom"));
+            Assert.Equal("Custom", result);
         }
 
-        [Test]
+        [Fact]
         public void If_PageHeading_block_has_no_text_PageHeadingOrName_returns_name()
         {
             // Arrange
@@ -53,10 +52,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = model.PageHeadingOrName();
 
             // Assert
-            Assert.That(result, Is.EqualTo("Page name"));
+            Assert.Equal("Page name", result);
         }
 
-        [Test]
+        [Fact]
         public void If_no_PageHeading_block_PageHeadingOrName_returns_name()
         {
             var testContext = new UmbracoTestContext();
@@ -67,7 +66,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
             var result = model.PageHeadingOrName();
 
             // Assert
-            Assert.That(result, Is.EqualTo("Page name"));
+            Assert.Equal("Page name", result);
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/TaskListTaskStatusProviderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/TaskListTaskStatusProviderTests.cs
@@ -1,4 +1,3 @@
-﻿using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks;
@@ -10,7 +9,6 @@ using Umbraco.Cms.Web.Common.PublishedModels;
 
 namespace GovUk.Frontend.Umbraco.Tests.Blocks
 {
-    [TestFixture]
     public class TaskListTaskStatusProviderTests
     {
         private static OverridableBlockListModel CreateBlockListWithTaskListSummaryAndTaskList(OverridableBlockListModel blockListOfTasks)
@@ -69,7 +67,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                                 );
         }
 
-        [Test]
+        [Fact]
         public void Null_content_throws_ArgumentNullException()
         {
             // Arrange
@@ -81,7 +79,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 #nullable enable
         }
 
-        [Test]
+        [Fact]
         public void Task_statuses_returned_from_BlockList()
         {
             // Arrange
@@ -96,12 +94,12 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             var result = provider.FindTaskStatuses(content.Object).ToList();
 
             // Assert
-            Assert.That(result.Count, Is.EqualTo(2));
-            Assert.That(result.Contains(TaskListTaskStatus.Completed));
-            Assert.That(result.Contains(TaskListTaskStatus.Incomplete));
+            Assert.Equal(2, result.Count);
+            Assert.Contains(TaskListTaskStatus.Completed, result);
+            Assert.Contains(TaskListTaskStatus.Incomplete, result);
         }
 
-        [Test]
+        [Fact]
         public void Task_statuses_returned_from_BlockGrid()
         {
             // Arrange
@@ -116,12 +114,12 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             var result = provider.FindTaskStatuses(content.Object).ToList();
 
             // Assert
-            Assert.That(result.Count, Is.EqualTo(2));
-            Assert.That(result.Contains(TaskListTaskStatus.Completed));
-            Assert.That(result.Contains(TaskListTaskStatus.Incomplete));
+            Assert.Equal(2, result.Count);
+            Assert.Contains(TaskListTaskStatus.Completed, result);
+            Assert.Contains(TaskListTaskStatus.Incomplete, result);
         }
 
-        [Test]
+        [Fact]
         public void BlockList_filter_is_applied_for_tasks()
         {
             // Arrange
@@ -137,11 +135,11 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             var result = provider.FindTaskStatuses(content.Object).ToList();
 
             // Assert
-            Assert.That(result.Count, Is.EqualTo(1));
-            Assert.That(result.Contains(TaskListTaskStatus.Completed));
+            Assert.Single(result);
+            Assert.Contains(TaskListTaskStatus.Completed, result);
         }
 
-        [Test]
+        [Fact]
         public void BlockGrid_filter_is_applied_for_tasks()
         {
             // Arrange
@@ -157,11 +155,11 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             var result = provider.FindTaskStatuses(content.Object).ToList();
 
             // Assert
-            Assert.That(result.Count, Is.EqualTo(1));
-            Assert.That(result.Contains(TaskListTaskStatus.Completed));
+            Assert.Single(result);
+            Assert.Contains(TaskListTaskStatus.Completed, result);
         }
 
-        [Test]
+        [Fact]
         public void Overridden_status_is_applied_for_tasks()
         {
             // Arrange
@@ -187,8 +185,8 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             var result = provider.FindTaskStatuses(content.Object).ToList();
 
             // Assert
-            Assert.That(result.Count, Is.EqualTo(1));
-            Assert.That(result.Contains(TaskListTaskStatus.NotStarted));
+            Assert.Single(result);
+            Assert.Contains(TaskListTaskStatus.NotStarted, result);
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Caching/GovUkUmbracoStaticFileCachePolicyTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Caching/GovUkUmbracoStaticFileCachePolicyTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Http;
-using NUnit.Framework;
 using System.Web;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Caching;
 
@@ -9,30 +8,30 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Caching
     {
         private readonly GovUkUmbracoStaticFileCachePolicy _policy = new();
 
-        [Test]
-        [TestCase("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk-component-hfdksfhks.js", true)]
-        [TestCase("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/package-version.generated-hjrkehwrk.js", true)]
-        [TestCase("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/example-helper-code-hdjskhfjds.js", true)]
-        [TestCase("/ThePensionsRegulator.GovUk.Frontend.Umbraco/css/govuk-frontend.css?v=1.0.0", true)]
-        [TestCase("/css/govuk-umbraco-backoffice.css?v=1.0.0", true)]
-        [TestCase("/THEPENSIONSREGULATOR.GOVUK.FRONTEND.UMBRACO/CSS/GOVUK-FRONTEND.CSS?v=1.0.0", true)]
+        [Theory]
+        [InlineData("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk-component-hfdksfhks.js", true)]
+        [InlineData("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/package-version.generated-hjrkehwrk.js", true)]
+        [InlineData("/App_Plugins/ThePensionsRegulator.GovUk.Frontend.Umbraco/example-helper-code-hdjskhfjds.js", true)]
+        [InlineData("/ThePensionsRegulator.GovUk.Frontend.Umbraco/css/govuk-frontend.css?v=1.0.0", true)]
+        [InlineData("/css/govuk-umbraco-backoffice.css?v=1.0.0", true)]
+        [InlineData("/THEPENSIONSREGULATOR.GOVUK.FRONTEND.UMBRACO/CSS/GOVUK-FRONTEND.CSS?v=1.0.0", true)]
 
         // no path
-        [TestCase("?v=1.0.0", false)]
+        [InlineData("?v=1.0.0", false)]
 
         // wrong path
-        [TestCase("/_content/OtherPackage/style.css?v=1.0.0", false)]
-        [TestCase("/_content/ThePensionsRegulator/style.css?v=1.0.0", false)]
-        [TestCase("/other-content/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk-component-hfjdkfs.js", false)]
+        [InlineData("/_content/OtherPackage/style.css?v=1.0.0", false)]
+        [InlineData("/_content/ThePensionsRegulator/style.css?v=1.0.0", false)]
+        [InlineData("/other-content/ThePensionsRegulator.GovUk.Frontend.Umbraco/govuk-component-hfjdkfs.js", false)]
 
         // no querystring
-        [TestCase("/ThePensionsRegulator.GovUk.Frontend.Umbraco/css/govuk-frontend.css", false)]
-        [TestCase("/css/govuk-umbraco-backoffice.css", false)]
-        [TestCase("/other/file.js", false)]
+        [InlineData("/ThePensionsRegulator.GovUk.Frontend.Umbraco/css/govuk-frontend.css", false)]
+        [InlineData("/css/govuk-umbraco-backoffice.css", false)]
+        [InlineData("/other/file.js", false)]
 
         // wrong querystring
-        [TestCase("/ThePensionsRegulator.GovUk.Frontend.Umbraco/css/govuk-frontend.css?other=value", false)]
-        [TestCase("/css/govuk-umbraco-backoffice.css?v=", false)]
+        [InlineData("/ThePensionsRegulator.GovUk.Frontend.Umbraco/css/govuk-frontend.css?other=value", false)]
+        [InlineData("/css/govuk-umbraco-backoffice.css?v=", false)]
         public void IsImmutable_ReturnsExpectedResult(string path, bool expected)
         {
             // Arrange
@@ -44,7 +43,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Caching
             var result = _policy.IsImmutable(path, new QueryCollection(dict));
 
             // Assert
-            Assert.That(result, Is.EqualTo(expected));
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/HtmlGeneration/DateInputHtmlEnhancerTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/HtmlGeneration/DateInputHtmlEnhancerTests.cs
@@ -1,10 +1,8 @@
-﻿using HtmlAgilityPack;
-using NUnit.Framework;
+using HtmlAgilityPack;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.HtmlGeneration;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.HtmlGeneration
 {
-    [TestFixture]
     public class DateInputHtmlEnhancerTests
     {
         private const string DATE_INPUT_HTML = @"
@@ -31,7 +29,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.HtmlGeneration
                 </div>
             </div>";
 
-        [Test]
+        [Fact]
         public void When_DayEnabled_Is_True_And_YearEnabled_Is_True_Html_Is_Unchanged()
         {
             // Arrange
@@ -41,10 +39,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.HtmlGeneration
             var result = enhancer.EnhanceHtml(DATE_INPUT_HTML, true, true);
 
             // Assert
-            Assert.That(result, Is.EqualTo(DATE_INPUT_HTML));
+            Assert.Equal(DATE_INPUT_HTML, result);
         }
 
-        [Test]
+        [Fact]
         public void When_DayEnabled_Is_False_Day_Field_Is_Removed()
         {
             // Arrange
@@ -57,13 +55,13 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.HtmlGeneration
             var doc = new HtmlDocument();
             doc.LoadHtml(result);
 
-            Assert.That(doc.DocumentNode.SelectNodes("//div[@class='govuk-date-input__item']").Count, Is.EqualTo(2));
-            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Day']"), Is.Null);
-            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Month']").Count, Is.EqualTo(1));
-            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Year']").Count, Is.EqualTo(1));
+            Assert.Equal(2, doc.DocumentNode.SelectNodes("//div[@class='govuk-date-input__item']").Count);
+            Assert.Null(doc.DocumentNode.SelectNodes("//input[@id='Example.Day']"));
+            Assert.Single(doc.DocumentNode.SelectNodes("//input[@id='Example.Month']"));
+            Assert.Single(doc.DocumentNode.SelectNodes("//input[@id='Example.Year']"));
         }
 
-        [Test]
+        [Fact]
         public void When_YearEnabled_Is_False_Year_Field_Is_Removed()
         {
             // Arrange
@@ -76,10 +74,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.HtmlGeneration
             var doc = new HtmlDocument();
             doc.LoadHtml(result);
 
-            Assert.That(doc.DocumentNode.SelectNodes("//div[@class='govuk-date-input__item']").Count, Is.EqualTo(2));
-            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Day']").Count, Is.EqualTo(1));
-            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Month']").Count, Is.EqualTo(1));
-            Assert.That(doc.DocumentNode.SelectNodes("//input[@id='Example.Year']"), Is.Null);
+            Assert.Equal(2, doc.DocumentNode.SelectNodes("//div[@class='govuk-date-input__item']").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//input[@id='Example.Day']"));
+            Assert.Single(doc.DocumentNode.SelectNodes("//input[@id='Example.Month']"));
+            Assert.Null(doc.DocumentNode.SelectNodes("//input[@id='Example.Year']"));
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -1,6 +1,5 @@
 using GovUk.Frontend.AspNetCore;
 using GovUk.Frontend.AspNetCore.ModelBinding;
-using GovUk.Frontend.Umbraco.Tests;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -8,7 +7,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Moq;
 using Moq.Protected;
-using NUnit.Framework;
 using System.Reflection;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.ModelBinding;
 using ThePensionsRegulator.Umbraco.Core;
@@ -24,8 +22,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
         private UmbracoTestContext _testContext;
 #nullable enable
 
-        [SetUp]
-        public void SetUp()
+        public UmbracoDateInputModelBinderTests()
         {
             _testContext = new();
         }
@@ -40,7 +37,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
                     _testContext.UmbracoHelperAccessor.Object
                 );
 
-        [Test]
+        [Fact]
         public async Task BindModelAsync_BackOfficeRequest_DoesNotBind()
         {
             // Arrange
@@ -73,7 +70,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             Assert.False(bindingContext.Result.IsModelSet);
         }
 
-        [Test]
+        [Fact]
         public async Task BindModelAsync_AllComponentsEmpty_DoesNotBind()
         {
             // Arrange
@@ -99,7 +96,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             Assert.False(bindingContext.Result.IsModelSet);
         }
 
-        [Test]
+        [Fact]
         public async Task BindModelAsync_CompleteDate_AllComponentsProvided_PassesValuesToConverterAndBindsResult()
         {
             // Arrange
@@ -137,20 +134,20 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
 
             Assert.True(bindingContext.Result.IsModelSet);
 
-            Assert.IsInstanceOf<DateOnly>(bindingContext.Result.Model);
+            Assert.IsType<DateOnly>(bindingContext.Result.Model);
             var date = (DateOnly)bindingContext.Result.Model!;
-            Assert.AreEqual(2020, date.Year);
-            Assert.AreEqual(4, date.Month);
-            Assert.AreEqual(1, date.Day);
+            Assert.Equal(2020, date.Year);
+            Assert.Equal(4, date.Month);
+            Assert.Equal(1, date.Day);
 
-            Assert.AreEqual("2020", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
-            Assert.AreEqual("4", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
-            Assert.AreEqual("1", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
+            Assert.Equal("2020", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
+            Assert.Equal("4", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
+            Assert.Equal("1", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
 
-            Assert.AreEqual(0, bindingContext.ModelState.ErrorCount);
+            Assert.Equal(0, bindingContext.ModelState.ErrorCount);
         }
 
-        [Test]
+        [Fact]
         public async Task BindModelAsync_MonthAndYear_AllComponentsProvided_PassesValuesToConverterAndBindsResult()
         {
             // Arrange
@@ -199,20 +196,20 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
 
             Assert.True(bindingContext.Result.IsModelSet);
 
-            Assert.IsInstanceOf<DateOnly>(bindingContext.Result.Model);
+            Assert.IsType<DateOnly>(bindingContext.Result.Model);
             var date = (DateOnly)bindingContext.Result.Model!;
-            Assert.AreEqual(2020, date.Year);
-            Assert.AreEqual(4, date.Month);
-            Assert.AreEqual(1, date.Day);
+            Assert.Equal(2020, date.Year);
+            Assert.Equal(4, date.Month);
+            Assert.Equal(1, date.Day);
 
-            Assert.AreEqual("2020", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
-            Assert.AreEqual("4", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
-            Assert.AreEqual(null, bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
+            Assert.Equal("2020", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
+            Assert.Equal("4", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
+            Assert.Null(bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
 
-            Assert.AreEqual(0, bindingContext.ModelState.ErrorCount);
+            Assert.Equal(0, bindingContext.ModelState.ErrorCount);
         }
 
-        [Test]
+        [Fact]
         public async Task BindModelAsync_DayAndMonth_AllComponentsProvided_PassesValuesToConverterAndBindsResult()
         {
             // Arrange
@@ -261,32 +258,33 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
 
             Assert.True(bindingContext.Result.IsModelSet);
 
-            Assert.IsInstanceOf<DateOnly>(bindingContext.Result.Model);
+            Assert.IsType<DateOnly>(bindingContext.Result.Model);
             var date = (DateOnly)bindingContext.Result.Model!;
-            Assert.AreEqual(1900, date.Year);
-            Assert.AreEqual(12, date.Month);
-            Assert.AreEqual(25, date.Day);
+            Assert.Equal(1900, date.Year);
+            Assert.Equal(12, date.Month);
+            Assert.Equal(25, date.Day);
 
-            Assert.AreEqual(null, bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
-            Assert.AreEqual("12", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
-            Assert.AreEqual("25", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
+            Assert.Null(bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Year"]?.AttemptedValue);
+            Assert.Equal("12", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Month"]?.AttemptedValue);
+            Assert.Equal("25", bindingContext.ModelState[$"{nameof(ExampleModel.DateProperty)}.Day"]?.AttemptedValue);
 
-            Assert.AreEqual(0, bindingContext.ModelState.ErrorCount);
+            Assert.Equal(0, bindingContext.ModelState.ErrorCount);
         }
 
-        [TestCase("", "4", "2020")]
-        [TestCase("1", "", "2020")]
-        [TestCase("1", "4", "")]
-        [TestCase("0", "4", "2020")]
-        [TestCase("-1", "4", "2020")]
-        [TestCase("32", "4", "2020")]
-        [TestCase("1", "0", "2020")]
-        [TestCase("1", "-1", "2020")]
-        [TestCase("1", "13", "2020")]
-        [TestCase("1", "4", "0")]
-        [TestCase("1", "4", "-1")]
-        [TestCase("1", "4", "10000")]
-        [TestCase("x", "y", "z")]
+        [Theory]
+        [InlineData("", "4", "2020")]
+        [InlineData("1", "", "2020")]
+        [InlineData("1", "4", "")]
+        [InlineData("0", "4", "2020")]
+        [InlineData("-1", "4", "2020")]
+        [InlineData("32", "4", "2020")]
+        [InlineData("1", "0", "2020")]
+        [InlineData("1", "-1", "2020")]
+        [InlineData("1", "13", "2020")]
+        [InlineData("1", "4", "0")]
+        [InlineData("1", "4", "-1")]
+        [InlineData("1", "4", "10000")]
+        [InlineData("x", "y", "z")]
         public async Task BindModelAsync_MissingOrInvalidComponents_FailsBinding(string day, string month, string year)
         {
             // Arrange
@@ -326,15 +324,15 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             await modelBinder.BindModelAsync(bindingContext);
 
             // Assert
-            Assert.AreEqual(ModelBindingResult.Failed(), bindingContext.Result);
+            Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
 
-            Assert.AreEqual(day, bindingContext.ModelState["TheModelName.Day"]?.AttemptedValue);
-            Assert.AreEqual(month, bindingContext.ModelState["TheModelName.Month"]?.AttemptedValue);
-            Assert.AreEqual(year, bindingContext.ModelState["TheModelName.Year"]?.AttemptedValue);
+            Assert.Equal(day, bindingContext.ModelState["TheModelName.Day"]?.AttemptedValue);
+            Assert.Equal(month, bindingContext.ModelState["TheModelName.Month"]?.AttemptedValue);
+            Assert.Equal(year, bindingContext.ModelState["TheModelName.Year"]?.AttemptedValue);
         }
 
-        [Test]
-        public void BindModelAsync_CannotAccessUmbracoHelper()
+        [Fact]
+        public async Task BindModelAsync_CannotAccessUmbracoHelper()
         {
             // Arrange
             var modelType = typeof(DateOnly);
@@ -360,25 +358,23 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             _testContext.UmbracoHelperAccessor.Setup(x => x.TryGetUmbracoHelper(out nullUmbracoHelper)).Returns(false);
 
             // Act / Assert
-            Assert.Multiple(() =>
-            {
-                var exc = Assert.ThrowsAsync<InvalidOperationException>(() => modelBinder.BindModelAsync(bindingContext));
-                Assert.That(exc?.Message, Is.EqualTo("Unable to access Umbraco helper"));
-            });
+            var exc = await Assert.ThrowsAsync<InvalidOperationException>(() => modelBinder.BindModelAsync(bindingContext));
+            Assert.Equal("Unable to access Umbraco helper", exc.Message);
         }
 
-        [TestCase(DateInputParseErrors.MissingYear, $"{nameof(ExampleModel.DateProperty)} must include a year")]
-        [TestCase(DateInputParseErrors.InvalidYear, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
-        [TestCase(DateInputParseErrors.MissingMonth, $"{nameof(ExampleModel.DateProperty)} must include a month")]
-        [TestCase(DateInputParseErrors.InvalidMonth, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
-        [TestCase(DateInputParseErrors.InvalidDay, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
-        [TestCase(DateInputParseErrors.MissingDay, $"{nameof(ExampleModel.DateProperty)} must include a day")]
-        [TestCase(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingMonth, $"{nameof(ExampleModel.DateProperty)} must include a month and year")]
-        [TestCase(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingDay, $"{nameof(ExampleModel.DateProperty)} must include a day and year")]
-        [TestCase(DateInputParseErrors.MissingMonth | DateInputParseErrors.MissingDay, $"{nameof(ExampleModel.DateProperty)} must include a day and month")]
-        [TestCase(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
-        [TestCase(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
-        [TestCase(DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
+        [Theory]
+        [InlineData(DateInputParseErrors.MissingYear, $"{nameof(ExampleModel.DateProperty)} must include a year")]
+        [InlineData(DateInputParseErrors.InvalidYear, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
+        [InlineData(DateInputParseErrors.MissingMonth, $"{nameof(ExampleModel.DateProperty)} must include a month")]
+        [InlineData(DateInputParseErrors.InvalidMonth, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
+        [InlineData(DateInputParseErrors.InvalidDay, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
+        [InlineData(DateInputParseErrors.MissingDay, $"{nameof(ExampleModel.DateProperty)} must include a day")]
+        [InlineData(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingMonth, $"{nameof(ExampleModel.DateProperty)} must include a month and year")]
+        [InlineData(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingDay, $"{nameof(ExampleModel.DateProperty)} must include a day and year")]
+        [InlineData(DateInputParseErrors.MissingMonth | DateInputParseErrors.MissingDay, $"{nameof(ExampleModel.DateProperty)} must include a day and month")]
+        [InlineData(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
+        [InlineData(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
+        [InlineData(DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, $"{nameof(ExampleModel.DateProperty)} must be a real date")]
         public void GetModelStateErrorMessageReturnsDefaultErrorMessage(DateInputParseErrors parseErrors, string expectedMessage)
         {
             // Arrange
@@ -389,21 +385,22 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             var result = UmbracoDateInputModelBinder.GetModelStateErrorMessage(Mock.Of<IOverridablePublishedElement>(), _testContext.CultureDictionaryForCurrentUICulture.Object, parseErrors, modelMetadata, _testContext.UmbracoHelper);
 
             // Assert
-            Assert.AreEqual(expectedMessage, result);
+            Assert.Equal(expectedMessage, result);
         }
 
-        [TestCase(DateInputParseErrors.MissingYear, DictionaryConstants.DateMustIncludeAYear, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.InvalidYear, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.MissingMonth, DictionaryConstants.DateMustIncludeAMonth, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.InvalidMonth, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.InvalidDay, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.MissingDay, DictionaryConstants.DateMustIncludeADay, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingMonth, DictionaryConstants.DateMustIncludeAMonthAndYear, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingDay, DictionaryConstants.DateMustIncludeADayAndYear, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.MissingMonth | DateInputParseErrors.MissingDay, DictionaryConstants.DateMustIncludeADayAndMonth, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
-        [TestCase(DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [Theory]
+        [InlineData(DateInputParseErrors.MissingYear, DictionaryConstants.DateMustIncludeAYear, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.InvalidYear, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.MissingMonth, DictionaryConstants.DateMustIncludeAMonth, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.InvalidMonth, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.InvalidDay, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.MissingDay, DictionaryConstants.DateMustIncludeADay, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingMonth, DictionaryConstants.DateMustIncludeAMonthAndYear, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.MissingYear | DateInputParseErrors.MissingDay, DictionaryConstants.DateMustIncludeADayAndYear, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.MissingMonth | DateInputParseErrors.MissingDay, DictionaryConstants.DateMustIncludeADayAndMonth, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.InvalidYear | DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
+        [InlineData(DateInputParseErrors.InvalidMonth | DateInputParseErrors.InvalidDay, DictionaryConstants.DateMustBeARealDate, $"{nameof(ExampleModel.DateProperty)}: custom error message")]
         public void GetModelStateErrorMessageReturnsCustomErrorMessage(DateInputParseErrors parseErrors, string dictionaryConstant, string expectedMessage)
         {
             // Arrange
@@ -416,16 +413,17 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             var result = UmbracoDateInputModelBinder.GetModelStateErrorMessage(Mock.Of<IOverridablePublishedElement>(), _testContext.CultureDictionaryForCurrentUICulture.Object, parseErrors, modelMetadata, _testContext.UmbracoHelper);
 
             // Assert
-            Assert.AreEqual(expectedMessage, result);
+            Assert.Equal(expectedMessage, result);
         }
 
-        [TestCase(DateInputItemTypes.MonthAndYear, null, "3", 3, "2020")]
-        [TestCase(DateInputItemTypes.DayMonthAndYear, "1", "1", 1, "2020")]
-        [TestCase(DateInputItemTypes.DayMonthAndYear, "29", "2", 2, "2020")]
-        [TestCase(DateInputItemTypes.DayMonthAndYear, "31", "12", 12, "2020")]
-        [TestCase(DateInputItemTypes.DayMonthAndYear, "31", "dec", 12, "2020")]
-        [TestCase(DateInputItemTypes.DayMonthAndYear, "31", "January", 1, "2020")]
-        [TestCase(DateInputItemTypes.DayMonthAndYear, "29", "February", 2, "2024")]
+        [Theory]
+        [InlineData(DateInputItemTypes.MonthAndYear, null, "3", 3, "2020")]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "1", 1, "2020")]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "29", "2", 2, "2020")]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "31", "12", 12, "2020")]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "31", "dec", 12, "2020")]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "31", "January", 1, "2020")]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "29", "February", 2, "2024")]
         public void Parse_ValidDate_Returns_Date(DateInputItemTypes itemTypes, string? day, string month, int expectedMonth, string year)
         {
             // Arrange
@@ -434,40 +432,41 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             var result = UmbracoDateInputModelBinder.Parse(itemTypes, day, month, year, true, out var parsed);
 
             // Assert
-            Assert.That(result, Is.EqualTo(DateInputParseErrors.None));
+            Assert.Equal(DateInputParseErrors.None, result);
 
             var expectedDay = (itemTypes & DateInputItemTypes.Day) != 0 ? int.Parse(day!) : 1;
             var expectedYear = int.Parse(year);
-            Assert.That(expectedDay, Is.EqualTo(parsed.Day));
-            Assert.That(expectedMonth, Is.EqualTo(parsed.Month));
-            Assert.That(expectedYear, Is.EqualTo(parsed.Year));
+            Assert.Equal(parsed.Day, expectedDay);
+            Assert.Equal(parsed.Month, expectedMonth);
+            Assert.Equal(parsed.Year, expectedYear);
         }
 
-        [TestCase("", "4", "2020", false, DateInputParseErrors.MissingDay)]
-        [TestCase(null, "4", "2020", false, DateInputParseErrors.MissingDay)]
-        [TestCase("1", "", "2020", false, DateInputParseErrors.MissingMonth)]
-        [TestCase("1", null, "2020", false, DateInputParseErrors.MissingMonth)]
-        [TestCase("1", "4", null, false, DateInputParseErrors.MissingYear)]
-        [TestCase("1", "4", "", false, DateInputParseErrors.MissingYear)]
-        [TestCase("0", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [TestCase("-1", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [TestCase("32", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [TestCase("x", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [TestCase("1", "0", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [TestCase("1", "-1", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [TestCase("1", "13", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [TestCase("1", "x", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [TestCase("1", "4", "15", false, DateInputParseErrors.InvalidYear)]
-        [TestCase("1", "4", "0", false, DateInputParseErrors.InvalidYear)]
-        [TestCase("1", "4", "-1", false, DateInputParseErrors.InvalidYear)]
-        [TestCase("1", "4", "10000", false, DateInputParseErrors.InvalidYear)]
-        [TestCase("1", "4", "x", false, DateInputParseErrors.InvalidYear)]
-        [TestCase("1", "x", "2020", true, DateInputParseErrors.InvalidMonth)]
-        [TestCase("1", "dec", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [TestCase("31", "January", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [TestCase("29", "February", "2023", true, DateInputParseErrors.InvalidDay)]
+        [Theory]
+        [InlineData("", "4", "2020", false, DateInputParseErrors.MissingDay)]
+        [InlineData(null, "4", "2020", false, DateInputParseErrors.MissingDay)]
+        [InlineData("1", "", "2020", false, DateInputParseErrors.MissingMonth)]
+        [InlineData("1", null, "2020", false, DateInputParseErrors.MissingMonth)]
+        [InlineData("1", "4", null, false, DateInputParseErrors.MissingYear)]
+        [InlineData("1", "4", "", false, DateInputParseErrors.MissingYear)]
+        [InlineData("0", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData("-1", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData("32", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData("x", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData("1", "0", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData("1", "-1", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData("1", "13", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData("1", "x", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData("1", "4", "15", false, DateInputParseErrors.InvalidYear)]
+        [InlineData("1", "4", "0", false, DateInputParseErrors.InvalidYear)]
+        [InlineData("1", "4", "-1", false, DateInputParseErrors.InvalidYear)]
+        [InlineData("1", "4", "10000", false, DateInputParseErrors.InvalidYear)]
+        [InlineData("1", "4", "x", false, DateInputParseErrors.InvalidYear)]
+        [InlineData("1", "x", "2020", true, DateInputParseErrors.InvalidMonth)]
+        [InlineData("1", "dec", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData("31", "January", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData("29", "February", "2023", true, DateInputParseErrors.InvalidDay)]
         public void Parse_InvalidDate_ComputesExpectedParseErrors(
-            string day, string month, string year, bool acceptMonthNames, DateInputParseErrors expectedParseErrors)
+            string? day, string? month, string? year, bool acceptMonthNames, DateInputParseErrors expectedParseErrors)
         {
             // Arrange
 
@@ -475,10 +474,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
             var result = UmbracoDateInputModelBinder.Parse(DateInputItemTypes.DayMonthAndYear, day, month, year, acceptMonthNames, out var dateComponents);
 
             // Assert
-            Assert.AreEqual(null, dateComponents.Day);
-            Assert.AreEqual(null, dateComponents.Month);
-            Assert.AreEqual(null, dateComponents.Year);
-            Assert.AreEqual(expectedParseErrors, result);
+            Assert.Null(dateComponents.Day);
+            Assert.Null(dateComponents.Month);
+            Assert.Null(dateComponents.Year);
+            Assert.Equal(expectedParseErrors, result);
         }
 
         private ActionContext CreateActionContext() => new ActionContext(_testContext.HttpContext.Object, new RouteData(), new ActionDescriptor());

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/GovUkTypographyPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/GovUkTypographyPropertyValueFormatterTests.cs
@@ -1,4 +1,3 @@
-﻿using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters;
 using ThePensionsRegulator.Umbraco.Testing;
 using Umbraco.Cms.Core;
@@ -7,11 +6,11 @@ using Umbraco.Cms.Core.Strings;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
 {
-    [TestFixture]
     public class GovUkTypographyPropertyValueFormatterTests
     {
-        [TestCase(Constants.PropertyEditors.Aliases.RichText, true)]
-        [TestCase("someOtherPropertyEditor", false)]
+        [Theory]
+        [InlineData(Constants.PropertyEditors.Aliases.RichText, true)]
+        [InlineData("someOtherPropertyEditor", false)]
         public void Applies_only_to_correct_rich_text_property_editor(string propertyEditorAlias, bool expected)
         {
             // Arrange
@@ -22,10 +21,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
             var result = formatter.IsFormatter(propertyType);
 
             // Assert
-            Assert.That(result, Is.EqualTo(expected));
+            Assert.Equal(expected, result);
         }
 
-        [Test]
+        [Fact]
         public void Accepts_string_or_HtmlEncodedString_as_input()
         {
             // Arrange
@@ -38,64 +37,67 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
 
             // Assert
-            Assert.That(((HtmlEncodedString)resultOfString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
-            Assert.That(((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfString)?.ToHtmlString());
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_ordered_lists()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromOrderedLists(
                 new GovUkTypographyPropertyValueFormatter());
         }
 
-        [TestCase("lower-alpha")]
-        [TestCase("lower-greek")]
-        [TestCase("lower-roman")]
-        [TestCase("upper-alpha")]
-        [TestCase("upper-roman")]
+        [Theory]
+        [InlineData("lower-alpha")]
+        [InlineData("lower-greek")]
+        [InlineData("lower-roman")]
+        [InlineData("upper-alpha")]
+        [InlineData("upper-roman")]
         public void Permitted_style_attribute_is_converted_to_class_from_ordered_lists(string listStyleType)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnOrderedLists(
                 new GovUkTypographyPropertyValueFormatter(), listStyleType);
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_unordered_lists()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromUnorderedLists(
                 new GovUkTypographyPropertyValueFormatter());
         }
 
-        [TestCase("circle")]
-        [TestCase("square")]
+        [Theory]
+        [InlineData("circle")]
+        [InlineData("square")]
         public void Permitted_style_attribute_is_converted_to_class_on_unordered_lists(string listStyleType)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnUnorderedLists(
                 new GovUkTypographyPropertyValueFormatter(), listStyleType);
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_paragraphs()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromParagraphs(
                 new GovUkTypographyPropertyValueFormatter());
         }
 
-        [TestCase("text-align: center", "govuk-!-text-align-centre")]
-        [TestCase("text-align: right", "govuk-!-text-align-right")]
-        [TestCase("padding-left: 40px", "govuk-!-padding-left-7")]
-        [TestCase("padding-left: 80px", "govuk-!-padding-left-14")]
-        [TestCase("padding-left: 120px", "govuk-!-padding-left-21")]
-        [TestCase("padding-left: 160px", "govuk-!-padding-left-28")]
-        [TestCase("padding-left: 200px", "govuk-!-padding-left-35")]
+        [Theory]
+        [InlineData("text-align: center", "govuk-!-text-align-centre")]
+        [InlineData("text-align: right", "govuk-!-text-align-right")]
+        [InlineData("padding-left: 40px", "govuk-!-padding-left-7")]
+        [InlineData("padding-left: 80px", "govuk-!-padding-left-14")]
+        [InlineData("padding-left: 120px", "govuk-!-padding-left-21")]
+        [InlineData("padding-left: 160px", "govuk-!-padding-left-28")]
+        [InlineData("padding-left: 200px", "govuk-!-padding-left-35")]
         public void Permitted_style_attribute_is_converted_to_class_on_paragraphs(string styleAttribute, string expectedClass)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnParagraphs(
                 new GovUkTypographyPropertyValueFormatter(), styleAttribute, expectedClass);
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_other_elements()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromOtherElements(

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphInversePropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphInversePropertyValueFormatterTests.cs
@@ -1,4 +1,3 @@
-﻿using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters;
 using ThePensionsRegulator.Umbraco.Testing;
 using Umbraco.Cms.Core;
@@ -7,12 +6,12 @@ using Umbraco.Cms.Core.Strings;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
 {
-    [TestFixture]
     public class NoParagraphInversePropertyValueFormatterTests
     {
-        [TestCase(ElementTypeAliases.Panel, "someOtherProperty", false)]
-        [TestCase("someOtherElementType", PropertyAliases.PanelText, false)]
-        [TestCase(ElementTypeAliases.Panel, PropertyAliases.PanelText, true)]
+        [Theory]
+        [InlineData(ElementTypeAliases.Panel, "someOtherProperty", false)]
+        [InlineData("someOtherElementType", PropertyAliases.PanelText, false)]
+        [InlineData(ElementTypeAliases.Panel, PropertyAliases.PanelText, true)]
         public void Applies_only_to_correct_rich_text_property(string contentTypeAlias, string propertyAlias, bool expected)
         {
             // Arrange
@@ -23,10 +22,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
             var result = formatter.IsFormatter(propertyType);
 
             // Assert
-            Assert.That(result, Is.EqualTo(expected));
+            Assert.Equal(expected, result);
         }
 
-        [Test]
+        [Fact]
         public void Accepts_string_or_HtmlEncodedString_as_input()
         {
             // Arrange
@@ -39,73 +38,76 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
 
             // Assert
-            Assert.That(((HtmlEncodedString)resultOfString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
-            Assert.That(((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfString)?.ToHtmlString());
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
         }
 
-        [Test]
+        [Fact]
         public void Single_wrapping_paragraph_with_no_class_is_removed()
         {
             TinyMCEValueFormattersTestHelper.SingleWrappingParagraphWithNoClassIsRemoved(
                 new NoParagraphInversePropertyValueFormatter());
         }
 
-        [Test]
+        [Fact]
         public void Single_wrapping_paragraph_with_class_is_left_alone()
         {
             TinyMCEValueFormattersTestHelper.SingleWrappingParagraphWithClassIsLeftAlone(
                 new NoParagraphInversePropertyValueFormatter());
         }
 
-        [Test]
+        [Fact]
         public void Multiple_wrapping_paragraphs_are_left_alone()
         {
             TinyMCEValueFormattersTestHelper.MultipleWrappingParagraphsAreLeftAlone(
                  new NoParagraphInversePropertyValueFormatter());
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_ordered_lists()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromOrderedLists(
                 new NoParagraphInversePropertyValueFormatter());
         }
 
-        [TestCase("lower-alpha")]
-        [TestCase("lower-greek")]
-        [TestCase("lower-roman")]
-        [TestCase("upper-alpha")]
-        [TestCase("upper-roman")]
+        [Theory]
+        [InlineData("lower-alpha")]
+        [InlineData("lower-greek")]
+        [InlineData("lower-roman")]
+        [InlineData("upper-alpha")]
+        [InlineData("upper-roman")]
         public void Permitted_style_attribute_is_converted_to_class_from_ordered_lists(string listStyleType)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnOrderedLists(
                 new NoParagraphInversePropertyValueFormatter(), listStyleType);
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_unordered_lists()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromUnorderedLists(
                 new NoParagraphInversePropertyValueFormatter());
         }
 
-        [TestCase("circle")]
-        [TestCase("square")]
+        [Theory]
+        [InlineData("circle")]
+        [InlineData("square")]
         public void Permitted_style_attribute_is_converted_to_class_on_unordered_lists(string listStyleType)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnUnorderedLists(
                 new NoParagraphInversePropertyValueFormatter(), listStyleType);
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_paragraphs()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromParagraphs(
                 new NoParagraphInversePropertyValueFormatter());
         }
 
-        [TestCase("text-align: center", "govuk-!-text-align-centre")]
-        [TestCase("text-align: right", "govuk-!-text-align-right")]
+        [Theory]
+        [InlineData("text-align: center", "govuk-!-text-align-centre")]
+        [InlineData("text-align: right", "govuk-!-text-align-right")]
         public void Permitted_style_attribute_is_converted_to_class_on_paragraphs(string styleAttribute, string expectedClass)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnParagraphs(

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/NoParagraphPropertyValueFormatterTests.cs
@@ -1,4 +1,3 @@
-﻿using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.PropertyEditors.ValueFormatters;
 using ThePensionsRegulator.Umbraco.Testing;
 using Umbraco.Cms.Core;
@@ -7,19 +6,19 @@ using Umbraco.Cms.Core.Strings;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
 {
-    [TestFixture]
     public class NoParagraphPropertyValueFormatterTests
     {
-        [TestCase("someOtherElementType", true, PropertyAliases.Hint, false)]
-        [TestCase(ElementTypeAliases.Hint, true, "someOtherProperty", false)]
-        [TestCase(ElementTypeAliases.Hint, true, PropertyAliases.Hint, true)]
-        [TestCase(ElementTypeAliases.Task, false, PropertyAliases.Hint, true)]
-        [TestCase(ElementTypeAliases.Details, false, PropertyAliases.DetailsText, true)]
-        [TestCase(ElementTypeAliases.InsetText, false, PropertyAliases.InsetText, true)]
-        [TestCase(ElementTypeAliases.WarningText, false, PropertyAliases.WarningText, true)]
-        [TestCase(ElementTypeAliases.PhaseBanner, true, PropertyAliases.PhaseBannerText, true)]
-        [TestCase(ElementTypeAliases.NotificationBanner, false, PropertyAliases.NotificationBannerHeading, true)]
-        [TestCase(ElementTypeAliases.SummaryListItem, false, PropertyAliases.SummaryListItemValue, true)]
+        [Theory]
+        [InlineData("someOtherElementType", true, PropertyAliases.Hint, false)]
+        [InlineData(ElementTypeAliases.Hint, true, "someOtherProperty", false)]
+        [InlineData(ElementTypeAliases.Hint, true, PropertyAliases.Hint, true)]
+        [InlineData(ElementTypeAliases.Task, false, PropertyAliases.Hint, true)]
+        [InlineData(ElementTypeAliases.Details, false, PropertyAliases.DetailsText, true)]
+        [InlineData(ElementTypeAliases.InsetText, false, PropertyAliases.InsetText, true)]
+        [InlineData(ElementTypeAliases.WarningText, false, PropertyAliases.WarningText, true)]
+        [InlineData(ElementTypeAliases.PhaseBanner, true, PropertyAliases.PhaseBannerText, true)]
+        [InlineData(ElementTypeAliases.NotificationBanner, false, PropertyAliases.NotificationBannerHeading, true)]
+        [InlineData(ElementTypeAliases.SummaryListItem, false, PropertyAliases.SummaryListItemValue, true)]
         public void Applies_only_to_correct_rich_text_properties(string contentTypeAlias, bool isComposition, string propertyAlias, bool expected)
         {
             // Arrange
@@ -35,10 +34,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
             var result = formatter.IsFormatter(propertyType);
 
             // Assert
-            Assert.That(result, Is.EqualTo(expected));
+            Assert.Equal(expected, result);
         }
 
-        [Test]
+        [Fact]
         public void Accepts_string_or_HtmlEncodedString_as_input()
         {
             // Arrange
@@ -51,58 +50,60 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
 
             // Assert
-            Assert.That(((HtmlEncodedString)resultOfString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
-            Assert.That(((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString(), Is.EqualTo(EXPECTED));
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfString)?.ToHtmlString());
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
         }
 
-        [Test]
+        [Fact]
         public void Single_wrapping_paragraph_with_no_class_is_removed()
         {
             TinyMCEValueFormattersTestHelper.SingleWrappingParagraphWithNoClassIsRemoved(
                 new NoParagraphPropertyValueFormatter());
         }
 
-        [Test]
+        [Fact]
         public void Single_wrapping_paragraph_with_class_is_left_alone()
         {
             TinyMCEValueFormattersTestHelper.SingleWrappingParagraphWithClassIsLeftAlone(
                 new NoParagraphPropertyValueFormatter());
         }
 
-        [Test]
+        [Fact]
         public void Multiple_wrapping_paragraphs_are_left_alone()
         {
             TinyMCEValueFormattersTestHelper.MultipleWrappingParagraphsAreLeftAlone(
                  new NoParagraphPropertyValueFormatter());
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_ordered_lists()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromOrderedLists(
                 new NoParagraphPropertyValueFormatter());
         }
 
-        [TestCase("lower-alpha")]
-        [TestCase("lower-greek")]
-        [TestCase("lower-roman")]
-        [TestCase("upper-alpha")]
-        [TestCase("upper-roman")]
+        [Theory]
+        [InlineData("lower-alpha")]
+        [InlineData("lower-greek")]
+        [InlineData("lower-roman")]
+        [InlineData("upper-alpha")]
+        [InlineData("upper-roman")]
         public void Permitted_style_attribute_is_converted_to_class_from_ordered_lists(string listStyleType)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnOrderedLists(
                 new NoParagraphPropertyValueFormatter(), listStyleType);
         }
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_unordered_lists()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromUnorderedLists(
                 new NoParagraphPropertyValueFormatter());
         }
 
-        [TestCase("circle")]
-        [TestCase("square")]
+        [Theory]
+        [InlineData("circle")]
+        [InlineData("square")]
         public void Permitted_style_attribute_is_converted_to_class_on_unordered_lists(string listStyleType)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnUnorderedLists(
@@ -110,20 +111,21 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
         }
 
 
-        [Test]
+        [Fact]
         public void Style_attribute_is_removed_from_paragraphs()
         {
             TinyMCEValueFormattersTestHelper.TestStyleAttributeIsRemovedFromParagraphs(
                 new NoParagraphPropertyValueFormatter());
         }
 
-        [TestCase("text-align: center", "govuk-!-text-align-centre")]
-        [TestCase("text-align: right", "govuk-!-text-align-right")]
-        [TestCase("padding-left: 40px", "govuk-!-padding-left-7")]
-        [TestCase("padding-left: 80px", "govuk-!-padding-left-14")]
-        [TestCase("padding-left: 120px", "govuk-!-padding-left-21")]
-        [TestCase("padding-left: 160px", "govuk-!-padding-left-28")]
-        [TestCase("padding-left: 200px", "govuk-!-padding-left-35")]
+        [Theory]
+        [InlineData("text-align: center", "govuk-!-text-align-centre")]
+        [InlineData("text-align: right", "govuk-!-text-align-right")]
+        [InlineData("padding-left: 40px", "govuk-!-padding-left-7")]
+        [InlineData("padding-left: 80px", "govuk-!-padding-left-14")]
+        [InlineData("padding-left: 120px", "govuk-!-padding-left-21")]
+        [InlineData("padding-left: 160px", "govuk-!-padding-left-28")]
+        [InlineData("padding-left: 200px", "govuk-!-padding-left-35")]
         public void Permitted_style_attribute_is_converted_to_class_on_paragraphs(string styleAttribute, string expectedClass)
         {
             TinyMCEValueFormattersTestHelper.TestPermittedStyleAttributeIsConvertedToClassOnParagraphs(

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TinyMCEValueFormattersTestHelper.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TinyMCEValueFormattersTestHelper.cs
@@ -1,5 +1,4 @@
-﻿using HtmlAgilityPack;
-using NUnit.Framework;
+using HtmlAgilityPack;
 using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
 using Umbraco.Cms.Core.Strings;
 
@@ -13,7 +12,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
-            Assert.AreEqual("Some content", result.ToHtmlString());
+            Assert.Equal("Some content", result.ToHtmlString());
         }
 
         internal static void SingleWrappingParagraphWithClassIsLeftAlone(IPropertyValueFormatter formatter)
@@ -22,7 +21,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var result = (IHtmlEncodedString)formatter.FormatValue(html);
 
-            Assert.AreEqual("<p class=\"some-class govuk-body\">Some content</p>", result.ToHtmlString());
+            Assert.Equal("<p class=\"some-class govuk-body\">Some content</p>", result.ToHtmlString());
         }
 
         internal static void MultipleWrappingParagraphsAreLeftAlone(IPropertyValueFormatter formatter)
@@ -33,7 +32,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//p").Count);
+            Assert.Equal(2, doc.DocumentNode.SelectNodes("//p").Count);
         }
 
         internal static void TestStyleAttributeIsRemovedFromOrderedLists(IPropertyValueFormatter formatter)
@@ -44,7 +43,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//ol").Count);
+            Assert.Equal(2, doc.DocumentNode.SelectNodes("//ol").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
         }
 
@@ -56,8 +55,8 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//ol").Count);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//ol[contains(@class,'govuk-list--{listStyleType}')]").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//ol"));
+            Assert.Single(doc.DocumentNode.SelectNodes($"//ol[contains(@class,'govuk-list--{listStyleType}')]"));
             Assert.Null(doc.DocumentNode.SelectNodes("//ol[@style]"));
         }
 
@@ -69,7 +68,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//ul").Count);
+            Assert.Equal(2, doc.DocumentNode.SelectNodes("//ul").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//ul[@style]"));
         }
 
@@ -81,8 +80,8 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//ul").Count);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//ul[contains(@class,'govuk-list--{listStyleType}')]").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//ul"));
+            Assert.Single(doc.DocumentNode.SelectNodes($"//ul[contains(@class,'govuk-list--{listStyleType}')]"));
             Assert.Null(doc.DocumentNode.SelectNodes("//ul[@style]"));
         }
 
@@ -94,7 +93,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(2, doc.DocumentNode.SelectNodes("//p").Count);
+            Assert.Equal(2, doc.DocumentNode.SelectNodes("//p").Count);
             Assert.Null(doc.DocumentNode.SelectNodes("//p[@style]"));
         }
 
@@ -106,8 +105,8 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//p").Count);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes($"//p[contains(@class,'{expectedClass}')]").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//p"));
+            Assert.Single(doc.DocumentNode.SelectNodes($"//p[contains(@class,'{expectedClass}')]"));
             Assert.Null(doc.DocumentNode.SelectNodes("//p[@style]"));
         }
 
@@ -119,8 +118,8 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.PropertyEditors.Valu
 
             var doc = new HtmlDocument();
             doc.LoadHtml(result.ToHtmlString() ?? string.Empty);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//h2").Count);
-            Assert.AreEqual(1, doc.DocumentNode.SelectNodes("//li").Count);
+            Assert.Single(doc.DocumentNode.SelectNodes("//h2"));
+            Assert.Single(doc.DocumentNode.SelectNodes("//li"));
             Assert.Null(doc.DocumentNode.SelectNodes("//*[@style]"));
         }
     }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Services/GovUkFieldsetErrorFinderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Services/GovUkFieldsetErrorFinderTests.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Moq;
-using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Services;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
@@ -14,7 +13,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
     {
         private const string VIEWMODEL_PROPERTY_NAME = "Field1";
 
-        [Test]
+        [Fact]
         public void Non_fieldset_returns_no_results()
         {
             var fieldsetBlock = CreateUmbracoTestContentForClasses(ElementTypeAliases.GridRow, ElementTypeAliases.ErrorMessage, true, VIEWMODEL_PROPERTY_NAME);
@@ -24,10 +23,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
 
             var results = new GovUkFieldsetErrorFinder().FindErrors(fieldsetBlock, modelState);
 
-            Assert.AreEqual(0, results.Count());
+            Assert.Empty(results);
         }
 
-        [Test]
+        [Fact]
         public void Render_error_classes_false_no_results()
         {
             var fieldsetBlock = CreateUmbracoTestContentForClasses(ElementTypeAliases.Fieldset, ElementTypeAliases.ErrorMessage, false, VIEWMODEL_PROPERTY_NAME);
@@ -37,10 +36,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
 
             var results = new GovUkFieldsetErrorFinder().FindErrors(fieldsetBlock, modelState);
 
-            Assert.AreEqual(0, results.Count());
+            Assert.Empty(results);
         }
 
-        [Test]
+        [Fact]
         public void No_ModelState_error_returns_no_results()
         {
             var fieldsetBlock = CreateUmbracoTestContentForClasses(ElementTypeAliases.Fieldset, ElementTypeAliases.ErrorMessage, true, VIEWMODEL_PROPERTY_NAME);
@@ -49,10 +48,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
 
             var results = new GovUkFieldsetErrorFinder().FindErrors(fieldsetBlock, modelState);
 
-            Assert.AreEqual(0, results.Count());
+            Assert.Empty(results);
         }
 
-        [Test]
+        [Fact]
         public void Block_other_than_ErrorMessage_bound_to_invalid_property_returns_no_results()
         {
             var fieldsetBlock = CreateUmbracoTestContentForClasses(ElementTypeAliases.Fieldset, ElementTypeAliases.TextInput, true, VIEWMODEL_PROPERTY_NAME);
@@ -62,10 +61,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
 
             var results = new GovUkFieldsetErrorFinder().FindErrors(fieldsetBlock, modelState);
 
-            Assert.AreEqual(0, results.Count());
+            Assert.Empty(results);
         }
 
-        [Test]
+        [Fact]
         public void ErrorMessage_block_bound_to_invalid_property_returns_ErrorMessage_block()
         {
             var fieldsetBlock = CreateUmbracoTestContentForClasses(ElementTypeAliases.Fieldset, ElementTypeAliases.ErrorMessage, true, VIEWMODEL_PROPERTY_NAME);
@@ -75,11 +74,11 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
 
             var results = new GovUkFieldsetErrorFinder().FindErrors(fieldsetBlock, modelState);
 
-            Assert.AreEqual(1, results.Count());
-            Assert.AreEqual(ElementTypeAliases.ErrorMessage, results.First().Content.ContentType.Alias);
+            Assert.Single(results);
+            Assert.Equal(ElementTypeAliases.ErrorMessage, results.First().Content.ContentType.Alias);
         }
 
-        [Test]
+        [Fact]
         public void Page_level_error_is_not_matched_to_unbound_error_message()
         {
             var fieldsetBlock = CreateUmbracoTestContentForClasses(ElementTypeAliases.Fieldset, ElementTypeAliases.ErrorMessage, true, string.Empty);
@@ -89,7 +88,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
 
             var results = new GovUkFieldsetErrorFinder().FindErrors(fieldsetBlock, modelState);
 
-            Assert.AreEqual(0, results.Count());
+            Assert.Empty(results);
         }
 
         private static OverridableBlockListItem CreateUmbracoTestContentForClasses(string aliasOfParentBlock, string aliasOfChildBlock, bool fieldsetErrorsEnabled, string modelPropertyBoundToErrorMessage)

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Services/UmbracoPaginationFactoryTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Services/UmbracoPaginationFactoryTests.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Moq;
-using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Models;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Services;
 using ThePensionsRegulator.Umbraco.Testing;
@@ -16,8 +15,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
         private int _pageNumberInQueryString = 33;
 #nullable enable
 
-        [SetUp]
-        public void Setup()
+        public UmbracoPaginationFactoryTests()
         {
             _httpContextAccessor = new();
 
@@ -31,7 +29,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
             request.SetupGet(x => x.Query).Returns(query);
         }
 
-        [Test]
+        [Fact]
         public void Uses_PaginationModel_defaults_if_settings_empty()
         {
             var factory = new UmbracoPaginationFactory(_httpContextAccessor.Object);
@@ -45,19 +43,19 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
                 );
 
 
-            Assert.AreEqual(defaults.PageNumber, pagination.PageNumber);
-            Assert.AreEqual(defaults.PageSize, pagination.PageSize);
-            Assert.AreEqual(defaults.TotalItems, pagination.TotalItems);
-            Assert.AreEqual(string.IsNullOrEmpty(defaults.CssClasses), string.IsNullOrEmpty(pagination.CssClasses));
-            Assert.AreEqual(defaults.LandmarkLabel, pagination.LandmarkLabel);
-            Assert.AreEqual(defaults.PreviousPageLabel, pagination.PreviousPageLabel);
-            Assert.AreEqual(defaults.NextPageLabel, pagination.NextPageLabel);
-            Assert.AreEqual(defaults.PageVisuallyHiddenText, pagination.PageVisuallyHiddenText);
-            Assert.AreEqual(defaults.QueryStringParameter, pagination.QueryStringParameter);
-            Assert.AreEqual(defaults.LargeNumberOfPagesThreshold, pagination.LargeNumberOfPagesThreshold);
+            Assert.Equal(defaults.PageNumber, pagination.PageNumber);
+            Assert.Equal(defaults.PageSize, pagination.PageSize);
+            Assert.Equal(defaults.TotalItems, pagination.TotalItems);
+            Assert.Equal(string.IsNullOrEmpty(defaults.CssClasses), string.IsNullOrEmpty(pagination.CssClasses));
+            Assert.Equal(defaults.LandmarkLabel, pagination.LandmarkLabel);
+            Assert.Equal(defaults.PreviousPageLabel, pagination.PreviousPageLabel);
+            Assert.Equal(defaults.NextPageLabel, pagination.NextPageLabel);
+            Assert.Equal(defaults.PageVisuallyHiddenText, pagination.PageVisuallyHiddenText);
+            Assert.Equal(defaults.QueryStringParameter, pagination.QueryStringParameter);
+            Assert.Equal(defaults.LargeNumberOfPagesThreshold, pagination.LargeNumberOfPagesThreshold);
         }
 
-        [Test]
+        [Fact]
         public void Uses_properties_from_settings()
         {
             var factory = new UmbracoPaginationFactory(_httpContextAccessor.Object);
@@ -88,18 +86,18 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
                 );
 
 
-            Assert.AreEqual(pageSize, pagination.PageSize);
-            Assert.AreEqual(totalItems, pagination.TotalItems);
-            Assert.AreEqual(cssClasses, pagination.CssClasses);
-            Assert.AreEqual(landmarkLabel, pagination.LandmarkLabel);
-            Assert.AreEqual(previousPageLabel, pagination.PreviousPageLabel);
-            Assert.AreEqual(nextPageLabel, pagination.NextPageLabel);
-            Assert.AreEqual(pageVisuallyHiddenText, pagination.PageVisuallyHiddenText);
-            Assert.AreEqual(_queryStringParameter, pagination.QueryStringParameter);
-            Assert.AreEqual(largeNumberOfPagesThreshold, pagination.LargeNumberOfPagesThreshold);
+            Assert.Equal(pageSize, pagination.PageSize);
+            Assert.Equal(totalItems, pagination.TotalItems);
+            Assert.Equal(cssClasses, pagination.CssClasses);
+            Assert.Equal(landmarkLabel, pagination.LandmarkLabel);
+            Assert.Equal(previousPageLabel, pagination.PreviousPageLabel);
+            Assert.Equal(nextPageLabel, pagination.NextPageLabel);
+            Assert.Equal(pageVisuallyHiddenText, pagination.PageVisuallyHiddenText);
+            Assert.Equal(_queryStringParameter, pagination.QueryStringParameter);
+            Assert.Equal(largeNumberOfPagesThreshold, pagination.LargeNumberOfPagesThreshold);
         }
 
-        [Test]
+        [Fact]
         public void Page_number_from_querystring_respects_setting()
         {
             var factory = new UmbracoPaginationFactory(_httpContextAccessor.Object);
@@ -114,7 +112,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
                 );
 
 
-            Assert.AreEqual(_pageNumberInQueryString, pagination.PageNumber);
+            Assert.Equal(_pageNumberInQueryString, pagination.PageNumber);
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
@@ -2,26 +2,35 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ThePensionsRegulator.GovUk.Frontend.Umbraco\ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj" />
     <ProjectReference Include="..\ThePensionsRegulator.Umbraco.Testing\ThePensionsRegulator.Umbraco.Testing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Usings.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Usings.cs
@@ -1,0 +1,1 @@
+﻿global using Xunit;

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/DependentFieldsActionFilterTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/DependentFieldsActionFilterTests.cs
@@ -1,18 +1,16 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Moq;
-using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Validation;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
 using ThePensionsRegulator.Umbraco.Testing;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
 {
-    [TestFixture]
     public class DependentFieldsActionFilterTests
     {
         private const string PARENT_MODEL_PROPERTY = "Field1";
@@ -20,7 +18,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
         private const string RADIO_WITH_DEPENDENT_FIELD_VALUE = "1";
         private const string RADIO_WITHOUT_DEPENDENT_FIELD_VALUE = "2";
 
-        [Test]
+        [Fact]
         public void Invalid_ModelState_remains_invalid_for_non_dependent_field()
         {
             // Arrange
@@ -39,13 +37,13 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
             filter.OnActionExecuting(actionExecutingContext);
 
             // Assert
-            Assert.That(modelState.Count, Is.EqualTo(1));
-            Assert.That(modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState, Is.EqualTo(ModelValidationState.Invalid));
+            Assert.Single(modelState);
+            Assert.Equal(ModelValidationState.Invalid, modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState);
         }
 
 
 
-        [Test]
+        [Fact]
         public void Invalid_ModelState_set_to_skipped_when_parent_field_is_invalid()
         {
             // Arrange
@@ -65,12 +63,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
             filter.OnActionExecuting(actionExecutingContext);
 
             // Assert
-            Assert.That(modelState.Count, Is.EqualTo(2));
-            Assert.That(modelState[PARENT_MODEL_PROPERTY]!.ValidationState, Is.EqualTo(ModelValidationState.Invalid));
-            Assert.That(modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState, Is.EqualTo(ModelValidationState.Skipped));
+            Assert.Equal(2, modelState.Count);
+            Assert.Equal(ModelValidationState.Invalid, modelState[PARENT_MODEL_PROPERTY]!.ValidationState);
+            Assert.Equal(ModelValidationState.Skipped, modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState);
         }
 
-        [Test]
+        [Fact]
         public void Invalid_ModelState_set_to_skipped_when_parent_field_is_valid_but_parent_option_not_selected()
         {
             // Arrange
@@ -91,12 +89,12 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
             filter.OnActionExecuting(actionExecutingContext);
 
             // Assert
-            Assert.That(modelState.Count, Is.EqualTo(2));
-            Assert.That(modelState[PARENT_MODEL_PROPERTY]!.ValidationState, Is.EqualTo(ModelValidationState.Valid));
-            Assert.That(modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState, Is.EqualTo(ModelValidationState.Skipped));
+            Assert.Equal(2, modelState.Count);
+            Assert.Equal(ModelValidationState.Valid, modelState[PARENT_MODEL_PROPERTY]!.ValidationState);
+            Assert.Equal(ModelValidationState.Skipped, modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState);
         }
 
-        [Test]
+        [Fact]
         public void Invalid_ModelState_remains_invalid_when_parent_field_is_valid_and_parent_option_selected()
         {
             // Arrange
@@ -117,9 +115,9 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
             filter.OnActionExecuting(actionExecutingContext);
 
             // Assert
-            Assert.That(modelState.Count, Is.EqualTo(2));
-            Assert.That(modelState[PARENT_MODEL_PROPERTY]!.ValidationState, Is.EqualTo(ModelValidationState.Valid));
-            Assert.That(modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState, Is.EqualTo(ModelValidationState.Invalid));
+            Assert.Equal(2, modelState.Count);
+            Assert.Equal(ModelValidationState.Valid, modelState[PARENT_MODEL_PROPERTY]!.ValidationState);
+            Assert.Equal(ModelValidationState.Invalid, modelState[DEPENDENT_MODEL_PROPERTY]!.ValidationState);
         }
 
         private static OverridableBlockListModel BlockListWithRadiosWithOneDependentField()

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/ModelStateExtensionsTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/ModelStateExtensionsTests.cs
@@ -1,13 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Primitives;
-using NUnit.Framework;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Validation;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
 {
     public class ModelStateExtensionsTests
     {
-        [Test]
+        [Fact]
         public void Initial_value_is_set_without_setting_IsValid_to_false()
         {
             var modelState = new ModelStateDictionary();
@@ -15,11 +14,11 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
             modelState.SetInitialValue("fieldname", "value");
 
             Assert.True(modelState.ContainsKey("fieldname"));
-            Assert.AreEqual("value", modelState["fieldname"]!.AttemptedValue);
+            Assert.Equal("value", modelState["fieldname"]!.AttemptedValue);
             Assert.True(modelState.IsValid);
         }
 
-        [Test]
+        [Fact]
         public void Initial_values_are_set_without_setting_IsValid_to_false()
         {
             var modelState = new ModelStateDictionary();
@@ -27,11 +26,11 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
             modelState.SetInitialValue("fieldname", new StringValues(new[] { "value1", "value2" }));
 
             Assert.True(modelState.ContainsKey("fieldname"));
-            Assert.AreEqual("value1,value2", modelState["fieldname"]!.AttemptedValue);
+            Assert.Equal("value1,value2", modelState["fieldname"]!.AttemptedValue);
             Assert.True(modelState.IsValid);
         }
 
-        [Test]
+        [Fact]
         public void Inital_value_is_set_when_initial_value_is_null()
         {
             // Arrange
@@ -46,7 +45,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
             {
                 Assert.True(modelState.ContainsKey(key));
                 Assert.True(modelState.IsValid);
-                Assert.That(modelState[key]!.AttemptedValue, Is.Null);
+                Assert.Null(modelState[key]!.AttemptedValue);
             });
         }
     }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/UmbracoBlockValidationMetadataProviderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/UmbracoBlockValidationMetadataProviderTests.cs
@@ -1,5 +1,4 @@
-﻿using Moq;
-using NUnit.Framework;
+using Moq;
 using System.ComponentModel.DataAnnotations;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Validation;
 using ThePensionsRegulator.Umbraco.Core;
@@ -10,7 +9,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
 {
     public class UmbracoBlockValidationMetadataProviderTests
     {
-        [Test]
+        [Fact]
         public void Attribute_error_message_is_updated_from_display_text_when_block_is_error_message()
         {
             var errorMessageContentType = new Mock<IPublishedContentType>();
@@ -30,10 +29,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
                 new List<ValidationAttribute> { attribute },
                 new Dictionary<Type, string> { { typeof(RequiredAttribute), PropertyAliases.ErrorMessageRequired } });
 
-            Assert.AreEqual("Custom required error", attribute.ErrorMessage);
+            Assert.Equal("Custom required error", attribute.ErrorMessage);
         }
 
-        [Test]
+        [Fact]
         public void Attribute_error_message_is_updated_from_settings_when_modelProperty_matches()
         {
             var textInputContentType = new Mock<IPublishedContentType>();
@@ -53,10 +52,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
                 new List<ValidationAttribute> { attribute },
                 new Dictionary<Type, string> { { typeof(RequiredAttribute), PropertyAliases.ErrorMessageRequired } });
 
-            Assert.AreEqual("Custom required error", attribute.ErrorMessage);
+            Assert.Equal("Custom required error", attribute.ErrorMessage);
         }
 
-        [Test]
+        [Fact]
         public void Attribute_error_message_is_not_updated_from_settings_when_modelProperty_does_not_match()
         {
             var block = UmbracoBlockListFactory.CreateOverridableBlock(
@@ -72,7 +71,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
                 new List<ValidationAttribute> { attribute },
                 new Dictionary<Type, string> { { typeof(RequiredAttribute), PropertyAliases.ErrorMessageRequired } });
 
-            Assert.AreEqual("Original error", attribute.ErrorMessage);
+            Assert.Equal("Original error", attribute.ErrorMessage);
         }
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/xunit.runner.json
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "methodDisplay": "method",
+  "methodDisplayOptions": "ReplaceUnderscoreWithSpace"
+}


### PR DESCRIPTION
## Context for this PR

This is one of a series of PRs which will upgrade this solution to the new LTS releases .NET 10 and Umbraco 17. As it's a major version release allowing breaking changes, I'm also addressing some of our tech debt.

As there are a lot of changes I'm submitting a series of smaller PRs to make reviewing easier. The competed work is on branch `feature/v17`and you can review there if you find things I might've missed (or just ask).

This does mean that the `develop` branch will not be in a releasable state until the series of PRs is complete. However is a `v13` branch where we can continue to make urgent changes to release for .NET 8.0 and Umbraco 13. Any changes merged into `v13` will also need to be upgraded to .NET 10 / Umbraco 17 and merged into `develop`.

## Scope of this PR

This PR converts the last NUnit test project to XUnit, so all test projects are now on TPR's preferred unit test platform.

## Out-of-scope for this PR

Everything else. You can expect the migration to be at the point where:
- .NET code builds
- .NET tests pass
- user-facing pages on the example apps load
- the backoffice works
- client-side files are minified and cached
- consuming the package works

Otherwise you can expect:
- outdated documentation

These will all be addressed in later PRs.

Closes #588