### PR TITLE
AB#257068 - Accessibility improvements for search results widget - Part 2

### DIFF
--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
@@ -2,6 +2,8 @@
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ThePensionsRegulator.Frontend.HtmlGeneration
 {
@@ -56,6 +58,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         {
             var li = new TagBuilder("li");
             var button = new TagBuilder("button");
+            button.Attributes.Add(new KeyValuePair<string, string?>("data-module", "govuk-button"));
             button.MergeAttributes(dictionary);
             button.MergeCssClass("govuk-link");
             button.InnerHtml.AppendHtml(content);

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace ThePensionsRegulator.Frontend.HtmlGeneration
 {

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
@@ -70,8 +70,7 @@
         color: $govuk-link-colour;
         background: none;
         border: none;
-        padding: 0 !important;
-        text-decoration: underline;
+        padding: 0;
         font-size: inherit;
         line-height: inherit;
 


### PR DESCRIPTION
This PR contains accessibility improvements for the search results widget as indicated by the latest audit.

Additional feedback from @sussexrick 

- Added data-module attribute for button as per govuk guidelines
- Cleanup css assets