### PR TITLE
Support styles for GOV.UK tabs when using TPR styles #736

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -33,6 +33,7 @@
 @import "govuk/components/service-navigation";
 @import "govuk/components/skip-link";
 @import "govuk/components/summary-list";
+@import "govuk/components/tabs";
 @import "govuk/components/table";
 @import "govuk/components/task-list";
 @import "govuk/components/textarea";


### PR DESCRIPTION
Similar to #729, this PR adds missing styles for the GOV.UK 'Tabs' component. 

This allows it to be used as a tag helper even though we don't customise the component in any way.

Fixes #736.