### PR TITLE
Update to govuk-frontend-aspnetcore v3.5.1 and GOV.UK Frontend v5.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We add support for:
   - [Back link](https://github.com/x-govuk/govuk-frontend-aspnetcore/blob/main/docs/components/back-link.md)
   - [Breadcrumbs](https://github.com/x-govuk/govuk-frontend-aspnetcore/blob/main/docs/components/breadcrumbs.md)
 
-We target [GOV.UK Frontend v5.13.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.13.0) in line with James Gunn's base project.
+We target [GOV.UK Frontend v5.14.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.14.0) in line with James Gunn's base project.
 
 ## ASP.NET projects without Umbraco
 

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -32,7 +32,7 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.4.3" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.5.1" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 	</ItemGroup>
 

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
@@ -1,4 +1,4 @@
-﻿import { Accordion } from '/govuk-frontend.min.js?v=5.13.0';
+﻿import { Accordion } from '/govuk-frontend.min.js?v=5.14.0';
 
 let searchResults = [];
 let popularContentApiUrl = "";

--- a/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
@@ -42,7 +42,7 @@
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="FileSignatures" Version="5.0.2" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.4.3" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.5.1" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 	</ItemGroup>
 

--- a/ThePensionsRegulator.GovUk.Frontend/wwwroot/ThePensionsRegulator.GovUk.Frontend/js/govuk-js-init.js
+++ b/ThePensionsRegulator.GovUk.Frontend/wwwroot/ThePensionsRegulator.GovUk.Frontend/js/govuk-js-init.js
@@ -1,4 +1,4 @@
-﻿import { initAll } from '/govuk-frontend.min.js?v=5.13.0';
+﻿import { initAll } from '/govuk-frontend.min.js?v=5.14.0';
 const [html] = document.getElementsByTagName("html");
 const lang = html.getAttribute("lang");
 const config = lang === 'cy' || lang === 'cy-GB' ? {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "brace-expansion": "1.1.12",
-        "govuk-frontend": "^5.13.0"
+        "govuk-frontend": "^5.14.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -2588,9 +2588,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.13.0.tgz",
-      "integrity": "sha512-6N3pHelWN7wftdM6e4YEzZAfattapa1gnd+Al6d5PUbfTr9D+T2dnphpNpjX75CTEhihlQqlL0RDQ3WIfZ3PSg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
+      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "brace-expansion": "1.1.12",
-    "govuk-frontend": "^5.13.0"
+    "govuk-frontend": "^5.14.0"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --ci --watchAll=false --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura",


### PR DESCRIPTION
This is a low-impact upgrade that brings us up-to-date with the latest version of `govuk-frontend-aspnetcore` and the latest on the v5.x branch of GOV.UK Frontend.

It's low impact because [GOV.UK.Frontend v5.14.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.14.0) has only minor CSS bug fixes that affect us. We're not using GOV.UK Footer or Service Navigation at this time.

[govuk-frontend-aspnetcore v3.5.1](https://github.com/x-govuk/govuk-frontend-aspnetcore/releases) upgrades GOV.UK Frontend and has a minor bug fix for Error Summary. We're not using Password at this time.