### PR TITLE
Upgrade to non-vulnerable version of Mimekit (v17)

### DIFF
--- a/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
+++ b/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Mimekit is a dependency of Umbraco and now has a published vulnerability, which has been patched.