### PR TITLE
Add support for typography updates when TPR styling is not in use 

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-typography.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/_govuk-typography.scss
@@ -1,0 +1,8 @@
+.govuk-phase-banner__text,
+.govuk-caption-m, .govuk-caption-l, .govuk-caption-xl,
+.govuk-heading-s, .govuk-heading-m, .govuk-heading-l, .govuk-heading-xl,
+.govuk-body, 
+.govuk-list,
+.govuk-link {
+    word-break: break-word;
+}

--- a/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
+++ b/GovUk.Frontend.AspNetCore.Extensions/Styles/govuk-frontend.scss
@@ -8,3 +8,4 @@ $govuk-new-organisation-colours: true; // Recommended in release notes for GOV.U
 @import "_govuk-radios.scss";
 @import "_govuk-select.scss";
 @import "_govuk-textarea.scss";
+@import "_govuk-typography.scss";

--- a/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Startup.cs
@@ -69,6 +69,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp
             services.AddTransient<ITprSideNavigationLinksService, SideNavigationLinksServiceForExampleApp>();
             services.AddTransient<ITprSearchResultsEndpointUrlProvider, TprQueryBasedSearchResultsEndpointUrlProvider>();
             services.AddTransient<IBlockViewInterceptor, SideNavigationBlockViewInterceptor>();
+            services.AddTransient<ITprGlobalNavigationService, TprGlobalNavigationService>();
         }
 
         /// <summary>

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-typography.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-typography.scss
@@ -1,8 +1,0 @@
-.govuk-phase-banner__text,
-.govuk-caption-l,
-.govuk-heading-l, .govuk-heading-m, .govuk-heading-s,
-.govuk-body,
-.govuk-list,
-.govuk-link {
-    word-break: break-word;
-}

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -42,6 +42,7 @@
 @import "_govuk-radios.scss";
 @import "_govuk-select.scss";
 @import "_govuk-textarea.scss";
+@import "_govuk-typography.scss";
 
 // Load our custom font (we are not allowed to use 'GDS Transport' https://design-system.service.gov.uk/styles/typography/)
 @import '_open-sans.scss';
@@ -72,7 +73,6 @@
 @import '_tpr-table.scss';
 @import '_tpr-tag.scss';
 @import '_tpr-textarea.scss';
-@import '_tpr-typography.scss';
 @import '_tpr-warning-text.scss';
 
 // Add different components and customisations that are not part of the GOV.UK Design System (or are in a later version than the one we're targeting)


### PR DESCRIPTION

Why:

- Raised as part of PR feedback, that it would be useful for pure GOVUK styling to benefit from changes to prevent horizontal scrolling.
- Some classes that were missing from styling change.

In this PR:

- Moved changes to make them available with pure GOVUK styling.
- Registered `TprGlobalNavigationService` to allow the example app to run with TPR styles turned off
- Added additional classes to stylesheet