### PR TITLE
Remove obsolete support for excluding block list models from model property picker

### DIFF
--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/PropertyEditors/ModelPropertyPicker/ModelTypeAttributeModelPropertyProvider.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/PropertyEditors/ModelPropertyPicker/ModelTypeAttributeModelPropertyProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
-using ThePensionsRegulator.Umbraco.Core.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Extensions;
@@ -40,8 +39,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.PropertyEditors.ModelPrope
                     if (modelType != null)
                     {
                         return modelType.GetProperties().Where(x =>
-                            !x.PropertyType.IsSubclassOf(typeof(PublishedContentModel)) &&
-                            !x.PropertyType.IsAssignableTo(typeof(OverridableBlockListModel))
+                            !x.PropertyType.IsSubclassOf(typeof(PublishedContentModel))
                             ).Select(x => x.Name);
                     }
                 }


### PR DESCRIPTION
Our custom model property picker, which we use to bind view model properties to Umbraco properties, has an inconsistency. It excludes properties based on a block list, but not those based on a block grid. 

<img width="345" height="208" alt="image" src="https://github.com/user-attachments/assets/a4db35bd-0ed3-47b4-bf12-ffe60ae73b35" />


This was missed [when block grid support was introduced in October 2023](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/releases?expanded=true&page=3&q=v5.0.0). It was missed because we're not using that kind of property any more.

In early versions of this repo if you filtered or overrode blocks you had to pass a custom block list model to the view via a view model property. This became unnecessary in July 2023 with the [introduction of an `OverridableBlockListPropertyValueConverter`](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/releases/tag/v1.1.0-ThePensionsRegulator.Umbraco). Since it was before block grid support was introduced, the lack of block grid support was not noticed.

Since we are about to release a major version with breaking changes, rather than increase complexity by adding block grid support, I've reduced it by removing unnecessary block list support.