### PR TITLE
#253769 Social link doesn't reach the proper target size (v13)

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-footer.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-footer.scss
@@ -49,6 +49,7 @@
 .tpr-footer__links a:visited {
     color: $tpr-colour-steel;
     margin-bottom: govuk-px-to-rem(20);
+    display: block;
 }
 
 .tpr-footer__links a:focus,


### PR DESCRIPTION
In this PR:
- Added `display: block` to the footer links so that their clickable area takes up the full width of their respective `<li>`'s, increasing the clickable area.

This change was suggested by CIVIC during one of the accessibility audits for the corporate website and flagged as a medium priority. Details can be found in [the work item these changes are related to](https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/253769). 