### PR TITLE
#259676 Breadcrumb does not adapt correctly on zoom

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-breadcrumb.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-breadcrumb.scss
@@ -1,0 +1,12 @@
+﻿
+
+@media(max-width: 15em){
+
+    .govuk-breadcrumbs__list {
+        flex-wrap: wrap;
+    }
+
+    .govuk-breadcrumbs__list-item {
+        margin-left: 0;
+    }
+}

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -49,6 +49,7 @@
 // Override compiled GOV.UK styles to apply differences from the TPR UI Kit
 @import '_tpr-accordion.scss';
 @import '_tpr-back.scss';
+@import '_tpr-breadcrumb.scss';
 @import '_tpr-button.scss';
 @import '_tpr-button-group.scss';
 @import '_tpr-caption.scss';


### PR DESCRIPTION
Why:

- Breadcrumb component was flagged as not adapting correctly on zoom, this meant the breadcrumb was obstructed and required horizontal scrolling to view.

<img width="705" height="710" alt="image" src="https://github.com/user-attachments/assets/0f183847-1b25-444b-b77e-73159eb51da0" />

In this PR: 

- Added additional styling to allow the breadcrumb to collapse down underneath parent, when under high magnification on smaller screens

 
<img width="539" height="340" alt="breadcrumb solution" src="https://github.com/user-attachments/assets/904bd698-c2f6-42df-8698-724fc3d656b0" />


