### PR TITLE
Resolve a vulnerability in OpenMcdf

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.0.0-beta006</Version>
+    <Version>10.0.0-beta007</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
@@ -1573,9 +1573,9 @@
       "peer": true
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.2.2.tgz",
-      "integrity": "sha512-sRiFvQczo4besCUjXut263k7BMc5J1Xf5A3cggFGf6WZ5q4nZSapVTV2cbI4NBWHaBkcPY3CPh57bWqu7QtodA==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.3.4.tgz",
+      "integrity": "sha512-7gGc7BXe0zhMHrF25AOKqcxwvobPmKtQoEHAObdePKzHLJYMxxgpVRGvfhfFAzG8SYnbWy4Jz3vKsxgd+xHRQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1583,29 +1583,29 @@
         "npm": ">=10.9.2"
       },
       "peerDependencies": {
-        "@heximal/expressions": "^0.1.5",
-        "@hey-api/openapi-ts": "^0.85.0",
+        "@heximal/expressions": ">=0.1.5 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.85.0 <1.0.0",
         "@microsoft/signalr": "^10.0.0",
-        "@tiptap/core": "3.16.0",
-        "@tiptap/extension-image": "3.16.0",
-        "@tiptap/extension-subscript": "3.16.0",
-        "@tiptap/extension-superscript": "3.16.0",
-        "@tiptap/extension-table": "3.16.0",
-        "@tiptap/extension-text-align": "3.16.0",
-        "@tiptap/extension-text-style": "3.16.0",
-        "@tiptap/extensions": "3.16.0",
-        "@tiptap/pm": "3.16.0",
-        "@tiptap/starter-kit": "3.16.0",
+        "@tiptap/core": "^3.16.0",
+        "@tiptap/extension-image": "^3.16.0",
+        "@tiptap/extension-subscript": "^3.16.0",
+        "@tiptap/extension-superscript": "^3.16.0",
+        "@tiptap/extension-table": "^3.16.0",
+        "@tiptap/extension-text-align": "^3.16.0",
+        "@tiptap/extension-text-style": "^3.16.0",
+        "@tiptap/extensions": "^3.16.0",
+        "@tiptap/pm": "^3.16.0",
+        "@tiptap/starter-kit": "^3.16.0",
         "@types/diff": "^7.0.2",
-        "@umbraco-ui/uui": "^1.17.0",
-        "@umbraco-ui/uui-css": "^1.17.0",
+        "@umbraco-ui/uui": "^1.17.2",
+        "@umbraco-ui/uui-css": "^1.17.1",
         "diff": "^8.0.3",
         "dompurify": "^3.3.0",
         "element-internals-polyfill": "^3.0.2",
         "lit": "^3.3.1",
         "luxon": "^3.7.2",
         "marked": "^17.0.1",
-        "monaco-editor": "^0.55.1",
+        "monaco-editor": ">=0.55.1 <1.0.0",
         "rxjs": "^7.8.2",
         "uuid": "^13.0.0"
       }
