### PR TITLE
I have simply changed the toggle button text on the model to conform …

### DIFF
--- a/ThePensionsRegulator.Frontend/Models/TprSideNavigationViewModel.cs
+++ b/ThePensionsRegulator.Frontend/Models/TprSideNavigationViewModel.cs
@@ -6,8 +6,8 @@ namespace ThePensionsRegulator.Frontend.Models
     {
         public required TprSideNavigationLink TitleLink { get; set; }
         public string AriaNavigationLabel { get; set; } = "Pages in this section";
-        public string ExpandItemLabel { get; set; } = "Expand {0}";
-        public string CollapseItemLabel { get; set; } = "Collapse {0}";
+        public string ExpandItemLabel { get; set; } = "{0} toggle button";
+        public string CollapseItemLabel { get; set; } = "{0} toggle button";
         public string ExpandedItemLabel { get; set; } = "{0} is expanded";
         public string CollapsedItemLabel { get; set; } = "{0} is collapsed";
         public List<TprSideNavigationLink> NavigationLinks { get; set; } = new();


### PR DESCRIPTION
I have simply changed the toggle button text on the model to conform with what was requested in the accessibility ticket (ie not to have separate expand and collapse text, but to have a 'toggle' text). The 'expandED' and 'collapsED' text remains the same as I believe it to be a far superior solution to what was requested in the ticket!