### PR TITLE
Fix error when consuming v17 packages and compiling SASS 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.0.0-beta004</Version>
+    <Version>10.0.0-beta005</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
@@ -127,6 +127,10 @@
 			<Pack>true</Pack>
 			<PackagePath>Styles\govuk\objects</PackagePath>
 		</Content>
+		<Content Include="$(GovUkFrontEndSrcFolder)\govuk\custom-properties\*.scss" Link="$(MsBuildThisFileDirectory)">
+			<Pack>true</Pack>
+			<PackagePath>Styles\govuk\custom-properties</PackagePath>
+		</Content>
 		<Content Remove="bundleconfig.json" />
 		<None Include="..\tpr-nuget.png">
 		  <Pack>True</Pack>


### PR DESCRIPTION
If you:
- consume `ThePensionsRegulator.GovUk.Frontend.Umbraco` or `ThePensionsRegulator.Frontend.Umbraco` version `10.0.0-beta004`
- have a `Styles` folder
- have a `.scss` file in the `Styles` folder which contains the following import: `@import 'govuk/base';`
- have the `AspNetCore.SassCompiler` package installed

When you compile the project you get a SASS compilation error reporting that `custom-properties/index` cannot be found.

<img width="445" height="184" alt="custom-properties/index not found" src="https://github.com/user-attachments/assets/dec57f6c-25d3-46a3-8abb-d8f5c469c430" />

This is because GOV.UK SASS in GOV.UK Frontend v6.0.0 now depends upon files in a new folder called `custom-properties`, so we need to include these files in our package along with other similar dependencies.

Fixes #766.