### PR TITLE
#259678 If you set any of the colours on the body or a element you must set all of them

### DIFF
--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
@@ -33,14 +33,33 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var logoElement = new TagBuilder(logoIsLinked ? "a" : "span");
             if (logoIsLinked) { logoElement.Attributes.Add("href", tprFooterBar.LogoHref); }
 
-            var logo = new TagBuilder("img");
-            logo.TagRenderMode = TagRenderMode.SelfClosing;
-            if (tprFooterBar.LogoAttributes != null) { logo.MergeAttributes(tprFooterBar.LogoAttributes); }
-            logo.Attributes.Add("src", "/_content/ThePensionsRegulator.Frontend/tpr/tpr-logo-footer.svg");
-            logo.Attributes.Add("alt", tprFooterBar.LogoAlternativeText);
-            logo.Attributes.Add("width", "126");
-            logo.Attributes.Add("height", "47");
-            logoElement.InnerHtml.AppendHtml(logo);
+            var pictureElement = new TagBuilder("picture");
+
+            var sourceElement = new TagBuilder("source");
+            sourceElement.Attributes.Add("srcset", "/_content/ThePensionsRegulator.Frontend/tpr/tpr-logo-header.svg");
+            sourceElement.Attributes.Add("media", "(forced-colors: active) and (prefers-color-scheme: dark)");
+            pictureElement.InnerHtml.AppendHtml(sourceElement);
+
+            var screenLogo = new TagBuilder("img");
+            screenLogo.TagRenderMode = TagRenderMode.SelfClosing;
+            if (tprFooterBar.LogoAttributes != null) { screenLogo.MergeAttributes(tprFooterBar.LogoAttributes); }
+            screenLogo.Attributes.Add("src", "/_content/ThePensionsRegulator.Frontend/tpr/tpr-logo-footer.svg");
+            screenLogo.Attributes.Add("alt", tprFooterBar.LogoAlternativeText);
+            screenLogo.Attributes.Add("width", "126");
+            screenLogo.Attributes.Add("height", "47");
+            screenLogo.AddCssClass("tpr-footer__footer-logo-img--screen");
+            pictureElement.InnerHtml.AppendHtml(screenLogo);
+
+            logoElement.InnerHtml.AppendHtml(pictureElement);
+
+            var printLogo = new TagBuilder("img");
+            printLogo.TagRenderMode = TagRenderMode.SelfClosing;
+            printLogo.Attributes.Add("src", "/_content/ThePensionsRegulator.Frontend/tpr/tpr-logo-footer.svg");
+            printLogo.Attributes.Add("alt", tprFooterBar.LogoAlternativeText);
+            printLogo.Attributes.Add("width", "126");
+            printLogo.Attributes.Add("height", "47");
+            printLogo.MergeCssClass("tpr-footer__footer-logo-img--print");
+            logoElement.InnerHtml.AppendHtml(printLogo);
 
             logoContainer.InnerHtml.AppendHtml(logoElement);
             upperFooterContainer.InnerHtml.AppendHtml(logoContainer);

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
@@ -199,7 +199,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var svgTag2 = new TagBuilder("g");
             svgTag2.Attributes.Add("transform", "translate(1.000000, -6.000000)");
-            svgTag2.Attributes.Add("fill", "#434343");
+            svgTag2.AddCssClass("tpr-header-search__button-icon");
             svgTag1.InnerHtml.AppendHtml(svgTag2);
 
             var path1 = new TagBuilder("path");

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
@@ -31,6 +31,13 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             }
             logoElement.MergeCssClass("tpr-header__logo");
 
+            var pictureElement = new TagBuilder("picture");
+
+            var sourceElement = new TagBuilder("source");
+            sourceElement.Attributes.Add("srcset", "/_content/ThePensionsRegulator.Frontend/tpr/tpr-logo-footer.svg");
+            sourceElement.Attributes.Add("media", "(forced-colors: active) and (prefers-color-scheme: light)");
+            pictureElement.InnerHtml.AppendHtml(sourceElement);
+
             var screenLogo = new TagBuilder("img");
             screenLogo.TagRenderMode = TagRenderMode.SelfClosing;
             if (tprHeaderBar.LogoAttributes != null) { screenLogo.MergeAttributes(tprHeaderBar.LogoAttributes); }
@@ -39,7 +46,9 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             screenLogo.Attributes.Add("width", "180");
             screenLogo.Attributes.Add("height", "75");
             screenLogo.MergeCssClass("tpr-header__logo-img--screen");
-            logoElement.InnerHtml.AppendHtml(screenLogo);
+
+            pictureElement.InnerHtml.AppendHtml(screenLogo);
+            logoElement.InnerHtml.AppendHtml(pictureElement);
 
             var printLogo = new TagBuilder("img");
             printLogo.TagRenderMode = TagRenderMode.SelfClosing;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-footer.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-footer.scss
@@ -12,9 +12,13 @@
     padding-bottom: govuk-px-to-rem(20);
 }
 
