### PR TITLE
Make cleanup tasks run before build, and add cleanup of some missed files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.0.0-beta005</Version>
+    <Version>10.0.0-beta006</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.targets
@@ -16,9 +16,6 @@
 		-->
 		<Message Text="ThePensionsRegulator.Frontend.Umbraco not copying uSync and backoffice CSS files because the target project is not a web project." Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) != true" Importance="high" />
 		<CallTarget Targets="TprFrontendUmbraco_CopyFiles" Condition="$(TprFrontendUmbraco_TargetProjectIsWebProject) == true" />
-
-		<!-- Always clean up obsolete files from previous versions where they would cause a conflict. -->
-		<CallTarget Targets="TprFrontendUmbraco_Cleanup" />
 	</Target>
 
 	<Target Name="TprFrontendUmbraco_CopyFiles">
@@ -61,7 +58,7 @@
 		<WriteLinesToFile File="$(ProjectDir)uSync\ThePensionsRegulator.Frontend.Umbraco\.gitignore" Lines="@(TprFrontendUmbracoUSyncGitIgnore)" Overwrite="True"/>
 	</Target>
 
-	<Target Name="TprFrontendUmbraco_Cleanup" BeforeTargets="CoreClean">
+	<Target Name="TprFrontendUmbraco_Cleanup" BeforeTargets="BeforeBuild">
 		<!-- Clean up obsolete files from previous versions where they would cause a conflict. -->
 		<ItemGroup>
 			<TprFrontendUmbraco_uSyncVersion Include="v9"/>
@@ -90,6 +87,7 @@
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheader.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheader.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenu.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenu.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenuchilditem.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenuchilditem.config')" />
+		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenuparentitem.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenuparentitem.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenuitem.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprheadermenuitem.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprimage.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprimage.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprimagesettings.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\ContentTypes\tprimagesettings.config')" />
@@ -124,6 +122,8 @@
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRFooterLanguageCodeRadioButtonList.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRFooterLanguageCodeRadioButtonList.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRFooterThreeColumnLinksBlockGrid.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRFooterThreeColumnLinksBlockGrid.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuBlockList.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuBlockList.config')" />
+		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuChildItemBlockList.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuChildItemBlockList.config')" />
+		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuParentItemBlockList.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuParentItemBlockList.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuItemBlockList.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeaderMenuItemBlockList.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeadingLevelSearchResults.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeadingLevelSearchResults.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeadingLevelSectionCards.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRHeadingLevelSectionCards.config')" />
@@ -131,6 +131,7 @@
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRNestedBoxStyle.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRNestedBoxStyle.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRRichTextEditorHeaderAndFooter.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRRichTextEditorHeaderAndFooter.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRRichTextEditorSectionCard.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRRichTextEditorSectionCard.config')" />
+		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRRichTextEditorYouTubeVideoDescription.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRRichTextEditorYouTubeVideoDescription.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRSectionCardsBlockList.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRSectionCardsBlockList.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRYouTubeVideoSettingsAutoplay.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRYouTubeVideoSettingsAutoplay.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRYouTubeVideoSettingsPlaysInline.config" Condition="Exists('$(ProjectDir)uSync\%(TprFrontendUmbraco_uSyncVersion.Identity)\DataTypes\TPRYouTubeVideoSettingsPlaysInline.config')" />

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.targets
@@ -87,7 +87,7 @@ govuk-umbraco-backoffice.css.map
 		<WriteLinesToFile File="$(ProjectDir)uSync\ThePensionsRegulator.GovUk.Frontend.Umbraco\.gitignore" Lines="@(GovUkFrontendUmbracoUSyncGitIgnore)" Overwrite="True" />
 	</Target>
 
-	<Target Name="GovUkFrontendUmbraco_Cleanup" BeforeTargets="CoreClean">
+	<Target Name="GovUkFrontendUmbraco_Cleanup" BeforeTargets="BeforeBuild">
 		<!-- Clean up obsolete files from previous versions where they would cause a conflict. -->
 		<ItemGroup>
 			<GovUkFrontendUmbraco_uSyncVersion Include="v9"/>
@@ -241,6 +241,7 @@ govuk-umbraco-backoffice.css.map
 		<Delete Files="$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKPhase.config" Condition="Exists('$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKPhase.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRadioButtons.config" Condition="Exists('$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRadioButtons.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRadiosLayout.config" Condition="Exists('$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRadiosLayout.config')" />
+		<Delete Files="$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditor.config" Condition="Exists('$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditor.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditorInline.config" Condition="Exists('$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditorInline.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditorInlineAndInverse.config" Condition="Exists('$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditorInlineAndInverse.config')" />
 		<Delete Files="$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditorNotificationBanner.config" Condition="Exists('$(ProjectDir)uSync\%(GovUkFrontendUmbraco_uSyncVersion.Identity)\DataTypes\GOVUKRichTextEditorNotificationBanner.config')" />


### PR DESCRIPTION
In the *.targets files built into the ThePensionsRegulator.Frontend.Umbraco and ThePensionsRegulator.GovUk.Frontend.Umbraco packages there are cleanup targets that remove obsolete uSync files.

Only one of these is called (unnecessarily) from another target, while both are set to run before the CoreClean target. However this target only runs when the 'Clean' option is selected in Visual Studio, meaning cleanup can be missed and then uSync fails due to errors.

This PR:
- Removes the redundant call to a cleanup task that runs anyway
- Changes the targeting to `BeforeBuild` so that these targets are guaranteed to run 

Also, on the corporate website upgrade they missed some files, so this PR adds ones that were definitely part of these packages at some point:

- GOVUKRichTextEditor.config data type
- TPRHeaderMenuChildItemBlockList.config data type
- TPRHeaderMenuParentItemBlockList.config data type
- TPRRichTextEditorYouTubeVideoDescription.config data type
- tprheadermenuparentitem.config content type

Fixes #770