### PR TITLE
 Refactor application of TPR styles for tables 

### DIFF
--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatterTests.cs
@@ -1,0 +1,105 @@
+﻿using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
+using ThePensionsRegulator.Umbraco.Testing;
+using Umbraco.Cms.Core.Strings;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueFormatters
+{
+    public class TprTablePropertyValueFormatterTests
+    {
+        [Fact]
+        public void Applies_to_rich_text_properties_with_any_alias()
+        {
+            // Arrange
+            var formatter = new TprTablePropertyValueFormatter();
+            var property = UmbracoPropertyFactory.CreateRichTextProperty(
+                Guid.NewGuid().ToString(),
+                "someContentType",
+                null);
+
+            // Act
+            var result = formatter.IsFormatter(property.PropertyType);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Does_not_apply_to_textbox_property()
+        {
+            // Arrange
+            var formatter = new TprTablePropertyValueFormatter();
+            var property = UmbracoPropertyFactory.CreateTextboxProperty(
+                Guid.NewGuid().ToString(),
+                "someContentType",
+                "");
+
+            // Act
+            var result = formatter.IsFormatter(property.PropertyType);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Accepts_string_or_HtmlEncodedString_as_input()
+        {
+            // Arrange
+            const string INPUT = "<table><tr><td>Example</td><td>Example</td></tr></table>";
+            const string EXPECTED = $"<table class=\"{TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
+            var formatter = new TprTablePropertyValueFormatter();
+
+            // Act
+            var resultOfString = formatter.FormatValue(INPUT);
+            var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
+
+            // Assert
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfString)?.ToHtmlString());
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
+        }
+
+        [Fact]
+        public void Does_not_affect_other_applied_classes()
+        {
+            // Arrange
+            const string INPUT = "<table class=\"existing-class\"><tr><td>Example</td><td>Example</td></tr></table>";
+            const string EXPECTED = $"<table class=\"existing-class {TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
+            var formatter = new TprTablePropertyValueFormatter();
+
+            // Act
+            var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
+
+            // Assert
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
+        }
+
+        [Fact]
+        public void Does_not_duplicate_class()
+        {
+            // Arrange
+            const string INPUT = $"<table class=\"{TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
+            const string EXPECTED = $"<table class=\"{TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
+            var formatter = new TprTablePropertyValueFormatter();
+
+            // Act
+            var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
+
+            // Assert
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
+        }
+
+        [Fact]
+        public void Does_not_apply_to_other_elements()
+        {
+            // Arrange
+            const string INPUT = "<h2>Example</h2><p>Example</p><strong>Example</strong>";
+            const string EXPECTED = INPUT;
+            var formatter = new TprTablePropertyValueFormatter();
+
+            // Act
+            var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
+
+            // Assert
+            Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatter.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatter.cs
@@ -1,0 +1,44 @@
+﻿using HtmlAgilityPack;
+using ThePensionsRegulator.Umbraco.Core;
+using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Strings;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters
+{
+    /// <summary>
+    /// Apply .tpr-table class to HTML tables from the Umbraco rich text editor.
+    /// </summary>
+    public class TprTablePropertyValueFormatter : IPropertyValueFormatter
+    {
+        public virtual bool IsFormatter(IPublishedPropertyType propertyType) => Constants.PropertyEditors.Aliases.RichText.Equals(propertyType.EditorAlias);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This property type should return <see cref="IHtmlEncodedString"/> but accept <c>string</c> as well so that
+        /// it is possible to provide a string of HTML to <see cref="OverridablePublishedElement.OverrideValue(string, object)"/>.
+        /// </remarks>
+        public object FormatValue(object value)
+        {
+            var richTextHtml = value is IHtmlEncodedString html ? html.ToHtmlString() : value as string;
+
+            if (!string.IsNullOrWhiteSpace(richTextHtml))
+            {
+                var document = new HtmlDocument();
+                document.LoadHtml(richTextHtml);
+
+                var tables = document.DocumentNode.SelectNodes("//table");
+                if (tables is not null)
+                {
+                    foreach (var table in tables)
+                    {
+                        table.AddClass(TprClassNames.Table);
+                    }
+                }
+                richTextHtml = document.DocumentNode.OuterHtml;
+            }
+            return new HtmlEncodedString(richTextHtml ?? "");
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -95,6 +95,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             services.AddTransient<IPropertyValueFormatter, HostNameInRichTextEditorPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, HostNameInMultiUrlPickerPropertyValueFormatter>();
             services.AddTransient<IPropertyValueFormatter, NoParagraphsPropertyValueFormatter>();
+            services.AddTransient<IPropertyValueFormatter, TprTablePropertyValueFormatter>();
             services.AddTransient<IBlockViewInterceptor, TprBoxViewInterceptor>();
             services.AddTransient<IBlockViewInterceptor, TprDividerViewInterceptor>();
             services.AddTransient<IDefaultColumnClassProvider, TprSectionCardsColumnClassProvider>();

--- a/ThePensionsRegulator.Frontend.Umbraco/TprClassNames.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/TprClassNames.cs
@@ -8,5 +8,6 @@
         public const string Image = "tpr-image";
         public const string ImageStretch = "tpr-image--fit-container";
         public const string ImageNoSpaceAfter = "tpr-image--no-space-after";
+        public const string Table = "govuk-table--tpr-default";
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-table.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-table.scss
@@ -2,15 +2,15 @@
 @import 'govuk/base';
 
 // Change GOV.UK table styles where the TPR brand diverges from the GOV.UK Design System.
-.govuk-table__caption {
+.govuk-table--tpr-default .govuk-table__caption {
     @include govuk-responsive-margin(1,"bottom");
 }
-.govuk-table__header, .govuk-table__header:last-child {
+.govuk-table--tpr-default .govuk-table__header, .govuk-table--tpr-default .govuk-table__header:last-child {
     @include govuk-responsive-padding(4);
     background-color: $tpr-colour-whisper;
     border: solid govuk-px-to-rem(2) $tpr-colour-very-light-grey;
 }
-.govuk-table__cell, .govuk-table__cell:last-child {
+.govuk-table--tpr-default .govuk-table__cell, .govuk-table--tpr-default .govuk-table__cell:last-child {
     @include govuk-responsive-padding(4);
     border: solid govuk-px-to-rem(2) $tpr-colour-very-light-grey;
 }


### PR DESCRIPTION
TPR design specs are evolving closer to GOV.UK styles and, while the default table style remains unchanged, latest designs are showing tables with the GOV.UK look and feel.

Currently we override GOV.UK tables styles in a way which is not easy to undo. This refactors those same changes into an additional style applied as an optional modifier alongside `govuk-table`. 

For ASP.NET apps this modifier will need to be applied manually, therefore this is a breaking change which belongs with the upcoming v10.0.0 major release. This will be covered in release notes.

For Umbraco apps an `IPropertyValueFormatter` is implemented which applies the new class to all rich text properties, which is where tables are normally used. If consuming apps need to opt-out of TPR styling and revert to GOV.UK styling they can do so by removing the service registration:

```csharp
builder.Services.AddTprFrontendUmbraco();
builder.Services.Remove(builder.Services.First(x => x.ImplementationType == typeof(TprTablePropertyValueFormatter)));
```

## Default style

<img width="974" height="504" alt="Table with TPR default style" src="https://github.com/user-attachments/assets/681bdbc1-f45e-497f-b45c-5f368facdba7" />

## GOV.UK style with service registration removed

<img width="992" height="335" alt="Table with GOV.UK style" src="https://github.com/user-attachments/assets/6cce8071-ed26-4f84-bb59-838c4ba641ad" />
