### PR TITLE
Fix transitive NuGet vulnerabilities on v13 branch

### DIFF
--- a/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
+++ b/GovUk.Frontend.AspNetCore.Extensions/GovUk.Frontend.AspNetCore.Extensions.csproj
@@ -38,10 +38,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
-		<PackageReference Include="FileSignatures" Version="5.0.2" />
+		<PackageReference Include="FileSignatures" Version="7.0.0" />
 		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="3.4.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
+		<PackageReference Include="OpenMcdf" Version="3.1.3" />
 	</ItemGroup>
 
 	<Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MimeKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="13.11.0" />
   </ItemGroup>
 

--- a/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
+++ b/ThePensionsRegulator.Umbraco/ThePensionsRegulator.Umbraco.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="13.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolve vulnerabilities in .NET transitive dependencies:

- OpenMcdf #778 
- Mailkit
- System.Security.Cryptography.Xml