### PR TITLE
Fix documentation references to the location of the connection string

### DIFF
--- a/docs/umbraco/new-umbraco-project-appsettings.md
+++ b/docs/umbraco/new-umbraco-project-appsettings.md
@@ -129,4 +129,4 @@
    }
    ```
 
-3. In `appsettings.Development.json` delete the `ConnectionStrings:umbracoDbDSN` and `ConnectionStrings:umbracoDbDSN_ProviderName` settings (these will be re-instated when you run the application).
+3. In `appsettings.json` delete the `ConnectionStrings:umbracoDbDSN` and `ConnectionStrings:umbracoDbDSN_ProviderName` settings (these will be re-instated when you run the application).

--- a/docs/umbraco/new-umbraco-project-govuk.md
+++ b/docs/umbraco/new-umbraco-project-govuk.md
@@ -58,7 +58,7 @@
 
 10. Build and run your project. On the first run you will see the 'Install Umbraco' screen. Enter your name, email and create a password when prompted. Accept the defaults for other settings.
 
-    > If you get `BootFailedException: Boot failed: Umbraco cannot run.` the real error can be found in the `umbraco\Logs` folder. The most common error is `SQLite Error 14: 'unable to open database file'`. The most common fix for this is to delete the `ConnectionStrings:umbracoDbDSN` and `ConnectionStrings:umbracoDbDSN_ProviderName` settings from `appsettings.Development.json`. These will be re-instated when you run the application.
+    > If you get `BootFailedException: Boot failed: Umbraco cannot run.` the real error can be found in the `umbraco\Logs` folder. The most common error is `SQLite Error 14: 'unable to open database file'`. The most common fix for this is to delete the `ConnectionStrings:umbracoDbDSN` and `ConnectionStrings:umbracoDbDSN_ProviderName` settings from `appsettings.json`. These will be re-instated when you run the application.
 
 11. Go to the Umbraco back office at `/umbraco`. Navigate to Settings > uSync. In the 'Everything' box, click 'Import'.
 

--- a/docs/umbraco/new-umbraco-project-tpr.md
+++ b/docs/umbraco/new-umbraco-project-tpr.md
@@ -67,7 +67,7 @@
 
 13. Build and run your project. On the first run you will see the 'Install Umbraco' screen. Enter your name, email and create a password when prompted. Accept the defaults for other settings.
 
-    > If you get `BootFailedException: Boot failed: Umbraco cannot run.` the real error can be found in the `umbraco\Logs` folder. The most common error is `SQLite Error 14: 'unable to open database file'`. The most common fix for this is to delete the `ConnectionStrings:umbracoDbDSN` and `ConnectionStrings:umbracoDbDSN_ProviderName` settings from `appsettings.Development.json`. These will be re-instated when you run the application.
+    > If you get `BootFailedException: Boot failed: Umbraco cannot run.` the real error can be found in the `umbraco\Logs` folder. The most common error is `SQLite Error 14: 'unable to open database file'`. The most common fix for this is to delete the `ConnectionStrings:umbracoDbDSN` and `ConnectionStrings:umbracoDbDSN_ProviderName` settings from `appsettings.json`. These will be re-instated when you run the application.
 
 14. Go to the Umbraco back office at `/umbraco`. Navigate to Settings > uSync. In the 'Everything' box, click 'Import'.
 


### PR DESCRIPTION
I previously tried moving the default connection string to `appsettings.Development.json`. It didn't work and I moved it back, but the docs weren't all updated the second time.

Closes #706