### PR TITLE
#257749 Welsh copy for accordion component (v17)

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/hide-all-sections.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/hide-all-sections.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Dictionary Key="a4524d9a-4656-4591-8a69-181f3479a287" Alias="Hide all sections" Level="0">
+  <Info />
+  <Translations>
+    <Translation Language="cy">Cuddio pob adran</Translation>
+    <Translation Language="en-GB">Hide all sections</Translation>
+    <Translation Language="en-US"></Translation>
+  </Translations>
+</Dictionary>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/hide.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/hide.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Dictionary Key="b7afc75d-59b1-4b57-a293-7d96354e152e" Alias="Hide" Level="0">
+  <Info />
+  <Translations>
+    <Translation Language="cy">Cuddio</Translation>
+    <Translation Language="en-GB">Hide</Translation>
+    <Translation Language="en-US"></Translation>
+  </Translations>
+</Dictionary>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/show-all-sections.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/show-all-sections.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Dictionary Key="61307377-c24e-4217-a5c4-69ff43fb2f87" Alias="Show all sections" Level="0">
+  <Info />
+  <Translations>
+    <Translation Language="cy">Dangos pob adran</Translation>
+    <Translation Language="en-GB">Show all sections</Translation>
+    <Translation Language="en-US"></Translation>
+  </Translations>
+</Dictionary>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/show.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/show.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Dictionary Key="331d0c84-731d-4c47-9f27-3fc8a3f25e94" Alias="Show" Level="0">
+  <Info />
+  <Translations>
+    <Translation Language="cy">Dangos</Translation>
+    <Translation Language="en-GB">Show</Translation>
+    <Translation Language="en-US"></Translation>
+  </Translations>
+</Dictionary>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkAccordion.cshtml
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkAccordion.cshtml
@@ -28,9 +28,14 @@
             _ => headingClasses.Heading2
         };
     }
+    var showAllSectionsText = Umbraco.GetDictionaryValueOrDefault("Hide all sections", "Hide all sections");
+    var showSectionText = Umbraco.GetDictionaryValueOrDefault("Hide", "Hide");
+
+    var hideAllSectionsText = Umbraco.GetDictionaryValueOrDefault("Show all sections", "Show all sections");
+    var hideSectionText = Umbraco.GetDictionaryValueOrDefault("Show", "Show");
     cssClasses = string.IsNullOrWhiteSpace(cssClasses) ? headingClass : headingClass + " " + cssClasses;
 }
-<govuk-accordion id="@Model.Content.Key" class="@cssClasses" heading-level="@headingLevel">
+<govuk-accordion id="@Model.Content.Key" class="@cssClasses" heading-level="@headingLevel" hide-all-sections-text="@hideAllSectionsText" hide-section-text="@hideSectionText" show-all-sections-text="@showAllSectionsText" show-section-text="@showSectionText">
     @foreach (var section in sections.FilteredBlocks())
     {
         var grid = section.Content.Value<OverridableBlockGridModel>(PropertyAliases.AccordionSectionBlocks)!;

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkAccordion.cshtml
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkAccordion.cshtml
@@ -28,11 +28,11 @@
             _ => headingClasses.Heading2
         };
     }
-    var showAllSectionsText = Umbraco.GetDictionaryValueOrDefault("Hide all sections", "Hide all sections");
-    var showSectionText = Umbraco.GetDictionaryValueOrDefault("Hide", "Hide");
+    var showAllSectionsText = Umbraco.GetDictionaryValueOrDefault("Show all sections", "Show all sections");
+    var showSectionText = Umbraco.GetDictionaryValueOrDefault("Show", "Show");
 
-    var hideAllSectionsText = Umbraco.GetDictionaryValueOrDefault("Show all sections", "Show all sections");
-    var hideSectionText = Umbraco.GetDictionaryValueOrDefault("Show", "Show");
+    var hideAllSectionsText = Umbraco.GetDictionaryValueOrDefault("Hide all sections", "Hide all sections");
+    var hideSectionText = Umbraco.GetDictionaryValueOrDefault("Hide", "Hide");
     cssClasses = string.IsNullOrWhiteSpace(cssClasses) ? headingClass : headingClass + " " + cssClasses;
 }
 <govuk-accordion id="@Model.Content.Key" class="@cssClasses" heading-level="@headingLevel" hide-all-sections-text="@hideAllSectionsText" hide-section-text="@hideSectionText" show-all-sections-text="@showAllSectionsText" show-section-text="@showSectionText">


### PR DESCRIPTION
Why:

- The accordion component needed a Welsh copy for 'Show all sections', 'Show', 'Hide all sections', 'Hide' when it is being used on a Welsh page.

<img width="602" height="148" alt="image" src="https://github.com/user-attachments/assets/6b61c7a3-109e-4370-945d-afb3c44b2639" />

In this PR:

- Received translations for all values and added to Umbraco dictionary.
- Added relevant properties to the tag helper to display these values.