### PR TITLE
Accessibility fixes for search results component

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/GovUk.Frontend.Umbraco.ExampleApp.csproj
+++ b/GovUk.Frontend.Umbraco.ExampleApp/GovUk.Frontend.Umbraco.ExampleApp.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+		<PackageReference Include="MimeKit" Version="4.15.1" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
         <PackageReference Include="Umbraco.Cms" Version="17.0.2" />
     <!-- Force Windows to use ICU. Otherwise Windows 10 2019H1+ will do it, but older Windows 10 and most, if not all, Windows Server editions will run NLS -->

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -57,6 +57,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="MimeKit" Version="4.15.1" />
 		<PackageReference Include="uSync.BackOffice" Version="17.0.1" />
 	</ItemGroup>
 

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Collections.Generic;
 
 namespace ThePensionsRegulator.Frontend.HtmlGeneration
 {
@@ -28,7 +29,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var builder = new HtmlContentBuilder();
             builder.Append(DefaultShowMoreQuestionsContent);
 
-            var li = CreateLink(showMoreQuestionsAttributes, builder);
+            var li = CreateButton(showMoreQuestionsAttributes, builder);
 
             list.InnerHtml.AppendHtml(li);
 
@@ -49,6 +50,18 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             a.MergeCssClass("govuk-link");
             a.InnerHtml.AppendHtml(content);
             li.InnerHtml.AppendHtml(a);
+
+            return li;
+        }
+        private TagBuilder CreateButton(AttributeDictionary dictionary, IHtmlContent content)
+        {
+            var li = new TagBuilder("li");
+            var button = new TagBuilder("button");
+            button.Attributes.Add(new KeyValuePair<string, string?>("data-module", "govuk-button"));
+            button.MergeAttributes(dictionary);
+            button.MergeCssClass("govuk-link");
+            button.InnerHtml.AppendHtml(content);
+            li.InnerHtml.AppendHtml(button);
 
             return li;
         }

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsInput.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsInput.cs
@@ -40,7 +40,6 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var input = new TagBuilder("input");
             input.Attributes.Add("type", "text");
             input.Attributes.Add("id", "tpr-search-results-ask-input");
