### PR TITLE
Upgrade to govuk-frontend-aspnetcore v4.0.0 and GOV.UK Frontend v6.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.0.0-beta003</Version>
+    <Version>10.0.0-beta004</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We add support for:
   - [Back link](https://github.com/x-govuk/govuk-frontend-aspnetcore/blob/main/docs/components/back-link.md)
   - [Breadcrumbs](/docs/components/breadcrumbs.md)
 
-We target [GOV.UK Frontend v5.14.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.14.0) in line with James Gunn's base project.
+We target [GOV.UK Frontend v6.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0) in line with James Gunn's base project.
 
 ## ASP.NET projects without Umbraco
 

--- a/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
+++ b/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
@@ -68,7 +68,7 @@ p.tpr-add-link {
 }
 
 .backoffice-block-view .is-trashed {
-    background: $govuk-error-colour;
+    background: govuk-functional-colour(error);
     color: $tpr-colour-white;
     padding: govuk-spacing(1)
 }

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -56,7 +56,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
 		<PackageReference Include="MimeKit" Version="4.15.1" />
 		<PackageReference Include="uSync.BackOffice" Version="17.0.4" />
 	</ItemGroup>

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprBackToMenu.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprBackToMenu.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -23,11 +22,11 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var tagBuilder = new TagBuilder(BackToMenuElement);
             if (attributes != null) tagBuilder.MergeAttributes(attributes);
-            tagBuilder.MergeCssClass("govuk-body");
-            tagBuilder.MergeCssClass("tpr-back-to-menu");
+            tagBuilder.AddCssClass("govuk-body");
+            tagBuilder.AddCssClass("tpr-back-to-menu");
 
             var linkBuilder = new TagBuilder(BackToMenuLinkElement);
-            linkBuilder.MergeCssClass("govuk-link");
+            linkBuilder.AddCssClass("govuk-link");
             linkBuilder.Attributes.Add("href", href);
             linkBuilder.InnerHtml.AppendHtml(content);
 

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprBackToTop.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprBackToTop.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -22,16 +21,16 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var outer = new TagBuilder("div");
             if (attributes != null) { outer.MergeAttributes(attributes); }
-            outer.MergeCssClass("tpr-back-to-top");
+            outer.AddCssClass("tpr-back-to-top");
 
             var middle = new TagBuilder("div");
-            middle.MergeCssClass("govuk-width-container");
+            middle.AddCssClass("govuk-width-container");
 
             var inner = new TagBuilder("div");
-            inner.MergeCssClass("tpr-back-to-top__inner");
+            inner.AddCssClass("tpr-back-to-top__inner");
 
             var link = new TagBuilder(BackToTopLinkElement);
-            link.MergeCssClass("govuk-link");
+            link.AddCssClass("govuk-link");
             link.Attributes.Add("href", href);
 
             outer.InnerHtml.AppendHtml(middle);

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprContextBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprContextBar.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace ThePensionsRegulator.Frontend.HtmlGeneration
@@ -11,20 +10,19 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         {
             var tagBuilder = new TagBuilder(TprContextBarElement);
             if (tprContextBar.ContextBarAttributes != null) tagBuilder.MergeAttributes(tprContextBar.ContextBarAttributes);
-            tagBuilder.MergeCssClass("tpr-context");
+            tagBuilder.AddCssClass("tpr-context");
 
             var inner = new TagBuilder("div");
-            inner.MergeCssClass("govuk-width-container");
-            inner.MergeCssClass("tpr-context__inner");
-
+            inner.AddCssClass("govuk-width-container");
+            inner.AddCssClass("tpr-context__inner");
             var hasContext1 = !string.IsNullOrWhiteSpace(tprContextBar.Context1Content?.ToString());
             var hasContext2 = !string.IsNullOrWhiteSpace(tprContextBar.Context2Content?.ToString());
             var hasContext3 = !string.IsNullOrWhiteSpace(tprContextBar.Context3Content?.ToString());
 
             var context1Element = new TagBuilder("div");
             if (tprContextBar.Context1Attributes != null) { context1Element.MergeAttributes(tprContextBar.Context1Attributes); }
-            context1Element.MergeCssClass("govuk-body");
-            context1Element.MergeCssClass("tpr-context__context-1");
+            context1Element.AddCssClass("govuk-body");
+            context1Element.AddCssClass("tpr-context__context-1");
             if (hasContext1)
             {
                 if (tprContextBar.Context1AllowHtml)
@@ -39,20 +37,20 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             inner.InnerHtml.AppendHtml(context1Element);
 
             var context23container = new TagBuilder("div");
-            context23container.MergeCssClass("tpr-context__container");
+            context23container.AddCssClass("tpr-context__container");
             if (!hasContext2)
             {
-                context23container.MergeCssClass("tpr-context__container--context-2-empty");
+                context23container.AddCssClass("tpr-context__container--context-2-empty");
             }
             if (!hasContext3)
             {
-                context23container.MergeCssClass("tpr-context__container--context-3-empty");
+                context23container.AddCssClass("tpr-context__container--context-3-empty");
             }
 
             var context2Element = new TagBuilder("div");
             if (tprContextBar.Context2Attributes != null) { context2Element.MergeAttributes(tprContextBar.Context2Attributes); }
-            context2Element.MergeCssClass("govuk-body");
-            context2Element.MergeCssClass("tpr-context__context-2");
+            context2Element.AddCssClass("govuk-body");
+            context2Element.AddCssClass("tpr-context__context-2");
             if (hasContext2)
             {
                 if (tprContextBar.Context2AllowHtml)
@@ -72,11 +70,11 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             {
                 var context3Element = new TagBuilder("div");
                 if (tprContextBar.Context3Attributes != null) { context3Element.MergeAttributes(tprContextBar.Context3Attributes); }
-                context3Element.MergeCssClass("govuk-body");
-                context3Element.MergeCssClass("tpr-context__context-3");
+                context3Element.AddCssClass("govuk-body");
+                context3Element.AddCssClass("tpr-context__context-3");
 
                 var context3InnerElement = new TagBuilder("div");
-                context3InnerElement.MergeCssClass("tpr-context__context-3-inner");
+                context3InnerElement.AddCssClass("tpr-context__context-3-inner");
                 if (tprContextBar.Context3AllowHtml)
                 {
                     context3InnerElement.InnerHtml.AppendHtml(tprContextBar.Context3Content!);

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFeaturedImage.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFeaturedImage.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -27,17 +26,17 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var featuredImageTagHelper = new TagBuilder(FeaturedImageElement);
             if (attributes is not null) { featuredImageTagHelper.MergeAttributes(attributes); }
-            featuredImageTagHelper.MergeCssClass("tpr-featured-image");
+            featuredImageTagHelper.AddCssClass("tpr-featured-image");
 
             if (horizontal)
             {
-                featuredImageTagHelper.MergeCssClass("tpr-featured-image--horizontal");
+                featuredImageTagHelper.AddCssClass("tpr-featured-image--horizontal");
             }
 
 
             var featuredImageThumbnailTagHelper = new TagBuilder(FeaturedImageThumbnailElement);
 
-            featuredImageThumbnailTagHelper.MergeCssClass("tpr-featured-image_thumbnail");
+            featuredImageThumbnailTagHelper.AddCssClass("tpr-featured-image_thumbnail");
 
 
             var imageTagHelper = new TagBuilder("img");
@@ -55,8 +54,8 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var featuredImageInfoTagHelper = new TagBuilder(FeaturedImageInfoElement);
 
-            featuredImageInfoTagHelper.MergeCssClass("tpr-featured-image_info");
-            featuredImageInfoTagHelper.MergeCssClass("tpr-box");
+            featuredImageInfoTagHelper.AddCssClass("tpr-featured-image_info");
+            featuredImageInfoTagHelper.AddCssClass("tpr-box");
 
 
             featuredImageInfoTagHelper.InnerHtml.AppendHtml(htmlContent);

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprFooterBar.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ThePensionsRegulator.GovUk.Frontend.Caching;
 
@@ -15,20 +14,19 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         {
             var tagBuilder = new TagBuilder(TprFooterBarElement);
             if (tprFooterBar.FooterBarAttributes != null) { tagBuilder.MergeAttributes(tprFooterBar.FooterBarAttributes); }
-            tagBuilder.MergeCssClass("tpr-footer");
+            tagBuilder.AddCssClass("tpr-footer");
             tagBuilder.MergeAttribute("role", "contentinfo");
 
             var widthContainer = new TagBuilder("div");
-            widthContainer.MergeCssClass("govuk-width-container");
+            widthContainer.AddCssClass("govuk-width-container");
             tagBuilder.InnerHtml.AppendHtml(widthContainer);
 
             var upperFooterContainer = new TagBuilder("div");
-            upperFooterContainer.MergeCssClass("govuk-grid-row");
+            upperFooterContainer.AddCssClass("govuk-grid-row");
             widthContainer.InnerHtml.AppendHtml(upperFooterContainer);
 
             var logoContainer = new TagBuilder("div");
-            logoContainer.MergeCssClass("govuk-grid-column-one-quarter tpr-footer__footer-logo");
-
+            logoContainer.AddCssClass("govuk-grid-column-one-quarter tpr-footer__footer-logo");
             var logoIsLinked = !string.IsNullOrEmpty(tprFooterBar.LogoHref);
             var logoElement = new TagBuilder(logoIsLinked ? "a" : "span");
             if (logoIsLinked) { logoElement.Attributes.Add("href", tprFooterBar.LogoHref); }
@@ -47,7 +45,6 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             if (tprFooterBar.ThreeColumnLinks != null && tprFooterBar.ThreeColumnLinks?.Count > 0)
             {
-
                 foreach (var column in tprFooterBar.ThreeColumnLinks)
                 {
                     if (column.ThreeColumnFooterLinks != null && column.ThreeColumnFooterLinks.Count > 0)
@@ -97,12 +94,12 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             if (hasContent || hasCopyright)
             {
                 var contentContainer = new TagBuilder("div");
-                contentContainer.MergeCssClass("tpr-footer__content-container");
+                contentContainer.AddCssClass("tpr-footer__content-container");
 
                 var contentElement = new TagBuilder("div");
                 if (tprFooterBar.ContentAttributes != null) { contentElement.MergeAttributes(tprFooterBar.ContentAttributes); }
-                contentElement.MergeCssClass("govuk-body");
-                contentElement.MergeCssClass("tpr-footer__content");
+                contentElement.AddCssClass("govuk-body");
+                contentElement.AddCssClass("tpr-footer__content");
                 if (hasContent)
                 {
                     if (tprFooterBar.ContentAllowHtml)
@@ -118,7 +115,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 }
                 else
                 {
-                    contentElement.MergeCssClass("tpr-footer__content--empty");
+                    contentElement.AddCssClass("tpr-footer__content--empty");
                 }
                 contentContainer.InnerHtml.AppendHtml(contentElement);
 
@@ -126,8 +123,8 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 {
                     var copyrightElement = new TagBuilder("p");
                     if (tprFooterBar.CopyrightAttributes != null) { copyrightElement.MergeAttributes(tprFooterBar.CopyrightAttributes); }
-                    copyrightElement.MergeCssClass("govuk-body");
-                    copyrightElement.MergeCssClass("tpr-footer__copyright");
+                    copyrightElement.AddCssClass("govuk-body");
+                    copyrightElement.AddCssClass("tpr-footer__copyright");
                     copyrightElement.InnerHtml.AppendHtml("&copy; ");
                     if (tprFooterBar.CopyrightAllowHtml)
                     {

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ThePensionsRegulator.GovUk.Frontend.Caching;
 
@@ -17,20 +16,20 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var tagBuilder = new TagBuilder(TprHeaderBarElement);
             if (tprHeaderBar.HeaderBarAttributes != null) { tagBuilder.MergeAttributes(tprHeaderBar.HeaderBarAttributes); }
-            tagBuilder.MergeCssClass("tpr-header");
+            tagBuilder.AddCssClass("tpr-header");
 
             var headerContent = new TagBuilder("div");
-            headerContent.MergeCssClass("govuk-width-container");
-            headerContent.MergeCssClass("tpr-header__inner");
+            headerContent.AddCssClass("govuk-width-container");
+            headerContent.AddCssClass("tpr-header__inner");
 
             var logoIsLinked = !string.IsNullOrEmpty(tprHeaderBar.LogoHref);
             var logoElement = new TagBuilder(logoIsLinked ? "a" : "span");
             if (logoIsLinked)
             {
-                logoElement.MergeCssClass("govuk-link-image");
+                logoElement.AddCssClass("govuk-link-image");
                 logoElement.Attributes.Add("href", tprHeaderBar.LogoHref);
             }
-            logoElement.MergeCssClass("tpr-header__logo");
+            logoElement.AddCssClass("tpr-header__logo");
 
             var screenLogo = new TagBuilder("img");
             screenLogo.TagRenderMode = TagRenderMode.SelfClosing;
@@ -39,7 +38,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             screenLogo.Attributes.Add("alt", tprHeaderBar.LogoAlternativeText);
             screenLogo.Attributes.Add("width", "180");
             screenLogo.Attributes.Add("height", "75");
-            screenLogo.MergeCssClass("tpr-header__logo-img--screen");
+            screenLogo.AddCssClass("tpr-header__logo-img--screen");
             logoElement.InnerHtml.AppendHtml(screenLogo);
 
             var printLogo = new TagBuilder("img");
@@ -48,7 +47,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             printLogo.Attributes.Add("alt", tprHeaderBar.LogoAlternativeText);
             printLogo.Attributes.Add("width", "180");
             printLogo.Attributes.Add("height", "75");
-            printLogo.MergeCssClass("tpr-header__logo-img--print");
+            printLogo.AddCssClass("tpr-header__logo-img--print");
             logoElement.InnerHtml.AppendHtml(printLogo);
 
             headerContent.InnerHtml.AppendHtml(logoElement);
@@ -57,8 +56,8 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             {
                 var labelElement = new TagBuilder("p");
                 if (tprHeaderBar.LabelAttributes != null) { labelElement.MergeAttributes(tprHeaderBar.LabelAttributes); }
-                labelElement.MergeCssClass("govuk-body");
-                labelElement.MergeCssClass("tpr-header__label");
+                labelElement.AddCssClass("govuk-body");
+                labelElement.AddCssClass("tpr-header__label");
                 if (tprHeaderBar.LabelAllowHtml)
                 {
                     labelElement.InnerHtml.AppendHtml(tprHeaderBar.Label);
@@ -74,8 +73,8 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             {
                 var contentElement = new TagBuilder("div");
                 if (tprHeaderBar.ContentAttributes != null) { contentElement.MergeAttributes(tprHeaderBar.ContentAttributes); }
-                contentElement.MergeCssClass("govuk-body");
-                contentElement.MergeCssClass("tpr-header__content");
+                contentElement.AddCssClass("govuk-body");
+                contentElement.AddCssClass("tpr-header__content");
                 headerContent.InnerHtml.AppendHtml(contentElement);
                 if (tprHeaderBar.ContentAllowHtml)
                 {

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprRelatedLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprRelatedLinks.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ThePensionsRegulator.GovUk.Frontend;
 
@@ -13,16 +12,16 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var outer = new TagBuilder("div");
             if (tprRelatedLinks.RelatedLinksAttributes != null) { outer.MergeAttributes(tprRelatedLinks.RelatedLinksAttributes); }
-            outer.MergeCssClass("tpr-related-links");
+            outer.AddCssClass("tpr-related-links");
 
             var heading = new TagBuilder("h2");
             if (tprRelatedLinks.HeadingAttributes != null) { heading.MergeAttributes(tprRelatedLinks.HeadingAttributes); }
-            heading.MergeCssClass("govuk-heading-m");
+            heading.AddCssClass("govuk-heading-m");
             heading.InnerHtml.AppendHtml(tprRelatedLinks.HeadingContent!);
             outer.InnerHtml.AppendHtml(heading);
 
             var list = new TagBuilder("ul");
-            list.MergeCssClass("govuk-list");
+            list.AddCssClass("govuk-list");
             outer.InnerHtml.AppendHtml(list);
 
             foreach (var link in tprRelatedLinks.Links)
@@ -30,7 +29,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 var li = new TagBuilder("li");
                 var a = new TagBuilder("a");
                 a.MergeAttributes(link.Attributes);
-                a.MergeCssClass("govuk-link");
+                a.AddCssClass("govuk-link");
                 a.InnerHtml.AppendHtml(link.Content);
                 li.InnerHtml.AppendHtml(a);
                 list.InnerHtml.AppendHtml(li);

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSearchResultsFooterLinks.cs
@@ -1,8 +1,6 @@
-﻿using GovUk.Frontend.AspNetCore;
-using Microsoft.AspNetCore.Html;
+﻿using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using System.Collections.Generic;
 
 namespace ThePensionsRegulator.Frontend.HtmlGeneration
 {
@@ -33,7 +31,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             list.InnerHtml.AppendHtml(li);
 
-            foreach(var link in footerLinks.Links)
+            foreach (var link in footerLinks.Links)
             {
                 var anchorListItem = CreateLink(link.Attributes, link.Content);
                 list.InnerHtml.AppendHtml(anchorListItem);
@@ -47,7 +45,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var li = new TagBuilder("li");
             var a = new TagBuilder("a");
             a.MergeAttributes(dictionary);
-            a.MergeCssClass("govuk-link");
+            a.AddCssClass("govuk-link");
             a.InnerHtml.AppendHtml(content);
             li.InnerHtml.AppendHtml(a);
 
@@ -59,7 +57,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var button = new TagBuilder("button");
             button.Attributes.Add(new KeyValuePair<string, string?>("data-module", "govuk-button"));
             button.MergeAttributes(dictionary);
-            button.MergeCssClass("govuk-link");
+            button.AddCssClass("govuk-link");
             button.InnerHtml.AppendHtml(content);
             li.InnerHtml.AppendHtml(button);
 

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSectionCards.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprSectionCards.cs
@@ -15,7 +15,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             var nav = new TagBuilder("nav");
 
             if (tprSectionCards.Attributes != null) { nav.MergeAttributes(tprSectionCards.Attributes); }
-            nav.MergeCssClass("tpr-section-cards");
+            nav.AddCssClass("tpr-section-cards");
 
             if (tprSectionCards.NavigationAriaLabel is not null && !string.IsNullOrWhiteSpace(tprSectionCards.NavigationAriaLabel))
             {
@@ -24,29 +24,29 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var ulTag = new TagBuilder("ul");
             nav.InnerHtml.AppendHtml(ulTag);
-            ulTag.MergeCssClass("govuk-list");
+            ulTag.AddCssClass("govuk-list");
             var culture = CultureInfo.CurrentCulture.TwoLetterISOLanguageName.ToLower();
 
             foreach (var card in tprSectionCards.Cards)
             {
                 var tprSectionCard = new TagBuilder("li");
                 if (card.CardAttributes != null) { tprSectionCard.MergeAttributes(card.CardAttributes); }
-                tprSectionCard.MergeCssClass("tpr-section-card");
+                tprSectionCard.AddCssClass("tpr-section-card");
 
                 var tprSectionCardBody = new TagBuilder("div");
-                tprSectionCardBody.MergeCssClass("tpr-section-card__body");
+                tprSectionCardBody.AddCssClass("tpr-section-card__body");
 
                 if (card.Title is not null && !string.IsNullOrWhiteSpace(card.Title.ToHtmlString(HtmlEncoder.Default)))
                 {
                     var tprSectionCardTitle = new TagBuilder($"h{tprSectionCards.SectionCardsTitleHeadingLevel}");
                     if (card.TitleAttributes != null) { tprSectionCardTitle.MergeAttributes(card.TitleAttributes); }
-                    tprSectionCardTitle.MergeCssClass(tprSectionCards.SectionCardsTitleHeadingClass);
-                    tprSectionCardTitle.MergeCssClass("tpr-section-card__title");
+                    tprSectionCardTitle.AddCssClass(tprSectionCards.SectionCardsTitleHeadingClass);
+                    tprSectionCardTitle.AddCssClass("tpr-section-card__title");
 
                     if (!string.IsNullOrEmpty(card.TitleUrl))
                     {
                         var anchorElement = new TagBuilder("a");
-                        anchorElement.MergeCssClass("govuk-link");
+                        anchorElement.AddCssClass("govuk-link");
                         anchorElement.Attributes.Add("href", card.TitleUrl);
 
                         if (card.TitleAllowHtml)
@@ -87,7 +87,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 if (card.Content is not null && !string.IsNullOrWhiteSpace(card.Content.ToHtmlString(HtmlEncoder.Default)))
                 {
                     var tprSectionCardContent = new TagBuilder("div");
-                    tprSectionCardContent.MergeCssClass("tpr-section-card__content");
+                    tprSectionCardContent.AddCssClass("tpr-section-card__content");
                     if (card.ContentAttributes != null) { tprSectionCardContent.MergeAttributes(card.ContentAttributes); }
 
                     if (card.ContentAllowHtml)
@@ -97,7 +97,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                     else
                     {
                         var tprSectionCardPara = new TagBuilder("p");
-                        tprSectionCardPara.MergeCssClass("govuk-body");
+                        tprSectionCardPara.AddCssClass("govuk-body");
                         tprSectionCardPara.InnerHtml.Append(card.Content.ToHtmlString(HtmlEncoder.Default));
                         tprSectionCardContent.InnerHtml.AppendHtml(tprSectionCardPara);
                     }

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using ThePensionsRegulator.GovUk.Frontend;
@@ -23,7 +22,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var timelineTagBuilder = new TagBuilder(TimelineElement);
             if (attributes is not null) { timelineTagBuilder.MergeAttributes(attributes); }
-            timelineTagBuilder.MergeCssClass("tpr-timeline");
+            timelineTagBuilder.AddCssClass("tpr-timeline");
             var accessibleTitle = "Timeline";
             if (!string.IsNullOrWhiteSpace(ariaTitle))
             {
@@ -47,7 +46,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
                 if (item.Attributes is not null) { itemBuilder.MergeAttributes(item.Attributes); }
 
-                itemBuilder.MergeCssClass("tpr-timeline__item");
+                itemBuilder.AddCssClass("tpr-timeline__item");
                 itemBuilder.InnerHtml.AppendHtml(itemContentBuilder);
                 timelineTagBuilder.InnerHtml.AppendHtml(itemBuilder);
 
@@ -69,7 +68,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         private static TagBuilder BuildDateTime(TprTimelineItem item)
         {
             var timelineItemDateTime = new TagBuilder("p");
-            timelineItemDateTime.MergeCssClass("tpr-timeline__datetime");
+            timelineItemDateTime.AddCssClass("tpr-timeline__datetime");
             timelineItemDateTime.InnerHtml.AppendHtml(item.DateTime!.ToString());
             return timelineItemDateTime;
         }
@@ -77,7 +76,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         private static TagBuilder BuildHeading(TprTimelineItem item, int headingLevel)
         {
             var timelineItemHeading = new TagBuilder($"h{headingLevel}");
-            timelineItemHeading.MergeCssClass("tpr-timeline__heading");
+            timelineItemHeading.AddCssClass("tpr-timeline__heading");
             timelineItemHeading.InnerHtml.AppendHtml(item.Heading!.ToString());
             return timelineItemHeading;
         }

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprYouTubeVideo.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprYouTubeVideo.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ThePensionsRegulator.GovUk.Frontend;
 
@@ -35,9 +34,9 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             var containerTag = new TagBuilder("div");
             containerTag.MergeAttributes(video.Attributes);
-            containerTag.MergeCssClass("tpr-video-wrapper-no-cookies");
+            containerTag.AddCssClass("tpr-video-wrapper-no-cookies");
             var wrapperTag = new TagBuilder("div");
-            wrapperTag.MergeCssClass("tpr-video-wrapper-no-cookies__video-container");
+            wrapperTag.AddCssClass("tpr-video-wrapper-no-cookies__video-container");
 
             var iFrame = new TagBuilder("iframe");
             var src = "https://www.youtube-nocookie.com/embed/" + video.YouTubeVideoId;
@@ -61,7 +60,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             if (!string.IsNullOrWhiteSpace(video.TranscriptUrl))
             {
                 var transcriptLink = new TagBuilder("a");
-                transcriptLink.MergeCssClass("tpr-video-wrapper-no-cookies__transcript-link");
+                transcriptLink.AddCssClass("tpr-video-wrapper-no-cookies__transcript-link");
                 transcriptLink.Attributes.Add("href", video.TranscriptUrl);
                 if (!string.IsNullOrWhiteSpace(video.TranscriptTarget))
                 {

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-autocomplete.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-autocomplete.scss
@@ -40,7 +40,7 @@
 }
 
 .autocomplete__input--focused {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline: $govuk-focus-width solid govuk-functional-colour(focus);
     outline-offset: 0
 }
 

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-button.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-button.scss
@@ -8,6 +8,11 @@
 // defining a specific variable.
 $tpr-button-padding: 20px;
 
+// Reset GOV.UK opacity change, as TPR colours were chosen at opacity: 1
+.govuk-button[disabled] {
+    opacity: 1;
+}
+
 .govuk-button, .govuk-file-upload::file-selector-button {
     color: $govuk-button-text-colour;
     border-width: 1px;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-file-upload.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-file-upload.scss
@@ -35,8 +35,8 @@ $button-shadow-size: $govuk-border-width-form-element;
 
 .govuk-file-upload:focus-within,
 .govuk-file-upload:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    box-shadow: inset 0 0 0 govuk-px-to-rem(2) $govuk-focus-text-colour;
+    outline: $govuk-focus-width solid govuk-functional-colour(focus);
+    box-shadow: inset 0 0 0 govuk-px-to-rem(2) govuk-functional-colour(focus-text);
 }
 
 .govuk-file-upload::file-selector-button:hover,

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
@@ -61,7 +61,7 @@
 }
 
 .tpr-box--blue {
-    background-color: govuk-tint($tpr-colour-regent-st-blue, 75)
+    background-color: $tpr-colour-regent-st-blue-tint-75;
 }
 
 .tpr-box.govuk-grid-row {
@@ -271,20 +271,20 @@
     }
 
     & .govuk-input, & .govuk-select {
-        border-color: $govuk-error-colour;
+        border-color: govuk-functional-colour(error);
 
         &:focus {
-            border-color: $govuk-input-border-colour;
+            border-color: govuk-functional-colour(input-border);
         }
     }
 }
 
 .govuk-grid-column--error {
     & .govuk-input, & .govuk-select {
-        border-color: $govuk-error-colour;
+        border-color: govuk-functional-colour(error);
 
         &:focus {
-            border-color: $govuk-input-border-colour;
+            border-color: govuk-functional-colour(input-border);
         }
     }
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -19,7 +19,7 @@
     cursor: pointer;
 
     &:focus {
-        outline: $govuk-focus-width solid $govuk-focus-colour;
+        outline: $govuk-focus-width solid govuk-functional-colour(focus);
     }
 }
 
@@ -187,7 +187,7 @@
     }
 
     .tpr-header-menu__arrow:focus-visible {
-        outline: $govuk-focus-width solid $govuk-focus-colour;
+        outline: $govuk-focus-width solid govuk-functional-colour(focus);
         border-right: $govuk-focus-width solid $tpr-colour-black;
         border-bottom: $govuk-focus-width solid $tpr-colour-black;
     }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header.scss
@@ -155,7 +155,7 @@ $tpr-header-left-width-xl: 200px;
 }
 
 .tpr-header__content a:focus {
-    color: $govuk-focus-text-colour;
+    color: govuk-functional-colour(focus-text);
 }
 
 .tpr-header__content a:active {
@@ -199,8 +199,8 @@ $tpr-header-left-width-xl: 200px;
 }
 
 .tpr-context .govuk-link:focus {
-    color: $govuk-focus-text-colour;
-    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $tpr-colour-blue-marguerite;
+    color: govuk-functional-colour(focus-text);
+    box-shadow: 0 -2px govuk-functional-colour(focus), 0 4px $tpr-colour-blue-marguerite;
 }
 // Required when the text inside .tpr-context__context-2 is short.
 .tpr-context__container {
@@ -399,7 +399,7 @@ $tpr-header-left-width-xl: 200px;
 
     .tpr-header__content > a:link,
     .tpr-header__content > a:visited {
-        color: $govuk-link-colour;
+        color: govuk-functional-colour(link);
     }
 
     .tpr-context {
@@ -407,7 +407,7 @@ $tpr-header-left-width-xl: 200px;
     }
 
     .tpr-context .govuk-body {
-        color: $govuk-text-colour;
+        color: govuk-functional-colour(text);
     }
 
     .tpr-context__context-1 {

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-input.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-input.scss
@@ -26,5 +26,5 @@
 
 .govuk-input__prefix--readonly,
 .govuk-input__suffix--readonly {
-    color: govuk-tint(black, 44);
+    color: $tpr-colour-black-tint-44;
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-search-results.scss
@@ -67,7 +67,7 @@
 
     #tpr-search-results-show-more-questions {
         cursor: pointer;
-        color: $govuk-link-colour;
+        color: govuk-functional-colour(link);
         background: none;
         border: none;
         padding: 0;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-tag.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-tag.scss
@@ -3,6 +3,6 @@
 
 // Change GOV.UK panel styles where the TPR brand diverges from the GOV.UK Design System.
 .govuk-tag {
-    color: govuk-shade($tpr-colour-royal-blue, 60);
-    background-color: govuk-tint($tpr-colour-royal-blue, 70);
+    color: $tpr-colour-royal-blue-shade-60;
+    background-color: $tpr-colour-royal-blue-tint-70;
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-task-list.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-task-list.scss
@@ -21,7 +21,7 @@
 }
 
 .govuk-task-list__link:visited {
-    color: $govuk-link-colour;
+    color: govuk-functional-colour(link);
 }
 
 .govuk-task-list__status > .govuk-tag {
@@ -43,12 +43,12 @@
 
 .govuk-task-list__status--not-started > .govuk-tag {
     color: $tpr-colour-white;
-    background-color: govuk-tint($tpr-colour-violet,20);
+    background-color: $tpr-colour-violet-tint-20;
 }
 
 .govuk-task-list__status--incomplete > .govuk-tag {
-    color: govuk-shade($tpr-colour-violet, 16);
-    background-color: govuk-tint($tpr-colour-violet, 75);
+    color: $tpr-colour-violet-shade-16;
+    background-color: $tpr-colour-violet-tint-75;
 }
 
 .govuk-task-list__status--completed > .govuk-tag {
@@ -57,6 +57,6 @@
 }
 
 .govuk-task-list__status--error > .govuk-tag {
-    color: govuk-shade($tpr-colour-fire-brick, 30);
-    background-color: govuk-tint($tpr-colour-fire-brick, 75);
+    color: $tpr-colour-fire-brick-shade-30;
+    background-color: $tpr-colour-fire-brick-tint-75;
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-variables.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-variables.scss
@@ -10,15 +10,23 @@ $govuk-font-weight-bold: $tpr-font-weight-bold;
 // TPR brand colours
 $tpr-colour-lime: #cdd500;
 $tpr-colour-violet: #483b8b;
+$tpr-colour-violet-shade-16: #3c3275;
+$tpr-colour-violet-tint-20: #6d62a2;
+$tpr-colour-violet-tint-75: #d1cee2;
 $tpr-colour-blue-marguerite: #7469ba;
 $tpr-colour-tolopea: #0b0030;
 $tpr-colour-eastern-blue: #0381a2;
 $tpr-colour-regent-st-blue: #99ccd9;
+$tpr-colour-regent-st-blue-tint-75: #e6f2f6;
 $tpr-colour-royal-blue: #006ebc;
+$tpr-colour-royal-blue-shade-60: #002c4b;
+$tpr-colour-royal-blue-tint-70: #b3d4eb;
 $tpr-colour-kashmir-blue: #557b97;
 $tpr-colour-cornflower: #98c4e4;
 $tpr-colour-camarone: #1e7e34;
 $tpr-colour-fire-brick: #a91717;
+$tpr-colour-fire-brick-shade-30: #761010;
+$tpr-colour-fire-brick-tint-75: #eac5c5;
 $tpr-colour-brick: #cd2e25;
 $tpr-colour-petite-orchid: #dca1a1;
 $tpr-colour-tawny: #ca5002;
@@ -35,21 +43,24 @@ $tpr-colour-steel: #54616c;
 $tpr-colour-eclipse: #3d3d3d;
 $tpr-colour-zambezi: #585858;
 $tpr-colour-black: #000000;
+$tpr-colour-black-tint-44: #707070;
 
-// Change the colours on GOV.UK components where TPR brand colours diverge from 
+// Change the colours on GOV.UK components where TPR brand colours diverge from
 // the GOV.UK Design System. Colours are changed in two ways:
 // - here, before GOV.UK classes are compiled, targeting situations where GOV.UK source
 //   defines a variable for the specific situation
 // - in _tpr-*.scss for individual components, after GOV.UK classes are compiled
-$govuk-text-colour: $tpr-colour-eclipse;
-$govuk-link-colour: $tpr-colour-royal-blue;
-$govuk-link-visited-colour: $tpr-colour-violet;
-$govuk-link-hover-colour: $tpr-colour-kashmir-blue;
-$govuk-link-active-colour: $tpr-colour-kashmir-blue;
-$govuk-secondary-text-colour: $tpr-colour-zambezi;
-$govuk-input-border-colour: $tpr-colour-eclipse;
-$govuk-focus-colour: $tpr-colour-tangerine-yellow;
-$govuk-error-colour: $tpr-colour-fire-brick;
+$govuk-functional-colours: (
+    error: $tpr-colour-fire-brick,
+    focus: $tpr-colour-tangerine-yellow,
+    input-border: $tpr-colour-eclipse,
+    link: $tpr-colour-royal-blue,
+    link-active: $tpr-colour-kashmir-blue,
+    link-hover: $tpr-colour-kashmir-blue,
+    link-visited: $tpr-colour-violet,
+    text: $tpr-colour-eclipse,
+    secondary-text: $tpr-colour-zambezi
+);
 $govuk-button-text-colour: $tpr-colour-white;
 $govuk-button-background-colour: $tpr-colour-eastern-blue;
 $govuk-inverse-button-text-colour: $govuk-button-text-colour;
@@ -164,26 +175,12 @@ $govuk-typography-scale: (
       font-size: 14pt,
       line-height: 1.2
     )
-  ),
-  14: (
-    null: (
-      font-size: 12px,
-      line-height: 15px
-    ),
-    tablet: (
-      font-size: 14px,
-      line-height: 20px
-    ),
-    print: (
-      font-size: 12pt,
-      line-height: 1.2
-    )
   )
 ) !default;
 
 @mixin tpr-read-only {
     opacity: 1;
     background-color: $tpr-colour-white-smoke;
-    border-color: govuk-tint(black, 44);
-    color: govuk-tint(black, 44);
+    border-color: $tpr-colour-black-tint-44;
+    color: $tpr-colour-black-tint-44;
 }

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -30,9 +30,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.5.1" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 	</ItemGroup>
 

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
@@ -1,4 +1,4 @@
-﻿import { Accordion } from '/govuk-frontend.min.js?v=5.14.0';
+﻿import { Accordion } from '/govuk-frontend.min.js?v=6.0.0';
 
 let searchResults = [];
 let popularContentApiUrl = "";

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
@@ -7,7 +7,7 @@
     padding-top: .1px;
     display: block;
     cursor: pointer;
-    color: $govuk-text-colour;
+    color: govuk-functional-colour(text);
 }
 
 .backoffice-block-view:link, .backoffice-block-view:visited {
@@ -90,7 +90,7 @@
     margin-bottom: 0;
 }
 .backoffice-block-view .govuk-task-list__link {
-    color: $govuk-link-colour;
+    color: govuk-functional-colour(link);
 }
 
 .backoffice-block-view .govuk-textarea {
@@ -115,11 +115,11 @@
 
 /* Links are disabled by converting them to span, but should still look like links. */
 .backoffice-block-view span.govuk-link {
-    color: $govuk-link-colour;
+    color: govuk-functional-colour(link);
     cursor: pointer;
 }
 .backoffice-block-view .govuk-error-summary span.govuk-link {
-    color: $govuk-error-colour;
+    color: govuk-functional-colour(error);
 }
 
 /* If govuk-\!-display-none is applied the preview could disappear entirely, leaving no backoffice UI,

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
@@ -61,7 +61,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
 		<PackageReference Include="MimeKit" Version="4.15.1" />
 		<PackageReference Include="TinyMCE.Umbraco" Version="17.2.0" />
 		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.2.2" />

--- a/ThePensionsRegulator.GovUk.Frontend/HtmlGeneration/ComponentGenerator.TaskList.cs
+++ b/ThePensionsRegulator.GovUk.Frontend/HtmlGeneration/ComponentGenerator.TaskList.cs
@@ -2,7 +2,6 @@ using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using System.Text.Encodings.Web;
-using ThePensionsRegulator.GovUk.Frontend;
 using ThePensionsRegulator.GovUk.Frontend.TagHelpers;
 
 namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
@@ -25,7 +24,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
 
             var taskListTagBuilder = new TagBuilder(TaskListElement);
             if (attributes is not null) { taskListTagBuilder.MergeAttributes(attributes); }
-            taskListTagBuilder.MergeCssClass("govuk-task-list");
+            taskListTagBuilder.AddCssClass("govuk-task-list");
 
             if (string.IsNullOrEmpty(idPrefix)) { idPrefix = "task-list"; }
 
@@ -46,9 +45,9 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
 
                 if (ShouldLinkToTask(task))
                 {
-                    taskTagBuilder.MergeCssClass("govuk-task-list__item--with-link");
+                    taskTagBuilder.AddCssClass("govuk-task-list__item--with-link");
                 }
-                taskTagBuilder.MergeCssClass("govuk-task-list__item");
+                taskTagBuilder.AddCssClass("govuk-task-list__item");
 
                 taskTagBuilder.InnerHtml.AppendHtml(BuildNameAndHint(task, hintId, statusId));
 
@@ -64,7 +63,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
         private static TagBuilder BuildNameAndHint(TaskListTask task, string? hintId, string? statusId)
         {
             var taskNameAndHintTagBuilder = new TagBuilder(TaskListTaskNameElement);
-            taskNameAndHintTagBuilder.MergeCssClass("govuk-task-list__name-and-hint");
+            taskNameAndHintTagBuilder.AddCssClass("govuk-task-list__name-and-hint");
 
             if (ShouldLinkToTask(task))
             {
@@ -96,7 +95,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
             {
                 statusOuterTagBuilder.MergeAttributes(task.Status.Attributes);
             }
-            statusOuterTagBuilder.MergeCssClass("govuk-task-list__status");
+            statusOuterTagBuilder.AddCssClass("govuk-task-list__status");
             if (!statusOuterTagBuilder.Attributes.ContainsKey("id")) { statusOuterTagBuilder.MergeAttribute("id", statusId); }
 
             var statusText = task.Status.Status.AsText(task.Status.Content);
@@ -104,7 +103,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
             {
                 var statusInnerTagBuilder = new TagBuilder(TaskListTaskStatusTagHelper.StatusTagElement);
                 statusInnerTagBuilder.MergeAttributes(task.Status.Tag.Attributes);
-                statusInnerTagBuilder.MergeCssClass("govuk-tag");
+                statusInnerTagBuilder.AddCssClass("govuk-tag");
 
                 statusInnerTagBuilder.InnerHtml.AppendHtml(statusText);
                 statusOuterTagBuilder.InnerHtml.AppendHtml(statusInnerTagBuilder);
@@ -122,7 +121,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
             var hintTagBuilder = new TagBuilder(TaskListHintElement);
             hintTagBuilder.Attributes.Add("id", hintId);
             hintTagBuilder.MergeAttributes(task.Hint!.Attributes);
-            hintTagBuilder.MergeCssClass("govuk-task-list__hint");
+            hintTagBuilder.AddCssClass("govuk-task-list__hint");
             hintTagBuilder.InnerHtml.AppendHtml(task.Hint.Content!);
             return hintTagBuilder;
         }
@@ -170,8 +169,8 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
             var taskLinkTagBuilder = new TagBuilder("a");
             taskLinkTagBuilder.MergeAttribute("href", task.Link.Href);
             taskLinkTagBuilder.MergeAttributes(task.Link.Attributes);
-            taskLinkTagBuilder.MergeCssClass("govuk-task-list__link");
-            taskLinkTagBuilder.MergeCssClass("govuk-link");
+            taskLinkTagBuilder.AddCssClass("govuk-task-list__link");
+            taskLinkTagBuilder.AddCssClass("govuk-link");
             taskLinkTagBuilder.InnerHtml.AppendHtml(task.Name.Content!);
 
             var linkDescribedBy = new List<string>();

--- a/ThePensionsRegulator.GovUk.Frontend/HtmlGeneration/ComponentGenerator.TaskListSummary.cs
+++ b/ThePensionsRegulator.GovUk.Frontend/HtmlGeneration/ComponentGenerator.TaskListSummary.cs
@@ -1,7 +1,5 @@
-using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System.Web;
-using ThePensionsRegulator.GovUk.Frontend;
 
 namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
 {
@@ -30,17 +28,17 @@ namespace ThePensionsRegulator.GovUk.Frontend.HtmlGeneration
 
             var tagBuilder = new TagBuilder(TaskListSummaryElement);
             if (taskListSummary.Attributes != null) { tagBuilder.MergeAttributes(taskListSummary.Attributes); }
-            tagBuilder.MergeCssClass("govuk-task-list-summary");
+            tagBuilder.AddCssClass("govuk-task-list-summary");
 
             var statusTagBuilder = new TagBuilder($"h{taskListSummary.HeadingLevel}");
-            statusTagBuilder.MergeCssClass("govuk-heading-s");
-            statusTagBuilder.MergeCssClass("govuk-task-list-summary__heading");
+            statusTagBuilder.AddCssClass("govuk-heading-s");
+            statusTagBuilder.AddCssClass("govuk-task-list-summary__heading");
             statusTagBuilder.InnerHtml.Append(taskListSummary.CompletedTasks == taskListSummary.TotalTasks ? taskListSummary.CompletedStatus : taskListSummary.IncompleteStatus);
             tagBuilder.InnerHtml.AppendHtml(statusTagBuilder);
 
             var trackerTagBuilder = new TagBuilder("p");
-            trackerTagBuilder.MergeCssClass("govuk-body");
-            trackerTagBuilder.MergeCssClass("govuk-task-list-summary__tracker");
+            trackerTagBuilder.AddCssClass("govuk-body");
+            trackerTagBuilder.AddCssClass("govuk-task-list-summary__tracker");
             trackerTagBuilder.InnerHtml.AppendHtml(string.Format(HttpUtility.HtmlEncode(taskListSummary.Tracker),
                 "<span class=\"govuk-task-list-summary__completed-tasks\">" + taskListSummary.CompletedTasks + "</span>",
                 "<span class=\"govuk-task-list-summary__total-tasks\">" + taskListSummary.TotalTasks + "</span>"));

--- a/ThePensionsRegulator.GovUk.Frontend/Styles/_govuk-pagination.scss
+++ b/ThePensionsRegulator.GovUk.Frontend/Styles/_govuk-pagination.scss
@@ -1,7 +1,7 @@
 ﻿// GOV.UK Design System documentation says not to show the ellipsis on small screens but govuk-frontend
 // doesn't implement that.
 @include govuk-media-query($until: tablet) {
-    .govuk-pagination__item--ellipses {
+    .govuk-pagination__item--ellipsis {
         display: none;
     }
 }

--- a/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
@@ -39,10 +39,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="FileSignatures" Version="5.0.2" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.5.1" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 	</ItemGroup>
 

--- a/ThePensionsRegulator.GovUk.Frontend/wwwroot/ThePensionsRegulator.GovUk.Frontend/js/govuk-js-init.js
+++ b/ThePensionsRegulator.GovUk.Frontend/wwwroot/ThePensionsRegulator.GovUk.Frontend/js/govuk-js-init.js
@@ -1,4 +1,4 @@
-﻿import { initAll } from '/govuk-frontend.min.js?v=5.14.0';
+﻿import { initAll } from '/govuk-frontend.min.js?v=6.0.0';
 const [html] = document.getElementsByTagName("html");
 const lang = html.getAttribute("lang");
 const config = lang === 'cy' || lang === 'cy-GB' ? {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "brace-expansion": "^5.0.5",
-        "govuk-frontend": "^5.14.0"
+        "govuk-frontend": "^6.0.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -2587,9 +2587,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.0.0.tgz",
+      "integrity": "sha512-n1DUbQD6coHL3UkQS0yTbd4ziIxLBzkWBODVCjXMclSY7FvOGeHcTg3c72z6u7DQECQb0tfZofhPjGxPUOIizA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "brace-expansion": "^5.0.5",
-    "govuk-frontend": "^5.14.0"
+    "govuk-frontend": "^6.0.0"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --ci --watchAll=false --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura",


### PR DESCRIPTION
This PR upgrades our core dependencies to:

- [govuk-frontend-aspnetcore v4.0.0](https://github.com/x-govuk/govuk-frontend-aspnetcore/releases/tag/v4.0.0)
- [GOV.UK Frontend v6.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0)

The first upgrade removes the `MergeCssClass` extension method we were using, so code is updated to use the standard `AddCssClass` instead.

The second introduces changes in the SASS code that are significant for us:
- We upgrade our SASS compiler package to get the latest version of the Dart SASS compiler.
- The `govuk-tint()` and `govuk-shade()` functions that we were using are gone, so define variables for the tints and shades we had previously defined using the functions, to leave the end result unchanged.
- Some core SASS variables defining colours are now set and consumed differently, using the `govuk-functional-colour()` function, so we update our code to leave the end result unchanged.
- A typo is corrected in the class name for the pagination ellipsis, so we update our customisation of the class to leave the end result unchanged.
- GOV.UK set disabled buttons to `0.5` opacity. We reset that to leave the end result unchanged.
- GOV.UK removed size `14` from their typography scale, so we do too. We were not using it.

 #739