### PR TITLE
#257061 Inconsistent and ambiguous interaction patterns in the side navigation component (v13)

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-side-navigation.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-side-navigation.scss
@@ -13,10 +13,6 @@ $side-nav-selection-border-size: govuk-spacing(1);
     text-decoration: underline;
 }
 
-a.tpr-side-nav__desktop-link {
-    display: none;
-}
-
 .tpr-side-nav li {
     border-left: $side-nav-selection-border-size solid;
     border-color: transparent;
@@ -26,35 +22,32 @@ a.tpr-side-nav__desktop-link {
 }
 
 .tpr-side-nav__mobile-expand-toggle {
-    display: block;
-    color: $tpr-colour-royal-blue;
-    border: none;
-    background-color: transparent;
-    text-decoration: none;
-    font-size: 1em;
-    padding: govuk-spacing(1) 0;
-    margin-right: ($side-nav-indentation-space * -1); 
     cursor: pointer;
-    width: 100%;
-    text-align: left;
+    background: transparent;
+    border: none;
+    display: flex;
+    float: inline-end;
+    padding: 0 2em;
 }
 
 .tpr-side-nav__mobile-expand-toggle__arrow {
     float: inline-end;
+    padding: 0.2em;
+    cursor: pointer;
 }
 
 .tpr-side-nav .govuk-link {
     font-weight: normal;
 }
 
-.tpr-side-nav a:not(.tpr-side-nav__mobile-expand-toggle):not(.tpr-side-nav__desktop-link) {
+.tpr-side-nav a:not(.tpr-side-nav__title-link):not(.tpr-side-nav__mobile-expand-toggle) {
     text-decoration: none;
     padding: govuk-spacing(1);
     padding-left: $side-nav-indentation-space;
     display: inline-block;
     position: relative;
 }
-.tpr-side-nav a.tpr-side-nav__desktop-link {
+.tpr-side-nav a.tpr-side-nav__title-link {
     padding-left: govuk-spacing(1);
 }
 
@@ -89,6 +82,7 @@ ul.tpr-side-nav__list {
     background: transparent;
     border: none;
     display: flex;
+    padding: 0 2.75em
 }
 
 .tpr-side-nav__list-item-arrow {
@@ -142,11 +136,12 @@ li.tpr-side-nav__list-item--expanded {
         display: block;
     }
 
-    a.tpr-side-nav__desktop-link {
-        display: block;
-    }
-
     .tpr-side-nav__mobile-expand-toggle {
         display: none;
+        padding: 0;
+    }
+
+    .tpr-side-nav__list-item__expand-toggle {
+        padding: 0;
     }
 }

--- a/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Components/TprSideNavigation/SideNavigation.cshtml
@@ -16,11 +16,10 @@
         if (Model.TitleLink is not null)
         {
             <h2 class="govuk-heading-m">
-                <a href="@expandMobileUrl" class="govuk-link govuk-link--no-visited-state tpr-side-nav__mobile-expand-toggle">
-                    @Model.TitleLink.Name
+                <a class="govuk-link govuk-link--no-visited-state tpr-side-nav__title-link" href="@Model.TitleLink.Url">@Model.TitleLink.Name</a>
+                <a href="@expandMobileUrl" class="tpr-side-nav__mobile-expand-toggle">
                     <img src="/_content/ThePensionsRegulator.Frontend/tpr/tpr-arrow-down.svg" width="25" height="25" alt="@(string.Format(isMobileExpanded ? Model.CollapseItemLabel : Model.ExpandItemLabel, string.Empty))" class="tpr-side-nav__mobile-expand-toggle__arrow" />
                 </a>
-                <a class="govuk-link govuk-link--no-visited-state tpr-side-nav__desktop-link" href="@Model.TitleLink.Url">@Model.TitleLink.Name</a>
             </h2>
         }
         await RenderNavListLayer(Model.NavigationLinks, null, level, isMobileExpanded ? "tpr-side-nav__list--expanded" : null);

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-side-navigation.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-side-navigation.js
@@ -13,8 +13,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const mobileToggle = document.createElement("button");
     mobileToggle.type = "button";
-    mobileToggle.classList.add("govuk-link");
-    mobileToggle.classList.add("govuk-link--no-visited-state");
     mobileToggle.classList.add("tpr-side-nav__mobile-expand-toggle");
     mobileToggle.setAttribute("aria-expanded", "false");
     mobileToggle.setAttribute("aria-controls", id + "__list");


### PR DESCRIPTION
In this PR:
- Made the mobile expand toggle for the side navigation work more similarly to how the desktop version / rest of the menu does:
     - The arrow on the right side of the title link now acts as the toggle for the expand/collapse in mobile;
     - The title link now acts as a regular link when in mobile.
- Added extra horizontal padding to the expand/collapse toggles when in mobile to make them easier to press and bring the arrows closer to the link text in order to help better associate each link with it's toggle.

These changes are related to the work item [AB#257061](https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/257061) which outlines the changes the external accessibility auditor CIVIC have requested.