-            input.Attributes.Add("aria-describedby", "tpr-search-results-error-text");
             input.Attributes.Add("required", "");
             input.AddCssClass("govuk-input");
 

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
@@ -68,6 +68,19 @@
     #tpr-search-results-show-more-questions {
         cursor: pointer;
         color: $govuk-link-colour;
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        line-height: inherit;
+
+        &:hover {
+            @include govuk-link-hover-decoration;
+        }
+
+        &:focus {
+            @include govuk-focused-text;
+        }
     }
 }
 

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
@@ -117,8 +117,8 @@ async function initialiseAccordion() {
 }
 
 async function searchWithTerm(searchValue) {
-    searchValue = sanitizeString(searchValue?.trim()) || '';
-
+    searchValue = (searchValue || '').trim();
+    searchValue = sanitizeString(searchValue);
     showErrorTextVisibility(false);
     hideShowMoreQuestionsButton(true);
 
@@ -275,7 +275,7 @@ async function searchButtonOnClick(event) {
         return;
     }
 
-    const searchValue = searchInput.value?.trim() || '';
+    const searchValue = (searchInput.value || '').trim() || '';
     if (!searchValue) {
         setErrorText('Please enter a question or phrase.');
         return;

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
@@ -50,9 +50,11 @@ function sanitizeString(input) {
     return (doc.body.textContent || '').trim();
 }
 
-function resetSearchInput() {
+function resetSearchInput(){
     const searchInput = getSearchInput();
     if (searchInput != null) {
+        searchInput.removeAttribute("aria-describedby");
+        searchInput.removeAttribute("aria-invalid");
         searchInput.value = '';
     }
 }
@@ -90,8 +92,9 @@ async function initialiseAccordion() {
         showMoreQuestions = queryStringShowMore.toLowerCase() === 'true';
     }
 
-    if (queryStringSearchTerm) {
-        await searchWithTerm(queryStringSearchTerm);
+    if(queryStringSearchTerm)
+    {
+        await searchWithTerm(queryStringSearchTerm);        
         return;
     }
 
@@ -105,17 +108,16 @@ async function initialiseAccordion() {
 
     if (results.length === 0) {
         createNoResultsFoundHeading();
-
+        
     } else {
         searchResults = results;
-
+        
         await displayResults();
     }
 }
 
 async function searchWithTerm(searchValue) {
-    searchValue = (searchValue || '').trim();
-    searchValue = sanitizeString(searchValue);
+    searchValue = sanitizeString(searchValue?.trim()) || '';
 
     showErrorTextVisibility(false);
     hideShowMoreQuestionsButton(true);
@@ -166,7 +168,8 @@ async function searchWithTerm(searchValue) {
     }
 }
 
-async function displayResults() {
+async function displayResults()
+{
     const accordionSections = [];
 
     let showNow = [];
@@ -174,7 +177,8 @@ async function displayResults() {
     if (showMoreQuestions === false) {
         showNow = searchResults.slice(0, INITIAL_VISIBLE_RESULTS);
     }
-    else {
+    else
+    {
         showNow = searchResults;
     }
 
@@ -184,7 +188,7 @@ async function displayResults() {
     });
 
     await createAccordion(accordionSections);
-    await updateShowMoreButton(searchResults, getShowMoreQuestionsButton());
+    await updateShowMoreButton();
 }
 
 function removeAccordion(id) {
@@ -243,11 +247,15 @@ function showErrorTextVisibility(showErrorText, errorTextContent = '') {
             errorText.classList.remove("govuk-visually-hidden");
             errorText.textContent = errorTextContent;
             searchInput.classList.add("govuk-input--error");
+            searchInput.setAttribute("aria-describedby","tpr-search-results-error-text");
+            searchInput.setAttribute("aria-invalid","true");
             formGroup.classList.add("govuk-form-group--error");
         } else {
             errorText.classList.add("govuk-visually-hidden");
             searchInput.classList.remove("govuk-input--error");
             formGroup.classList.remove("govuk-form-group--error");
+            searchInput.removeAttribute("aria-describedby");
+            searchInput.removeAttribute("aria-invalid");
         }
     }
 }
@@ -267,7 +275,7 @@ async function searchButtonOnClick(event) {
         return;
     }
 
-    const searchValue = (searchInput.value || '').trim();
+    const searchValue = searchInput.value?.trim() || '';
     if (!searchValue) {
         setErrorText('Please enter a question or phrase.');
         return;
@@ -300,29 +308,32 @@ async function showMoreAnswersOnClick() {
 
     if (showMoreQuestions === false) {
         showMoreQuestions = true;
-        setSearchTermQueryString(SHOW_MORE_QUERY_PARAM, true);
+        setSearchTermQueryString(SHOW_MORE_QUERY_PARAM,true);
     }
     else {
         showMoreQuestions = false;
-        setSearchTermQueryString(SHOW_MORE_QUERY_PARAM, undefined);
+        setSearchTermQueryString(SHOW_MORE_QUERY_PARAM,undefined);
     }
-    updateShowMoreButton(searchResults, getShowMoreQuestionsButton());
+    updateShowMoreButton()
     await displayResults();
 }
 
-async function updateShowMoreButton(results, button) {
+async function updateShowMoreButton(){
 
-    if (results.length <= INITIAL_VISIBLE_RESULTS) {
+    if(searchResults.length <= INITIAL_VISIBLE_RESULTS)
+    {
         hideShowMoreQuestionsButton(true);
         return;
     }
-    else {
+    else
+    {
         hideShowMoreQuestionsButton(false);
+        const showMoreButton = getShowMoreQuestionsButton();
         if (showMoreQuestions === false) {
-            if (button) button.textContent = 'Show more questions';
+            if (showMoreButton) showMoreButton.textContent = 'Show more questions';
         }
         else {
-            if (button) button.textContent = 'Show fewer questions';
+            if (showMoreButton) showMoreButton.textContent = 'Show fewer questions';
         }
     }
 }
@@ -386,21 +397,25 @@ function navigateToSearchInput(scrollIntoView) {
     }
 }
 
-function setSearchTermQueryString(key, value) {
+function setSearchTermQueryString(key,value) {
     const url = new URL(window.location.href); // Get the current URL
     const params = url.searchParams; // Access query parameters
 
-    if (value) {
+    if(value)
+    {
         params.set(key, value); // Add or update the search parameter
     }
-    else {
+    else
+    {
         params.delete(key); // Remove the search parameter
     }
 
-    if (params.size > 0) {
+    if(params.size > 0)
+    {
         window.history.replaceState({}, '', `${url.pathname}?${params.toString()}`); // Update the URL without reloading
     }
-    else {
+    else
+    {
         window.history.replaceState({}, '', url.pathname); // Update the URL without reloading
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
@@ -62,6 +62,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="MimeKit" Version="4.15.1" />
 		<PackageReference Include="TinyMCE.Umbraco" Version="17.0.0" />
 		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.0.2" />
 		<PackageReference Include="Umbraco.Cms.Web.Website" Version="17.0.2" />

--- a/ThePensionsRegulator.Umbraco.Core.Tests/ThePensionsRegulator.Umbraco.Core.Tests.csproj
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/ThePensionsRegulator.Umbraco.Core.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
+++ b/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.0.2" />
   </ItemGroup>
 

--- a/ThePensionsRegulator.Umbraco.Testing.Tests/ThePensionsRegulator.Umbraco.Testing.Tests.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/ThePensionsRegulator.Umbraco.Testing.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR contains accessibility improvements for the search results widget as indicated by the latest audit as follows:

- Replaced pagination Show more/few link with button tag while preserving link appearance
- Enforce correct aria attributes for error placeholder
image

<img width="1358" height="751" alt="image" src="https://github.com/user-attachments/assets/771eb2c0-2bee-4707-ba34-3237cad294c9" />

