### PR TITLE
AB#257068 - Aria attribute adjustments for error placeholder on searc…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>9.2.5</Version>
+    <Version>9.2.6</Version>
   </PropertyGroup>
 </Project>

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
@@ -28,7 +28,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var builder = new HtmlContentBuilder();
             builder.Append(DefaultShowMoreQuestionsContent);
 
-            var li = CreateLink(showMoreQuestionsAttributes, builder);
+            var li = CreateButton(showMoreQuestionsAttributes, builder);
 
             list.InnerHtml.AppendHtml(li);
 
@@ -49,6 +49,17 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             a.MergeCssClass("govuk-link");
             a.InnerHtml.AppendHtml(content);
             li.InnerHtml.AppendHtml(a);
+
+            return li;
+        }
+        private TagBuilder CreateButton(AttributeDictionary dictionary, IHtmlContent content)
+        {
+            var li = new TagBuilder("li");
+            var button = new TagBuilder("button");
+            button.MergeAttributes(dictionary);
+            button.MergeCssClass("govuk-link");
+            button.InnerHtml.AppendHtml(content);
+            li.InnerHtml.AppendHtml(button);
 
             return li;
         }

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsInput.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsInput.cs
@@ -40,7 +40,6 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var input = new TagBuilder("input");
             input.Attributes.Add("type", "text");
             input.Attributes.Add("id", "tpr-search-results-ask-input");
-            input.Attributes.Add("aria-describedby", "tpr-search-results-error-text");
             input.Attributes.Add("required", "");
             input.AddCssClass("govuk-input");
 

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
@@ -68,6 +68,20 @@
     #tpr-search-results-show-more-questions {
         cursor: pointer;
         color: $govuk-link-colour;
+        background: none;
+        border: none;
+        padding: 0 !important;
+        text-decoration: underline;
+        font-size: inherit;
+        line-height: inherit;
+
+        &:hover {
+            @include govuk-link-hover-decoration;
+        }
+
+        &:focus {
+            @include govuk-focused-text;
+        }
     }
 }
 

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-search-results.js
@@ -53,6 +53,8 @@ function sanitizeString(input) {
 function resetSearchInput(){
     const searchInput = getSearchInput();
     if (searchInput != null) {
+        searchInput.removeAttribute("aria-describedby");
+        searchInput.removeAttribute("aria-invalid");
         searchInput.value = '';
     }
 }
@@ -245,11 +247,15 @@ function showErrorTextVisibility(showErrorText, errorTextContent = '') {
             errorText.classList.remove("govuk-visually-hidden");
             errorText.textContent = errorTextContent;
             searchInput.classList.add("govuk-input--error");
+            searchInput.setAttribute("aria-describedby","tpr-search-results-error-text");
+            searchInput.setAttribute("aria-invalid","true");
             formGroup.classList.add("govuk-form-group--error");
         } else {
             errorText.classList.add("govuk-visually-hidden");
             searchInput.classList.remove("govuk-input--error");
             formGroup.classList.remove("govuk-form-group--error");
+            searchInput.removeAttribute("aria-describedby");
+            searchInput.removeAttribute("aria-invalid");
         }
     }
 }


### PR DESCRIPTION
This PR contains accessibility improvements for the search results widget as indicated by the latest audit as follows:

- Replaced pagination Show more/few link with button tag while preserving link appearance
- Enforce correct aria attributes for error placeholder 
<img width="1358" height="751" alt="image" src="https://github.com/user-attachments/assets/32a5b97a-5b44-4e5f-8832-8e0940ba2cca" />