@@ -2912,9 +2912,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -4141,9 +4141,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -4156,9 +4156,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package.json
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package.json
@@ -14,6 +14,7 @@
   },
   "overrides": {
     "dompurify": "^3.3.3",
-    "handlebars": "^4.7.9"
+    "handlebars": "^4.7.9",
+    "uuid": "^14.0.0"
   }
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
@@ -1573,9 +1573,9 @@
       "peer": true
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.2.2.tgz",
-      "integrity": "sha512-sRiFvQczo4besCUjXut263k7BMc5J1Xf5A3cggFGf6WZ5q4nZSapVTV2cbI4NBWHaBkcPY3CPh57bWqu7QtodA==",
+      "version": "17.3.4",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.3.4.tgz",
+      "integrity": "sha512-7gGc7BXe0zhMHrF25AOKqcxwvobPmKtQoEHAObdePKzHLJYMxxgpVRGvfhfFAzG8SYnbWy4Jz3vKsxgd+xHRQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1583,29 +1583,29 @@
         "npm": ">=10.9.2"
       },
       "peerDependencies": {
-        "@heximal/expressions": "^0.1.5",
-        "@hey-api/openapi-ts": "^0.85.0",
+        "@heximal/expressions": ">=0.1.5 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.85.0 <1.0.0",
         "@microsoft/signalr": "^10.0.0",
-        "@tiptap/core": "3.16.0",
-        "@tiptap/extension-image": "3.16.0",
-        "@tiptap/extension-subscript": "3.16.0",
-        "@tiptap/extension-superscript": "3.16.0",
-        "@tiptap/extension-table": "3.16.0",
-        "@tiptap/extension-text-align": "3.16.0",
-        "@tiptap/extension-text-style": "3.16.0",
-        "@tiptap/extensions": "3.16.0",
-        "@tiptap/pm": "3.16.0",
-        "@tiptap/starter-kit": "3.16.0",
+        "@tiptap/core": "^3.16.0",
+        "@tiptap/extension-image": "^3.16.0",
+        "@tiptap/extension-subscript": "^3.16.0",
+        "@tiptap/extension-superscript": "^3.16.0",
+        "@tiptap/extension-table": "^3.16.0",
+        "@tiptap/extension-text-align": "^3.16.0",
+        "@tiptap/extension-text-style": "^3.16.0",
+        "@tiptap/extensions": "^3.16.0",
+        "@tiptap/pm": "^3.16.0",
+        "@tiptap/starter-kit": "^3.16.0",
         "@types/diff": "^7.0.2",
-        "@umbraco-ui/uui": "^1.17.0",
-        "@umbraco-ui/uui-css": "^1.17.0",
+        "@umbraco-ui/uui": "^1.17.2",
+        "@umbraco-ui/uui-css": "^1.17.1",
         "diff": "^8.0.3",
         "dompurify": "^3.3.0",
         "element-internals-polyfill": "^3.0.2",
         "lit": "^3.3.1",
         "luxon": "^3.7.2",
         "marked": "^17.0.1",
-        "monaco-editor": "^0.55.1",
+        "monaco-editor": ">=0.55.1 <1.0.0",
         "rxjs": "^7.8.2",
         "uuid": "^13.0.0"
       }
@@ -2912,9 +2912,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -4141,9 +4141,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -4156,9 +4156,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package.json
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package.json
@@ -14,6 +14,7 @@
   },
   "overrides": {
     "dompurify": "^3.3.3",
-    "handlebars": "^4.7.9"
+    "handlebars": "^4.7.9",
+    "uuid": "^14.0.0"
   }
 }

--- a/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
@@ -41,9 +41,10 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-		<PackageReference Include="FileSignatures" Version="5.0.2" />
+		<PackageReference Include="FileSignatures" Version="7.0.0" />
 		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.1" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+		<PackageReference Include="OpenMcdf" Version="3.1.3" />
 	</ItemGroup>
 
 	<Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
-        "jest-junit": "^14.0.0"
+        "jest-junit": "^8.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3155,6 +3155,16 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-get-type": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/jest-haste-map": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
@@ -3181,19 +3191,207 @@
       }
     },
     "node_modules/jest-junit": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-14.0.1.tgz",
-      "integrity": "sha512-h7/wwzPbllgpQhhVcRzRC76/cc89GlazThoV1fDxcALkf26IIlRsu/AcTG64f4nR2WPE3Cbd+i/sVf+NCUHrWQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-8.0.0.tgz",
+      "integrity": "sha512-cuD2XM2youMjrOxOu/7H2pLfsO8LfAG4D3WsBxd9fFyI9U0uPpmr/CORH64kbIyZ47X5x1Rbzb9ovUkAEvhEEA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "mkdirp": "^1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2",
+        "jest-validate": "^24.0.0",
+        "mkdirp": "^0.5.1",
+        "strip-ansi": "^4.0.0",
         "xml": "^1.0.1"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/jest-junit/node_modules/@types/yargs": {
+      "version": "13.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-junit/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-junit/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-junit/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/jest-junit/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-junit/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-junit/node_modules/jest-validate": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+      "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-junit/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-junit/node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-junit/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -3790,6 +3988,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -3801,16 +4009,16 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -4735,16 +4943,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
-    "jest-junit": "^14.0.0"
+    "jest-junit": "^8.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",


### PR DESCRIPTION
Update FileSignatures to a version that uses v3.x of OpenMcdf, so that OpenMcdf can be updated to resolve a vulnerability.

Package 'OpenMcdf' 2.3.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-jxpf-xq2m-q525

Also resolves some vulnerabilities in the npm ecosystem including #776 

uuid <14.0.0
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pquuid <14.0.0
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq