### PR TITLE
Upgrade to non-vulnerable version of Mimekit (v13)

### DIFF
--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="13.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Mimekit is a dependency of Umbraco and now has a published vulnerability, which has been patched.