### PR TITLE
Upgrade govuk-frontend-aspnetcore to 4.0.1

### DIFF
--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -32,7 +32,7 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.1" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 	</ItemGroup>
 

--- a/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
@@ -42,7 +42,7 @@
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="FileSignatures" Version="5.0.2" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.0" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.1" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 	</ItemGroup>
 


### PR DESCRIPTION
Apply a [minor bug fix](https://github.com/x-govuk/govuk-frontend-aspnetcore/releases/tag/v4.0.1) as we're already on 4.0.0.