-.tpr-footer__footer-logo img {
+.tpr-footer__footer-logo-img--screen {
     width: govuk-px-to-rem(126);
     height: govuk-px-to-rem(47);
+}
+
+.tpr-footer__footer-logo-img--print {
+    display: none;
 }
 
 .tpr-footer__links { 
@@ -79,5 +83,15 @@
     .tpr-footer__content > a {
         margin-bottom: 0;
         margin-right: govuk-px-to-rem(29);
+    }
+}
+
+@media print{
+    .tpr-footer__footer-logo-img--print {
+        display: block;
+    }
+
+    .tpr-footer__footer-logo-img--screen {
+        display: none;
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -69,12 +69,18 @@
     display: flex;
 }
 
-    .tpr-mobile-menu__svg.tpr-mobile-menu__svg--hide {
-        display: none;
-    }
+.tpr-mobile-menu__svg.tpr-mobile-menu__svg--hide {
+    display: none;
+}
 
-.tpr-mobile-menu__toggle .tpr-header-menu__menu-icon {
+ .tpr-header-menu__menu-icon {
     fill: $tpr-colour-white;
+}
+
+@media (prefers-color-scheme: light) {
+    .tpr-header-menu__menu-icon {
+        fill: $tpr-colour-black;
+    }
 }
 
 .tpr-header-menu__nav-container {
@@ -345,6 +351,7 @@
         a {
             color: $tpr-colour-royal-blue;
         }
+
             a:hover {
                 color: none;
                 background: none;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -20,7 +20,7 @@
 
     &:focus-within {
         box-shadow: 0 0 0 4px $tpr-colour-tangerine-yellow, 0 0 0 8px $tpr-colour-black;
-        outline: 3px solid transparent;
+        outline: $govuk-focus-width solid transparent;
     }
 }
 

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -18,8 +18,9 @@
     margin-bottom: -0.6rem;
     cursor: pointer;
 
-    &:focus {
-        outline: $govuk-focus-width solid $govuk-focus-colour;
+    &:focus-within {
+        box-shadow: 0 0 0 4px $tpr-colour-tangerine-yellow, 0 0 0 8px $tpr-colour-black;
+        outline: 3px solid transparent;
     }
 }
 
@@ -33,13 +34,6 @@
     font-family: $govuk-font-family;
     cursor: pointer;
 }
-
-    .tpr-header-menu__button:focus {
-        color: $tpr-colour-black;
-        background-color: $tpr-colour-tangerine-yellow;
-        box-shadow: 0 -2px $tpr-colour-tangerine-yellow, 0 4px $tpr-colour-black;
-        text-decoration: none;
-    }
 
     .tpr-header-menu__button:focus-visible {
         outline: transparent;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -77,7 +77,7 @@
     fill: $tpr-colour-white;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: light) and (forced-colors: active) {
     .tpr-header-menu__menu-icon {
         fill: $tpr-colour-black;
     }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-search.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-search.scss
@@ -45,6 +45,15 @@
     vertical-align: bottom;
 }
 
+.tpr-header-search__button-icon {
+    fill: $tpr-colour-steel;
+}
+
+@media(prefers-color-scheme: dark ) and (forced-colors: active) {
+    .tpr-header-search__button-image-icon {
+        fill: $tpr-colour-white;
+    }
+}
 
 .tpr-header-search__mobile {
     display: inline;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-search.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-search.scss
@@ -49,8 +49,8 @@
     fill: $tpr-colour-steel;
 }
 
-@media(prefers-color-scheme: dark ) and (forced-colors: active) {
-    .tpr-header-search__button-image-icon {
+@media (prefers-color-scheme: dark ) and (forced-colors: active) {
+    .tpr-header-search__button-icon {
         fill: $tpr-colour-white;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3458,9 +3458,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3802,16 +3802,16 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minipass": {
@@ -4093,9 +4093,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "brace-expansion": "1.1.12",
+        "brace-expansion": "^1.1.13",
         "govuk-frontend": "^5.13.0"
       },
       "devDependencies": {
@@ -1902,9 +1902,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minimatch": ">=10.2.1"
   },
   "dependencies": {
-    "brace-expansion": "1.1.12",
+    "brace-expansion": "^1.1.13",
     "govuk-frontend": "^5.13.0"
   },
   "scripts": {


### PR DESCRIPTION
Why:

Raised in [AB#259678](https://dev.azure.com/thepensionsregulator/TPR/_boards/board/t/Web%20Platform%20Team/Stories?System.Tags=Corp%20Web%20Accessibility%2CCorp%20Website%20Migration&workitem=259678) that not all colour styling had been set meaning that some content is not available for users with alternate browser colour schemes. 

Areas identified through testing with forced colours set to both light and dark mode include:

-  the logo (Header and footer)
- search icon 
- mobile menu toggle hamburger icon 
- mobile menu toggle focus style.

In this PR:

- Added support for different logo's displaying depending on users chosen colour scheme
- Added styling for light mode hamburger icon to ensure visibility
- Added styling for search icon to increase visibility with dark colour scheme 
- Moved focus to the outside of the toggle, this is consistent with focus style of the logo and ensure it is visible with forced colour schemes.

`Note`: Similar to the header a print logo was also added for the footer logo, this is to address a situation where a user may load the page without forced colours but decides to turn them on. Without the print logo the wrong logo will be used meaning its not visible. This is a bit of an edge case as this is not present if the page is loaded with forced colours already enabled.