### PR TITLE
#255078 - ROS-02 Main heading and content do not adapt correctly when page is zoomed

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-typography.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-typography.scss
@@ -1,0 +1,8 @@
+.govuk-phase-banner__text,
+.govuk-caption-l,
+.govuk-heading-l, .govuk-heading-m, .govuk-heading-s,
+.govuk-body,
+.govuk-list,
+.govuk-link {
+    word-break: break-word;
+}

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -71,6 +71,7 @@
 @import '_tpr-table.scss';
 @import '_tpr-tag.scss';
 @import '_tpr-textarea.scss';
+@import '_tpr-typography.scss';
 @import '_tpr-warning-text.scss';
 
 // Add different components and customisations that are not part of the GOV.UK Design System (or are in a later version than the one we're targeting)


### PR DESCRIPTION
Why:

- When viewing a page at 200% zoom on smaller screens, main content and headings would not adapt correctly forcing the user to scroll horizontally to view. 

In this PR:

- Added TPR specific styling of GOVUK typography, ensuring relevant classes enforce word-break to prevent horizontal scrolling.