### PR TITLE
#253762 ROS-1 Logo and mobile menu button do not adapt correctly on zoom

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -318,17 +318,17 @@
         outline: 3px solid transparent;
     }
 
-     
-        .js.tpr-header-menu__arrow-container:hover {
-            background: $tpr-colour-white;
-            cursor: pointer;
 
-            .tpr-header-menu__arrow {
-                border-right: $govuk-focus-width solid $tpr-colour-black;
-                border-bottom: $govuk-focus-width solid $tpr-colour-black;
-            }
+    .js.tpr-header-menu__arrow-container:hover {
+        background: $tpr-colour-white;
+        cursor: pointer;
+
+        .tpr-header-menu__arrow {
+            border-right: $govuk-focus-width solid $tpr-colour-black;
+            border-bottom: $govuk-focus-width solid $tpr-colour-black;
         }
-    
+    }
+
 
     .tpr-header-menu__arrow:focus {
         border-right: $govuk-focus-width solid $tpr-colour-black;
@@ -458,5 +458,22 @@
 @media(max-width: 993px) {
     .tpr-header-menu__nav-menu-item--active:focus {
         color: $tpr-colour-black;
+    }
+}
+
+@media(max-width: 315px) {
+
+    .tpr-mobile-menu__container {
+        display: inline;
+        margin-top: 0;
+        margin-left: 0;
+    }
+
+    .tpr-mobile-menu__toggle {
+        justify-content: flex-start;
+        margin-left: 0;
+        padding-right: 0;
+        padding-left: 0;
+        margin-top: 0;
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -472,8 +472,6 @@
     .tpr-mobile-menu__toggle {
         justify-content: flex-start;
         margin-left: 0;
-        padding-right: 0;
-        padding-left: 0;
         margin-top: 0;
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
@@ -426,3 +426,9 @@ $tpr-header-left-width-xl: 200px;
         margin-top: 0;
     }
 }
+
+@media(max-width: 315px) {
+    .tpr-header__logo {
+        margin-bottom: 0.5rem;
+    }   
+}


### PR DESCRIPTION
Why: 

- Under high magnification the mobile menu toggle would overlap the logo element, this can result in a difficult experience for mobile users with low vision, as key header elements become harder to perceive or interact with.

<img width="425" height="164" alt="logo overlap" src="https://github.com/user-attachments/assets/11edc933-43e1-48e1-bbf7-62c42ad59084" />

In this PR: 

- Amended media query to allow mobile menu toggle to stack underneath the logo under high magnification or on very small screens.
