### PR TITLE
Support royal blue and green boxes

### DIFF
--- a/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/Index.cshtml
@@ -71,6 +71,9 @@
         <div class="tpr-box tpr-box--royal-blue">
             <p class="govuk-body">This box has its background colour set to royal blue.</p>
         </div>
+        <div class="tpr-box tpr-box--green">
+            <p class="govuk-body">This box has its background colour set to green.</p>
+        </div>
     </div>
 </div>
 <div class="govuk-grid-row govuk-grid-row--tpr-divider tpr-box">
@@ -87,7 +90,12 @@
         </div>
         <div class="tpr-box tpr-box--royal-blue">
             <partial name="_BoxContentPart1" />
-            <p class="govuk-body">This box is set to Royal Blue. Inverse colours must be used when the box has a dark background.</p>
+            <p class="govuk-body">This box is set to royal blue. Inverse colours must be used when the box has a dark background.</p>
+            <partial name="_BoxContentPart2" />
+        </div>
+        <div class="tpr-box tpr-box--green">
+            <partial name="_BoxContentPart1" />
+            <p class="govuk-body">This box is set to green. Inverse colours must be used when the box has a dark background.</p>
             <partial name="_BoxContentPart2" />
         </div>
     </div>

--- a/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/Index.cshtml
@@ -60,10 +60,16 @@
         <div class="tpr-box">
             <p class="govuk-body">Boxes can be added within columns.</p>
         </div>
-    </div>
-    <div class="govuk-grid-column govuk-grid-column-one-half">
         <div class="tpr-box tpr-box--bordered">
             <p class="govuk-body">Bordered boxes can be added within columns too.</p>
+        </div>
+    </div>
+    <div class="govuk-grid-column govuk-grid-column-one-half">
+        <div class="tpr-box tpr-box--blue">
+            <p class="govuk-body">This box has its background colour set to blue.</p>
+        </div>
+        <div class="tpr-box tpr-box--royal-blue">
+            <p class="govuk-body">This box has its background colour set to royal blue.</p>
         </div>
     </div>
 </div>
@@ -72,6 +78,21 @@
         <p class="govuk-body">This box has a divider applied and the column is set to full width to show the two styles working together.</p>
     </div>
 </div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column govuk-grid-column-full">
+        <div class="tpr-box">
+            <partial name="_BoxContentPart1" />
+            <partial name="_BoxContentPart2" />
+        </div>
+        <div class="tpr-box tpr-box--royal-blue">
+            <partial name="_BoxContentPart1" />
+            <p class="govuk-body">This box is set to Royal Blue. Inverse colours must be used when the box has a dark background.</p>
+            <partial name="_BoxContentPart2" />
+        </div>
+    </div>
+</div>
+
 <div class="govuk-grid-row govuk-grid-row--tpr-divider-for-fieldset govuk-grid-row--tpr-divider">
     <div class="govuk-grid-column govuk-grid-column-two-thirds-from-desktop">
         <div class="govuk-form-group">

--- a/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/_BoxContentPart1.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/_BoxContentPart1.cshtml
@@ -1,0 +1,3 @@
+﻿<span class="govuk-caption-xl">Caption is supported</span>
+<h2 class="govuk-heading-l">Content within boxes</h2>
+<p class="govuk-body">A limited range of content and components is supported within boxes. This includes paragraphs, <a href="https://example.org" class="govuk-link">links</a>, lists and tables.</p>

--- a/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/_BoxContentPart2.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/DividerLinesAndBoxes/_BoxContentPart2.cshtml
@@ -1,0 +1,46 @@
+﻿<ul class="govuk-list govuk-list--bullet">
+    <li>List items</li>
+    <li>List items</li>
+    <li>List items</li>
+</ul>
+<ol class="govuk-list govuk-list--number">
+    <li>List items</li>
+    <li>List items</li>
+    <li>List items</li>
+</ol>
+<table class="govuk-!-width-full govuk-table govuk-table--tpr-default">
+    <caption class="govuk-table__caption">Text in tables</caption>
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Text in tables</th>
+            <th scope="col" class="govuk-table__header">Text in tables</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">Text in tables</td>
+            <td class="govuk-table__cell">Text in tables</td>
+        </tr>
+    </tbody>
+</table>
+<govuk-inset-text>Inset text is supported.</govuk-inset-text>
+<govuk-warning-text>Warning text is supported.</govuk-warning-text>
+<govuk-details>
+    <govuk-details-summary>Details is supported.</govuk-details-summary>
+    <govuk-details-text>
+        <p class="govuk-body">These are the details revealed by clicking the summary.</p>
+    </govuk-details-text>
+</govuk-details>
+<govuk-summary-list>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Example</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>Summary list is supported.</govuk-summary-list-row-value>
+        <govuk-summary-list-row-actions>
+            <govuk-summary-list-row-action href="https://example.org">Action 1</govuk-summary-list-row-action>
+        </govuk-summary-list-row-actions>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Example</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>Summary list is supported.</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+</govuk-summary-list>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Content/divider-lines-and-boxes.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Content/divider-lines-and-boxes.config
@@ -2257,7 +2257,7 @@
               "expose": [],
               "Layout": {}
             },
-            "markup": "\u003Ch2 class=\u0022govuk-heading-l\u0022\u003EContent within boxes\u003C/h2\u003E\n\u003Cp\u003EA limited range of content and components is supported within boxes. This includes paragraphs, \u003Ca type=\u0022external\u0022 href=\u0022https://example.org\u0022\u003Elinks\u003C/a\u003E, lists and tables.\u003C/p\u003E\n\u003Cp\u003EThis box is set to Royal Blue. Inverse colours must be used when the box has a dark background. Inverse colours must also be used in the Umbraco backoffice.\u003C/p\u003E\n\u003Cul\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ul\u003E\n\u003Col\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ol\u003E\n\u003Ctable class=\u0022govuk-!-width-full\u0022\u003E\u003Ccaption\u003EText in tables\u003C/caption\u003E\n\u003Cthead\u003E\n\u003Ctr\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003C/tr\u003E\n\u003C/thead\u003E\n\u003Ctbody\u003E\n\u003Ctr\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003C/tr\u003E\n\u003C/tbody\u003E\n\u003C/table\u003E"
+            "markup": "\u003Ch2 class=\u0022govuk-heading-l\u0022\u003EContent within boxes\u003C/h2\u003E\n\u003Cp\u003EA limited range of content and components is supported within boxes. This includes paragraphs, \u003Ca type=\u0022external\u0022 href=\u0022https://example.org\u0022\u003Elinks\u003C/a\u003E, lists and tables.\u003C/p\u003E\n\u003Cp\u003EThis box is set to royal blue. Inverse colours must be used when the box has a dark background. Inverse colours must also be used in the Umbraco backoffice.\u003C/p\u003E\n\u003Cul\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ul\u003E\n\u003Col\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ol\u003E\n\u003Ctable class=\u0022govuk-!-width-full\u0022\u003E\u003Ccaption\u003EText in tables\u003C/caption\u003E\n\u003Cthead\u003E\n\u003Ctr\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003C/tr\u003E\n\u003C/thead\u003E\n\u003Ctbody\u003E\n\u003Ctr\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003C/tr\u003E\n\u003C/tbody\u003E\n\u003C/table\u003E"
           }
         }
       ]
@@ -2553,6 +2553,311 @@
           }
         }
       ]
+    },
+    {
+      "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
+      "key": "d25c1392-9b85-4327-a4fa-c13822f7140b",
+      "values": []
+    },
+    {
+      "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
+      "key": "d05e80db-04ae-4350-b389-4adfdc9c8fb6",
+      "values": [
+        {
+          "alias": "caption",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Caption is supported"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "key": "a85a2ca9-ed30-4a05-81ef-db87a7f276b1",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Ch2 class=\u0022govuk-heading-l\u0022\u003EContent within boxes\u003C/h2\u003E\n\u003Cp\u003EA limited range of content and components is supported within boxes. This includes paragraphs, \u003Ca type=\u0022external\u0022 href=\u0022https://example.org\u0022\u003Elinks\u003C/a\u003E, lists and tables.\u003C/p\u003E\n\u003Cp\u003EThis box is set to green. Inverse colours must be used when the box has a dark background. Inverse colours must also be used in the Umbraco backoffice.\u003C/p\u003E\n\u003Cul\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ul\u003E\n\u003Col\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ol\u003E\n\u003Ctable class=\u0022govuk-!-width-full\u0022\u003E\u003Ccaption\u003EText in tables\u003C/caption\u003E\n\u003Cthead\u003E\n\u003Ctr\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003C/tr\u003E\n\u003C/thead\u003E\n\u003Ctbody\u003E\n\u003Ctr\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003C/tr\u003E\n\u003C/tbody\u003E\n\u003C/table\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "40bb2a3e-3d75-4ec1-9134-e0c46c6f04a0",
+      "key": "5fe9b0b1-f32d-4379-8d93-92390c5decc7",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EInset text is supported.\u003C/p\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "83cb35fb-51da-45cd-913f-1b8bdfd6a1d9",
+      "key": "c3975386-d75e-4765-9cbc-2f8a4ea634f7",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EWarning text is supported.\u003C/p\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "9d15adb9-fb63-4b20-ada3-fc9239a72a8c",
+      "key": "fa272fe0-2058-4db7-aa25-21f26ddaadd8",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EThese are the details revealed by expanding the summary.\u003C/p\u003E"
+          }
+        },
+        {
+          "alias": "summary",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Details is supported"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "bd6069cc-a8c1-456b-8a00-1d180c45c36c",
+      "key": "e55ccfd4-bacc-4666-aa88-e826da6106a4",
+      "values": [
+        {
+          "alias": "items",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "contentData": [
+              {
+                "contentTypeKey": "4e3c68a7-d651-4898-b1e3-e8f29a9ffe48",
+                "key": "ebaf6e5a-1799-4326-a56f-7780b954843c",
+                "values": [
+                  {
+                    "alias": "itemKey",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Example"
+                  },
+                  {
+                    "alias": "itemValue",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "Layout": {}
+                      },
+                      "markup": "\u003Cp\u003ESummary list is supported.\u003C/p\u003E"
+                    }
+                  },
+                  {
+                    "alias": "actions",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "contentData": [
+                        {
+                          "contentTypeKey": "c7fa9985-51bd-409a-a621-f295dbf9a691",
+                          "key": "6185cf01-7771-44c7-8cfa-923e36a02e5c",
+                          "values": [
+                            {
+                              "alias": "link",
+                              "culture": null,
+                              "editorAlias": null,
+                              "segment": null,
+                              "value": [
+                                {
+                                  "name": "Home",
+                                  "target": null,
+                                  "unique": null,
+                                  "type": null,
+                                  "udi": "umb://document/5e682cbeb867491a955f3382446d5663",
+                                  "url": null,
+                                  "queryString": null
+                                }
+                              ]
+                            },
+                            {
+                              "alias": "text",
+                              "culture": null,
+                              "editorAlias": null,
+                              "segment": null,
+                              "value": "Action 1"
+                            }
+                          ]
+                        }
+                      ],
+                      "settingsData": [],
+                      "expose": [
+                        {
+                          "contentKey": "6185cf01-7771-44c7-8cfa-923e36a02e5c",
+                          "culture": null,
+                          "segment": null
+                        }
+                      ],
+                      "Layout": {
+                        "Umbraco.BlockList": [
+                          {
+                            "contentKey": "6185cf01-7771-44c7-8cfa-923e36a02e5c",
+                            "contentUdi": null,
+                            "settingsKey": null,
+                            "settingsUdi": null
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "contentTypeKey": "4e3c68a7-d651-4898-b1e3-e8f29a9ffe48",
+                "key": "6b611eaa-b3ae-4acc-ab96-cd7bf51e212b",
+                "values": [
+                  {
+                    "alias": "itemKey",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Example"
+                  },
+                  {
+                    "alias": "itemValue",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "Layout": {}
+                      },
+                      "markup": "\u003Cp\u003ESummary list is supported.\u003C/p\u003E"
+                    }
+                  }
+                ]
+              }
+            ],
+            "settingsData": [
+              {
+                "contentTypeKey": "18d06fa1-27bf-4f86-bc9d-b0a339512ca1",
+                "key": "38ec10b9-8a21-4e40-9203-a0629bb477fc",
+                "values": []
+              },
+              {
+                "contentTypeKey": "18d06fa1-27bf-4f86-bc9d-b0a339512ca1",
+                "key": "5204f215-eb6f-4051-b5ae-ed3eb1f6a126",
+                "values": []
+              }
+            ],
+            "expose": [
+              {
+                "contentKey": "ebaf6e5a-1799-4326-a56f-7780b954843c",
+                "culture": null,
+                "segment": null
+              },
+              {
+                "contentKey": "6b611eaa-b3ae-4acc-ab96-cd7bf51e212b",
+                "culture": null,
+                "segment": null
+              }
+            ],
+            "Layout": {
+              "Umbraco.BlockList": [
+                {
+                  "contentKey": "ebaf6e5a-1799-4326-a56f-7780b954843c",
+                  "contentUdi": null,
+                  "settingsKey": "38ec10b9-8a21-4e40-9203-a0629bb477fc",
+                  "settingsUdi": null
+                },
+                {
+                  "contentKey": "6b611eaa-b3ae-4acc-ab96-cd7bf51e212b",
+                  "contentUdi": null,
+                  "settingsKey": "5204f215-eb6f-4051-b5ae-ed3eb1f6a126",
+                  "settingsUdi": null
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
+      "key": "27ba6fb0-3b2f-459c-a284-5918997b3d22",
+      "values": []
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "key": "3131f360-3af0-40fd-9eb7-cfc161fa275b",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EThis box has its background colour set to green.\u003C/p\u003E"
+          }
+        }
+      ]
     }
   ],
   "settingsData": [
@@ -2588,6 +2893,13 @@
       "key": "bdce6dde-c09d-4e1d-af8c-062c40740069",
       "values": [
         {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -2605,13 +2917,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -2712,13 +3017,6 @@
       "key": "91e4fddc-089c-4e2b-8798-ba9756c74302",
       "values": [
         {
-          "alias": "cssClassesForRow",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -2734,6 +3032,13 @@
         },
         {
           "alias": "cssClassesForColumn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -2908,6 +3213,13 @@
       "key": "7199b2e1-1615-4851-9fc1-f4199b9ba240",
       "values": [
         {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -2923,13 +3235,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -2942,6 +3247,13 @@
       "key": "4b2f7579-475f-4439-a780-ec287c8a3e24",
       "values": [
         {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -2957,13 +3269,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3016,6 +3321,13 @@
       "key": "fb0ee542-8b9a-42af-8967-7a769781f805",
       "values": [
         {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -3031,13 +3343,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3131,6 +3436,13 @@
       "key": "fc6e0d1b-e721-48d7-b2e8-c937b8d860a0",
       "values": [
         {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -3146,13 +3458,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3165,13 +3470,6 @@
       "key": "c2caf2f9-25fa-4170-b959-a945a5069b4c",
       "values": [
         {
-          "alias": "cssClassesForRow",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -3187,6 +3485,13 @@
         },
         {
           "alias": "cssClassesForColumn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3233,6 +3538,13 @@
       "key": "6af3f8cc-a66f-46ef-b592-3b7116fa014f",
       "values": [
         {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -3248,13 +3560,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3355,6 +3660,13 @@
       "key": "06e71b08-ca30-4210-9493-0f5b46d88d89",
       "values": [
         {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
           "alias": "columnSize",
           "culture": null,
           "editorAlias": null,
@@ -3370,13 +3682,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3672,14 +3977,14 @@
       "key": "529b33c4-480c-47e5-a92e-2b0f5c8f5dae",
       "values": [
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3699,14 +4004,14 @@
       "key": "84a3e9b8-630b-4c8a-a0b8-ab48748383ab",
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3726,14 +4031,14 @@
       "key": "a66f11b4-87ed-4079-aac4-202da8673e4b",
       "values": [
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3807,14 +4112,14 @@
       "key": "52483911-5400-4bea-b003-7ba512691f45",
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3861,14 +4166,14 @@
       "key": "12d55c68-0da3-41e3-a40f-a50e9ac82622",
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3915,14 +4220,14 @@
       "key": "0734a87b-210e-449a-b20f-2dce15deef25",
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3969,14 +4274,14 @@
       "key": "aebe2971-0396-4fac-8e39-95f5971042a8",
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -4071,13 +4376,6 @@
           "value": ""
         },
         {
-          "alias": "cssClasses",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "cssClassesForColumn",
           "culture": null,
           "editorAlias": null,
@@ -4086,6 +4384,13 @@
         },
         {
           "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -4160,13 +4465,6 @@
           "value": ""
         },
         {
-          "alias": "cssClasses",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "cssClassesForColumn",
           "culture": null,
           "editorAlias": null,
@@ -4175,6 +4473,13 @@
         },
         {
           "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -4338,13 +4643,6 @@
           "value": ""
         },
         {
-          "alias": "cssClasses",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "cssClassesForColumn",
           "culture": null,
           "editorAlias": null,
@@ -4353,6 +4651,13 @@
         },
         {
           "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -4980,13 +5285,6 @@
       "key": "7b6b80ee-d905-4e16-8b8f-e04f42127433",
       "values": [
         {
-          "alias": "cssClasses",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
@@ -4995,6 +5293,13 @@
             "label": "Royal Blue",
             "value": "#006ebc"
           }
+        },
+        {
+          "alias": "cssClasses",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
         },
         {
           "alias": "styleOfBox",
@@ -5008,6 +5313,116 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "ea46d4f2-dff3-4485-9758-1b0f93291f87",
+      "values": [
+        {
+          "alias": "columnSize",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "columnSizeFromDesktop",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForColumn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
+      "key": "dbd827dc-7b4a-4cdc-aba0-bb7b5cf786a1",
+      "values": [
+        {
+          "alias": "backgroundColour",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "label": "Green",
+            "value": "#1e7e34"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
+      "key": "0241bb34-436b-45e6-bcd2-c3510da16671",
+      "values": []
+    },
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "key": "68f80cc9-2fd9-4785-8c22-ec9113f8c625",
+      "values": []
+    },
+    {
+      "contentTypeKey": "29d9a3c9-4047-484a-8816-e233e161fcb0",
+      "key": "5454bdfc-687b-448d-a4f0-c5b7eb82f519",
+      "values": []
+    },
+    {
+      "contentTypeKey": "0bac8213-4607-4547-902a-6a9d84b92633",
+      "key": "4235c46c-c45d-4dcd-9f06-a795c0571b90",
+      "values": []
+    },
+    {
+      "contentTypeKey": "a6689021-cc6e-4d94-8c37-235906ebeff1",
+      "key": "137e2ddc-a07a-4569-804d-e1f41f778643",
+      "values": []
+    },
+    {
+      "contentTypeKey": "d43b72b5-edac-42e0-aa09-1b080d7bd6eb",
+      "key": "0a1b3cec-4110-4be8-9d3d-12e82e17cf95",
+      "values": []
+    },
+    {
+      "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
+      "key": "4fe4b083-7464-499e-9bfd-480ef34fcd52",
+      "values": [
+        {
+          "alias": "cssClasses",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "backgroundColour",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "label": "Green",
+            "value": "#1e7e34"
+          }
+        },
+        {
+          "alias": "styleOfBox",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Solid"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "key": "2d9e2fe9-c6ce-4b03-a908-edf20623e8a2",
       "values": [
         {
           "alias": "columnSize",
@@ -5500,6 +5915,51 @@
       "contentKey": "38f6c7cb-a426-43a1-8037-85c351676f53",
       "culture": null,
       "segment": null
+    },
+    {
+      "contentKey": "d25c1392-9b85-4327-a4fa-c13822f7140b",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "d05e80db-04ae-4350-b389-4adfdc9c8fb6",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "a85a2ca9-ed30-4a05-81ef-db87a7f276b1",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "5fe9b0b1-f32d-4379-8d93-92390c5decc7",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "c3975386-d75e-4765-9cbc-2f8a4ea634f7",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "fa272fe0-2058-4db7-aa25-21f26ddaadd8",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "e55ccfd4-bacc-4666-aa88-e826da6106a4",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "27ba6fb0-3b2f-459c-a284-5918997b3d22",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "3131f360-3af0-40fd-9eb7-cfc161fa275b",
+      "culture": null,
+      "segment": null
     }
   ],
   "Layout": {
@@ -5631,6 +6091,30 @@
                 "contentUdi": null,
                 "rowSpan": 1,
                 "settingsKey": "7b6b80ee-d905-4e16-8b8f-e04f42127433",
+                "settingsUdi": null
+              },
+              {
+                "areas": [
+                  {
+                    "items": [
+                      {
+                        "areas": [],
+                        "columnSpan": 12,
+                        "contentKey": "3131f360-3af0-40fd-9eb7-cfc161fa275b",
+                        "contentUdi": null,
+                        "rowSpan": 1,
+                        "settingsKey": "2d9e2fe9-c6ce-4b03-a908-edf20623e8a2",
+                        "settingsUdi": null
+                      }
+                    ],
+                    "key": "e3d17c0e-a303-4d7e-9cbb-52752a355127"
+                  }
+                ],
+                "columnSpan": 6,
+                "contentKey": "27ba6fb0-3b2f-459c-a284-5918997b3d22",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "4fe4b083-7464-499e-9bfd-480ef34fcd52",
                 "settingsUdi": null
               }
             ],
@@ -6345,6 +6829,75 @@
         "contentUdi": null,
         "rowSpan": 1,
         "settingsKey": "f3de4194-2b2e-4e97-af88-0f389f2c83dd",
+        "settingsUdi": null
+      },
+      {
+        "areas": [
+          {
+            "items": [
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "d05e80db-04ae-4350-b389-4adfdc9c8fb6",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "0241bb34-436b-45e6-bcd2-c3510da16671",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "a85a2ca9-ed30-4a05-81ef-db87a7f276b1",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "68f80cc9-2fd9-4785-8c22-ec9113f8c625",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "5fe9b0b1-f32d-4379-8d93-92390c5decc7",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "5454bdfc-687b-448d-a4f0-c5b7eb82f519",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "c3975386-d75e-4765-9cbc-2f8a4ea634f7",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "4235c46c-c45d-4dcd-9f06-a795c0571b90",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "fa272fe0-2058-4db7-aa25-21f26ddaadd8",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "137e2ddc-a07a-4569-804d-e1f41f778643",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "e55ccfd4-bacc-4666-aa88-e826da6106a4",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "0a1b3cec-4110-4be8-9d3d-12e82e17cf95",
+                "settingsUdi": null
+              }
+            ],
+            "key": "b50dd71c-b7a2-408b-9d23-10d5752470bf"
+          }
+        ],
+        "columnSpan": 12,
+        "contentKey": "d25c1392-9b85-4327-a4fa-c13822f7140b",
+        "contentUdi": null,
+        "rowSpan": 1,
+        "settingsKey": "dbd827dc-7b4a-4cdc-aba0-bb7b5cf786a1",
         "settingsUdi": null
       },
       {

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Content/divider-lines-and-boxes.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Content/divider-lines-and-boxes.config
@@ -19,7 +19,6 @@
     {
       "contentTypeKey": "394dc214-e2ad-4605-ab3f-2c6b83063ef6",
       "key": "bb9937a5-216c-4a58-a0c3-1ac46a981914",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -33,7 +32,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "fef09d4a-5fcb-4fce-b235-6135df68a203",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -55,7 +53,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "72ca2291-9065-4357-a88e-8dbd6663d681",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -77,7 +74,6 @@
     {
       "contentTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
       "key": "db2adb60-5123-4e02-a0f2-de1f6c5c59cb",
-      "udi": null,
       "values": [
         {
           "alias": "hint",
@@ -98,7 +94,6 @@
     {
       "contentTypeKey": "fe2dd0de-55a9-4249-be03-6896aa719974",
       "key": "e9db258f-23cd-479e-93dc-e1946fc7d168",
-      "udi": null,
       "values": [
         {
           "alias": "hint",
@@ -119,7 +114,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "41c33483-7468-4b27-b333-ae0a9ca1a69d",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -141,7 +135,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "07e37dad-713f-4058-9720-84c21693993b",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -163,7 +156,6 @@
     {
       "contentTypeKey": "b84a633b-1ee7-4a5c-80bd-4267420ed133",
       "key": "ca951f08-7666-4cf0-9078-a04f7a2ebb84",
-      "udi": null,
       "values": [
         {
           "alias": "fieldsetBlocks",
@@ -204,7 +196,6 @@
               {
                 "contentTypeKey": "d7861a37-8d74-4a8b-85db-016ea1323b9f",
                 "key": "2457aac3-0676-4e00-a7ad-4e0e14347e0d",
-                "udi": null,
                 "values": [
                   {
                     "alias": "conditionalBlocks",
@@ -239,7 +230,6 @@
               {
                 "contentTypeKey": "d7861a37-8d74-4a8b-85db-016ea1323b9f",
                 "key": "888cc4dc-c429-4117-918a-edc282a56c54",
-                "udi": null,
                 "values": [
                   {
                     "alias": "conditionalBlocks",
@@ -276,13 +266,11 @@
               {
                 "contentTypeKey": "1a84595b-3f9d-49ba-a3c0-ee82a547fb7f",
                 "key": "2a7a19e7-dc27-41a3-a932-247e4e0a9908",
-                "udi": null,
                 "values": []
               },
               {
                 "contentTypeKey": "1a84595b-3f9d-49ba-a3c0-ee82a547fb7f",
                 "key": "ddc6e6e2-cf8e-483f-bc70-1839fda009d1",
-                "udi": null,
                 "values": []
               }
             ],
@@ -321,7 +309,6 @@
     {
       "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
       "key": "9e7d7f5d-3446-4660-b460-ac1f204f565b",
-      "udi": null,
       "values": [
         {
           "alias": "caption",
@@ -337,7 +324,6 @@
     {
       "contentTypeKey": "6ca199b3-814c-4aa9-b466-fc0533f2b543",
       "key": "4a177205-3b42-4d7b-a710-3b69c6d2183a",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -379,7 +365,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "9b254b99-97f3-4d38-a7a6-b27bff5b715a",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -414,7 +399,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "4b60cece-286e-4e78-b68f-4685f98c0b2b",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -449,7 +433,6 @@
     {
       "contentTypeKey": "98070ce9-d528-4bfc-bd90-e411e5110f56",
       "key": "7cf4ce88-0aca-4672-8400-2de5523c460e",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -624,7 +607,6 @@
     {
       "contentTypeKey": "98070ce9-d528-4bfc-bd90-e411e5110f56",
       "key": "a14f2278-d6f0-4721-ab3b-5de12fbf8163",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -799,7 +781,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "fa3c3801-7f35-4577-9383-d7874dbe81be",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -836,7 +817,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "a49b698f-e7f3-46b1-bd31-622c9eb762d4",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -873,7 +853,6 @@
     {
       "contentTypeKey": "40da6b15-489b-4249-854a-56954e5917e1",
       "key": "7da4331c-4533-433c-bc48-26ca981349e6",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -964,7 +943,6 @@
     {
       "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
       "key": "bf732b32-94bc-4157-9295-c00ce8a75d97",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -1117,13 +1095,11 @@
     {
       "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
       "key": "ab53b8e9-4bf0-4cb9-bf2c-8aba70f61d1d",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "9e34feaf-107d-4032-a22a-4c00acadc480",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1145,13 +1121,11 @@
     {
       "contentTypeKey": "3fa201d9-0d89-458f-b6dc-f5fb6fc8e10a",
       "key": "a3c8b6d9-90b6-4123-97bb-adf2dcfa6eda",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "f96fe10a-21c9-404b-8c6d-15a6e931af21",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1173,7 +1147,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "24431920-98bd-47d0-9bae-82cbe99f9967",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1195,7 +1168,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "723bf915-e099-4a02-82ad-91dba6f3dba2",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1217,25 +1189,21 @@
     {
       "contentTypeKey": "77726c2e-3248-4fab-bb3a-478e65ba9256",
       "key": "e0f1972f-52af-491e-a0dd-b53b0bbc75d4",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
       "key": "82366f5c-f9b0-4a38-9434-f26b560ec039",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "3fa201d9-0d89-458f-b6dc-f5fb6fc8e10a",
       "key": "7c931c79-8127-425a-98b9-2e3c953825ab",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "eb657806-e8ed-4b91-a142-a48bd2a35eb2",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1257,7 +1225,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "435f4ca4-98a3-4624-8e74-90c3127e3040",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1279,13 +1246,11 @@
     {
       "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
       "key": "2cf19a5a-19fd-49f4-a3f5-ed6b093f1f0d",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "853131dc-44cd-40d2-b0ff-76dde6e39606",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1307,7 +1272,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "7a673e01-a687-45f3-ad99-f4067720b0ec",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1329,19 +1293,16 @@
     {
       "contentTypeKey": "650d7119-e9cf-4c26-a08c-21cf2ffbbbbc",
       "key": "3da0a195-884f-48ad-bb19-6a44482a444f",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "3fa201d9-0d89-458f-b6dc-f5fb6fc8e10a",
       "key": "98c9e716-6247-4fa1-bb6d-8cfa12a0dde7",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "b9ec4087-9ad7-47ad-ae16-f6972a2d2cc0",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1363,19 +1324,16 @@
     {
       "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
       "key": "9ef9f127-c3fd-4077-8319-1ea10c660319",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "f7721eea-7712-4d9c-91e4-9c04f0ad3036",
       "key": "9709ea00-160e-4959-b8a9-33e2182dbf9c",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "48c81075-5b70-4c72-8eb0-45f730db212e",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1397,7 +1355,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "13ec193a-3f74-4463-b0e5-947aa0018040",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1419,7 +1376,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "6d4330de-355c-4e27-879f-fa8fbae985d1",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1441,7 +1397,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "49f62a11-de7a-46b4-9e76-0fd8b26ddde0",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1463,7 +1418,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "85fc4728-9637-4a67-85b9-e0ee9a54fed3",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1485,7 +1439,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "382a58ed-d846-4074-8db8-375b553b2c7e",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1507,13 +1460,11 @@
     {
       "contentTypeKey": "3fa201d9-0d89-458f-b6dc-f5fb6fc8e10a",
       "key": "b7e87702-ccc0-46bb-8ce5-c3f78cba7c8f",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "704aa73f-941b-4903-9e02-09e167df6058",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1535,7 +1486,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "49103119-1b0c-4ca4-9ad2-c54b3f054789",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1557,19 +1507,16 @@
     {
       "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
       "key": "505a6a36-d23d-4c50-aae0-0293c84a3af1",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "f7721eea-7712-4d9c-91e4-9c04f0ad3036",
       "key": "48afcc3f-3ad5-4710-b726-86d76a70650d",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "c2ea1f79-9818-47c0-84e8-848ef44b0fe7",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1591,7 +1538,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "577a6913-f119-4d29-9858-fbb183484be9",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1613,7 +1559,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "6c4e18ba-3663-499b-aec5-1c8aa94e2f44",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1635,13 +1580,11 @@
     {
       "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
       "key": "a7276a9d-6f85-4af0-aaf6-105b16f8a0b4",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "d8450d8c-adcc-4b60-a0c9-6daf1837814e",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1663,7 +1606,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "9be22386-3b03-4c28-87f8-d467e6f0df1a",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1685,7 +1627,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "49c7126e-f99b-4216-b32a-ca16fc61c5f4",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1707,85 +1648,71 @@
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "91b78ace-819a-48a0-b103-7b258b913fd7",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "20e66124-159f-467d-81c4-c4fed52f3593",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "c2c33055-0d91-4db4-9484-41ec7ae226a6",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "c9bac213-6a07-4dce-bc5b-5c6ebe4eae01",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "8c04e76a-ccf1-4e0e-ac35-defd081c3d6f",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "4a585902-6d9d-4c5b-a7ea-174cad13ac21",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "08d23bb9-1cfb-47a6-a6f6-3ec72f124e2b",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "22976e88-12c4-41ff-b92b-7410a1a15adb",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "624ff595-8a4b-457c-9092-eeebde518106",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "f7c51bed-622c-489e-86cd-f632cf85ca87",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "09633053-1679-44f6-8644-c112983a4ea0",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "4ada10e4-ce17-4925-9bfe-4fa72563ee08",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
       "key": "933ad32e-285c-497d-a5e3-2c4a27d4c082",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "f5c3fcfc-9fb0-4d10-981e-463dc554c194",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1807,13 +1734,11 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "1ceea948-9598-4494-9425-4eec7d787cdf",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "179d4c72-42a4-4a5d-ab28-00b5515739d5",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1835,13 +1760,11 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "fe16fc4d-1431-4ec9-ba8e-492315e877d5",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "4b61e413-b5e7-4f3a-a4e6-844d79cfcfc9",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1863,13 +1786,11 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "9618a2d4-4d78-47d2-9961-f232f2381b2e",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "af975a0c-ff5c-4990-be2a-786b7f08b9ed",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1891,19 +1812,16 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "21833f6d-73e9-44f2-8e38-442b3bf1b2c0",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "714d4aac-3e4d-4991-b026-598de2424249",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "1e44d796-4914-4b41-aa72-fa6991e9d089",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1925,7 +1843,6 @@
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "fcc7cee5-0345-4429-ae29-58a6290aa5fa",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1947,13 +1864,11 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "873b36e1-72dc-4845-afa5-8c60ce75b760",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "156410c5-dc38-4c2d-a539-c455284dfd1d",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -1975,13 +1890,11 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "c07cce6a-5d39-421f-b337-a1786e7ff17a",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "dd4dca28-df9f-4d2b-82e4-8af8eb31f14f",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -2003,13 +1916,11 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "db3b5fc8-9ed5-4f79-8d7e-bbed9d620a49",
-      "udi": null,
       "values": []
     },
     {
       "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
       "key": "d255b042-ac5d-4dd1-a815-0e0775fb2461",
-      "udi": null,
       "values": [
         {
           "alias": "text",
@@ -2031,15 +1942,623 @@
     {
       "contentTypeKey": "5d33cd38-b819-4afd-9d4a-499ee73799ab",
       "key": "195eacae-f506-4828-b60d-3b145c5b6778",
-      "udi": null,
       "values": []
+    },
+    {
+      "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
+      "key": "cdef66f9-3bc4-48ff-b6be-9429c034bfd7",
+      "values": []
+    },
+    {
+      "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
+      "key": "119523ec-db2b-45e6-9cb5-03603ff22ce7",
+      "values": [
+        {
+          "alias": "caption",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Caption is supported"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "key": "df290159-c2c6-402c-9af2-0f4b80e35e4b",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Ch2 class=\u0022govuk-heading-l\u0022\u003EContent within boxes\u003C/h2\u003E\n\u003Cp\u003EA limited range of content and components is supported within boxes. This includes paragraphs, \u003Ca type=\u0022external\u0022 href=\u0022https://example.org\u0022\u003Elinks\u003C/a\u003E, lists and tables.\u003C/p\u003E\n\u003Cul\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ul\u003E\n\u003Col\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ol\u003E\n\u003Ctable class=\u0022govuk-!-width-full\u0022\u003E\u003Ccaption\u003EText in tables\u003C/caption\u003E\n\u003Cthead\u003E\n\u003Ctr\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003C/tr\u003E\n\u003C/thead\u003E\n\u003Ctbody\u003E\n\u003Ctr\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003C/tr\u003E\n\u003C/tbody\u003E\n\u003C/table\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "40bb2a3e-3d75-4ec1-9134-e0c46c6f04a0",
+      "key": "ceaa5ea7-7f3f-4c7c-8884-c37bb9a5c7b7",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EInset text is supported.\u003C/p\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "83cb35fb-51da-45cd-913f-1b8bdfd6a1d9",
+      "key": "896ff51a-7453-45a9-bef3-5288ba3b7207",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EWarning text is supported.\u003C/p\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "9d15adb9-fb63-4b20-ada3-fc9239a72a8c",
+      "key": "f2b2fbb3-5824-4d82-a98d-2520f4968343",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EThese are the details revealed by expanding the summary.\u003C/p\u003E"
+          }
+        },
+        {
+          "alias": "summary",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Details is supported"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "bd6069cc-a8c1-456b-8a00-1d180c45c36c",
+      "key": "ec5a3fcc-4002-4e5e-ab9f-972c1707b96d",
+      "values": [
+        {
+          "alias": "items",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "contentData": [
+              {
+                "contentTypeKey": "4e3c68a7-d651-4898-b1e3-e8f29a9ffe48",
+                "key": "6022a6fd-c856-4b8f-b0e5-f9bcc003e52d",
+                "values": [
+                  {
+                    "alias": "itemKey",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Example"
+                  },
+                  {
+                    "alias": "itemValue",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "Layout": {}
+                      },
+                      "markup": "\u003Cp\u003ESummary list is supported.\u003C/p\u003E"
+                    }
+                  },
+                  {
+                    "alias": "actions",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "contentData": [
+                        {
+                          "contentTypeKey": "c7fa9985-51bd-409a-a621-f295dbf9a691",
+                          "key": "b3ac0ba5-b4e2-42ba-a894-f6cb0cc69147",
+                          "values": [
+                            {
+                              "alias": "link",
+                              "culture": null,
+                              "editorAlias": null,
+                              "segment": null,
+                              "value": [
+                                {
+                                  "name": "Home",
+                                  "target": null,
+                                  "unique": null,
+                                  "type": null,
+                                  "udi": "umb://document/5e682cbeb867491a955f3382446d5663",
+                                  "url": null,
+                                  "queryString": null
+                                }
+                              ]
+                            },
+                            {
+                              "alias": "text",
+                              "culture": null,
+                              "editorAlias": null,
+                              "segment": null,
+                              "value": "Action 1"
+                            }
+                          ]
+                        }
+                      ],
+                      "settingsData": [],
+                      "expose": [
+                        {
+                          "contentKey": "b3ac0ba5-b4e2-42ba-a894-f6cb0cc69147",
+                          "culture": null,
+                          "segment": null
+                        }
+                      ],
+                      "Layout": {
+                        "Umbraco.BlockList": [
+                          {
+                            "contentKey": "b3ac0ba5-b4e2-42ba-a894-f6cb0cc69147",
+                            "contentUdi": null,
+                            "settingsKey": null,
+                            "settingsUdi": null
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "contentTypeKey": "4e3c68a7-d651-4898-b1e3-e8f29a9ffe48",
+                "key": "c4fc536e-ec00-48f0-baa7-c3d4f5bbd0c1",
+                "values": [
+                  {
+                    "alias": "itemKey",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Example"
+                  },
+                  {
+                    "alias": "itemValue",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "Layout": {}
+                      },
+                      "markup": "\u003Cp\u003ESummary list is supported.\u003C/p\u003E"
+                    }
+                  }
+                ]
+              }
+            ],
+            "settingsData": [
+              {
+                "contentTypeKey": "18d06fa1-27bf-4f86-bc9d-b0a339512ca1",
+                "key": "635f5503-4b98-4765-b9fc-b87023698847",
+                "values": []
+              },
+              {
+                "contentTypeKey": "18d06fa1-27bf-4f86-bc9d-b0a339512ca1",
+                "key": "346f76fd-29c2-431d-88e2-fac456bf6bb6",
+                "values": []
+              }
+            ],
+            "expose": [
+              {
+                "contentKey": "6022a6fd-c856-4b8f-b0e5-f9bcc003e52d",
+                "culture": null,
+                "segment": null
+              },
+              {
+                "contentKey": "c4fc536e-ec00-48f0-baa7-c3d4f5bbd0c1",
+                "culture": null,
+                "segment": null
+              }
+            ],
+            "Layout": {
+              "Umbraco.BlockList": [
+                {
+                  "contentKey": "6022a6fd-c856-4b8f-b0e5-f9bcc003e52d",
+                  "contentUdi": null,
+                  "settingsKey": "635f5503-4b98-4765-b9fc-b87023698847",
+                  "settingsUdi": null
+                },
+                {
+                  "contentKey": "c4fc536e-ec00-48f0-baa7-c3d4f5bbd0c1",
+                  "contentUdi": null,
+                  "settingsKey": "346f76fd-29c2-431d-88e2-fac456bf6bb6",
+                  "settingsUdi": null
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "61baed41-7e14-4615-af1e-0150c6d0a15f",
+      "key": "b7730a85-1717-45dd-b61a-2b4ccf09e3ff",
+      "values": []
+    },
+    {
+      "contentTypeKey": "bfeed15c-3ebb-46d4-b805-07d0f9b083c7",
+      "key": "694bdc0b-4f73-4e58-a1ff-9a77b56475ea",
+      "values": [
+        {
+          "alias": "caption",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Caption is supported"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "key": "cae47173-9f60-42e0-99da-9e24258ab548",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Ch2 class=\u0022govuk-heading-l\u0022\u003EContent within boxes\u003C/h2\u003E\n\u003Cp\u003EA limited range of content and components is supported within boxes. This includes paragraphs, \u003Ca type=\u0022external\u0022 href=\u0022https://example.org\u0022\u003Elinks\u003C/a\u003E, lists and tables.\u003C/p\u003E\n\u003Cp\u003EThis box is set to Royal Blue. Inverse colours must be used when the box has a dark background. Inverse colours must also be used in the Umbraco backoffice.\u003C/p\u003E\n\u003Cul\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ul\u003E\n\u003Col\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003Cli\u003EList items\u003C/li\u003E\n\u003C/ol\u003E\n\u003Ctable class=\u0022govuk-!-width-full\u0022\u003E\u003Ccaption\u003EText in tables\u003C/caption\u003E\n\u003Cthead\u003E\n\u003Ctr\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003Cth scope=\u0022col\u0022\u003EText in tables\u003C/th\u003E\n\u003C/tr\u003E\n\u003C/thead\u003E\n\u003Ctbody\u003E\n\u003Ctr\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003Ctd\u003EText in tables\u003C/td\u003E\n\u003C/tr\u003E\n\u003C/tbody\u003E\n\u003C/table\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "40bb2a3e-3d75-4ec1-9134-e0c46c6f04a0",
+      "key": "5c700189-e747-4b15-ae4b-79f5b0541026",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EInset text is supported.\u003C/p\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "83cb35fb-51da-45cd-913f-1b8bdfd6a1d9",
+      "key": "9d2927ae-1426-4b70-a8b5-89acc7e45412",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EWarning text is supported.\u003C/p\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "9d15adb9-fb63-4b20-ada3-fc9239a72a8c",
+      "key": "f9136709-726f-4076-ad16-6229e92d2cec",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EThese are the details revealed by expanding the summary.\u003C/p\u003E"
+          }
+        },
+        {
+          "alias": "summary",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Details is supported"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "bd6069cc-a8c1-456b-8a00-1d180c45c36c",
+      "key": "25a49c40-645d-4177-8279-3b933345289e",
+      "values": [
+        {
+          "alias": "items",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "contentData": [
+              {
+                "contentTypeKey": "4e3c68a7-d651-4898-b1e3-e8f29a9ffe48",
+                "key": "4f6d71cb-c365-4bc0-a284-f2e59426da11",
+                "values": [
+                  {
+                    "alias": "itemKey",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Example"
+                  },
+                  {
+                    "alias": "itemValue",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "Layout": {}
+                      },
+                      "markup": "\u003Cp\u003ESummary list is supported.\u003C/p\u003E"
+                    }
+                  },
+                  {
+                    "alias": "actions",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "contentData": [
+                        {
+                          "contentTypeKey": "c7fa9985-51bd-409a-a621-f295dbf9a691",
+                          "key": "646bca3e-a72f-41ee-97c0-797e763cdc33",
+                          "values": [
+                            {
+                              "alias": "link",
+                              "culture": null,
+                              "editorAlias": null,
+                              "segment": null,
+                              "value": [
+                                {
+                                  "name": "Home",
+                                  "target": null,
+                                  "unique": null,
+                                  "type": null,
+                                  "udi": "umb://document/5e682cbeb867491a955f3382446d5663",
+                                  "url": null,
+                                  "queryString": null
+                                }
+                              ]
+                            },
+                            {
+                              "alias": "text",
+                              "culture": null,
+                              "editorAlias": null,
+                              "segment": null,
+                              "value": "Action 1"
+                            }
+                          ]
+                        }
+                      ],
+                      "settingsData": [],
+                      "expose": [
+                        {
+                          "contentKey": "646bca3e-a72f-41ee-97c0-797e763cdc33",
+                          "culture": null,
+                          "segment": null
+                        }
+                      ],
+                      "Layout": {
+                        "Umbraco.BlockList": [
+                          {
+                            "contentKey": "646bca3e-a72f-41ee-97c0-797e763cdc33",
+                            "contentUdi": null,
+                            "settingsKey": null,
+                            "settingsUdi": null
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "contentTypeKey": "4e3c68a7-d651-4898-b1e3-e8f29a9ffe48",
+                "key": "fbe6b89a-3e2c-4919-8266-d7e3f97624e7",
+                "values": [
+                  {
+                    "alias": "itemKey",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Example"
+                  },
+                  {
+                    "alias": "itemValue",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "Layout": {}
+                      },
+                      "markup": "\u003Cp\u003ESummary list is supported.\u003C/p\u003E"
+                    }
+                  }
+                ]
+              }
+            ],
+            "settingsData": [
+              {
+                "contentTypeKey": "18d06fa1-27bf-4f86-bc9d-b0a339512ca1",
+                "key": "425eaf47-3d31-4567-89c3-56c6d055a062",
+                "values": []
+              },
+              {
+                "contentTypeKey": "18d06fa1-27bf-4f86-bc9d-b0a339512ca1",
+                "key": "5fc5d63a-665c-4245-afd7-61db37b12675",
+                "values": []
+              }
+            ],
+            "expose": [
+              {
+                "contentKey": "4f6d71cb-c365-4bc0-a284-f2e59426da11",
+                "culture": null,
+                "segment": null
+              },
+              {
+                "contentKey": "fbe6b89a-3e2c-4919-8266-d7e3f97624e7",
+                "culture": null,
+                "segment": null
+              }
+            ],
+            "Layout": {
+              "Umbraco.BlockList": [
+                {
+                  "contentKey": "4f6d71cb-c365-4bc0-a284-f2e59426da11",
+                  "contentUdi": null,
+                  "settingsKey": "425eaf47-3d31-4567-89c3-56c6d055a062",
+                  "settingsUdi": null
+                },
+                {
+                  "contentKey": "fbe6b89a-3e2c-4919-8266-d7e3f97624e7",
+                  "contentUdi": null,
+                  "settingsKey": "5fc5d63a-665c-4245-afd7-61db37b12675",
+                  "settingsUdi": null
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
+      "key": "1c1fd83c-8d3f-4fc1-ae96-ddd6afaa0a33",
+      "values": []
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "key": "dc4064ae-9aa4-4658-a964-bb4a55e8d506",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EThis box has its background colour set to blue.\u003C/p\u003E"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "2e831668-9e36-44d9-95f4-de209f9a35d0",
+      "key": "f13977dc-2fed-4769-ba5d-6b4351100fb2",
+      "values": []
+    },
+    {
+      "contentTypeKey": "e0876897-88f4-4dcf-ae0a-ec5a37e3a185",
+      "key": "38f6c7cb-a426-43a1-8037-85c351676f53",
+      "values": [
+        {
+          "alias": "text",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "Layout": {}
+            },
+            "markup": "\u003Cp\u003EThis box has its background colour set to royal blue.\u003C/p\u003E"
+          }
+        }
+      ]
     }
   ],
   "settingsData": [
     {
       "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
       "key": "073aeb41-0c3e-4d4f-8dad-cb8d01e31ea6",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -2067,7 +2586,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "bdce6dde-c09d-4e1d-af8c-062c40740069",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2104,7 +2622,6 @@
     {
       "contentTypeKey": "53edb934-ee79-4ff0-b23a-84b91e9fef7a",
       "key": "3210be83-b61c-4827-bca3-9d6032b549f5",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2125,7 +2642,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "3e91ec27-f68d-4f65-9ff1-94c8ce4aa338",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2160,8 +2676,14 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "f69abffe-f9db-4430-987b-1eab3ec18899",
-      "udi": null,
       "values": [
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
         {
           "alias": "columnSize",
           "culture": null,
@@ -2178,13 +2700,6 @@
         },
         {
           "alias": "cssClassesForColumn",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -2195,8 +2710,14 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "91e4fddc-089c-4e2b-8798-ba9756c74302",
-      "udi": null,
       "values": [
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
         {
           "alias": "columnSize",
           "culture": null,
@@ -2217,20 +2738,12 @@
           "editorAlias": null,
           "segment": null,
           "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
         }
       ]
     },
     {
       "contentTypeKey": "085fe7f7-9496-44bd-bda7-fe27726abed3",
       "key": "08869393-724e-4bd7-afe0-ed73bb23fcc7",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2251,7 +2764,6 @@
     {
       "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
       "key": "57738c78-efc1-43aa-9dd7-7faa1634d956",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -2279,7 +2791,6 @@
     {
       "contentTypeKey": "53edb934-ee79-4ff0-b23a-84b91e9fef7a",
       "key": "61131510-f88b-4bef-a4d4-1608610fe12b",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2300,7 +2811,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "49baa0da-8837-4604-8a33-b234ddf85dcf",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2335,8 +2845,14 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "bc90d9d0-7597-4dfd-8c7c-6b82c7d53eda",
-      "udi": null,
       "values": [
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
         {
           "alias": "columnSize",
           "culture": null,
@@ -2357,20 +2873,12 @@
           "editorAlias": null,
           "segment": null,
           "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
         }
       ]
     },
     {
       "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
       "key": "36b2fcf6-8499-48a6-884a-7e95affcfca7",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -2398,7 +2906,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "7199b2e1-1615-4851-9fc1-f4199b9ba240",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2433,7 +2940,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "4b2f7579-475f-4439-a780-ec287c8a3e24",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2468,7 +2974,6 @@
     {
       "contentTypeKey": "53edb934-ee79-4ff0-b23a-84b91e9fef7a",
       "key": "551a4255-5b81-4137-b3ea-5abf4f2a79fe",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2489,7 +2994,6 @@
     {
       "contentTypeKey": "53edb934-ee79-4ff0-b23a-84b91e9fef7a",
       "key": "33bfc204-6ef6-43e1-bcf0-6623b35cce3c",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2510,7 +3014,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "fb0ee542-8b9a-42af-8967-7a769781f805",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2545,7 +3048,6 @@
     {
       "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
       "key": "8cda5eee-9926-47ab-9b16-704b3bab37d0",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -2573,7 +3075,6 @@
     {
       "contentTypeKey": "e326cfa6-2167-4763-840a-f52a25039f14",
       "key": "fcfd6958-2310-40ca-8646-f55717eec9e0",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2594,8 +3095,14 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "6a6dfc59-e177-4c82-abd0-8cb3d4bc1a48",
-      "udi": null,
       "values": [
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
         {
           "alias": "columnSize",
           "culture": null,
@@ -2616,20 +3123,12 @@
           "editorAlias": null,
           "segment": null,
           "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
         }
       ]
     },
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "fc6e0d1b-e721-48d7-b2e8-c937b8d860a0",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2664,8 +3163,14 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "c2caf2f9-25fa-4170-b959-a945a5069b4c",
-      "udi": null,
       "values": [
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
         {
           "alias": "columnSize",
           "culture": null,
@@ -2686,20 +3191,12 @@
           "editorAlias": null,
           "segment": null,
           "value": ""
-        },
-        {
-          "alias": "cssClassesForRow",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
         }
       ]
     },
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "383dc583-b29f-4eed-a0a4-0cf85b872cea",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2734,7 +3231,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "6af3f8cc-a66f-46ef-b592-3b7116fa014f",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2769,7 +3265,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "b10b669f-8efb-4ae5-8b1b-b41c81b8f231",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2804,7 +3299,6 @@
     {
       "contentTypeKey": "53edb934-ee79-4ff0-b23a-84b91e9fef7a",
       "key": "e90ca735-5298-4704-8949-2addf732c968",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2825,7 +3319,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "58f55a8e-9546-4a96-a0e6-2b4359cae555",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2860,7 +3353,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "06e71b08-ca30-4210-9493-0f5b46d88d89",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2895,7 +3387,6 @@
     {
       "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
       "key": "f19b748a-65ae-4642-bc25-3f0658c24d26",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -2923,7 +3414,6 @@
     {
       "contentTypeKey": "e326cfa6-2167-4763-840a-f52a25039f14",
       "key": "fc2ed743-c032-4a6d-878b-3e7bfd37e469",
-      "udi": null,
       "values": [
         {
           "alias": "cssClassesForRow",
@@ -2944,7 +3434,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "4b44e630-1f73-4cd3-b32b-ce9e68965196",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -2979,7 +3468,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "e68accc0-01dd-493f-b8cf-604bf3c5bd46",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3014,7 +3502,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "8801d225-5f60-4ab3-b1be-7ceb0f3d9222",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3049,8 +3536,14 @@
     {
       "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
       "key": "38a8be44-7bff-4899-8f14-637dd82adb8d",
-      "udi": null,
       "values": [
+        {
+          "alias": "cssClasses",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
         {
           "alias": "backgroundColour",
           "culture": null,
@@ -3064,13 +3557,6 @@
           }
         },
         {
-          "alias": "cssClasses",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "styleOfBox",
           "culture": null,
           "editorAlias": null,
@@ -3082,7 +3568,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "38a351ae-b3fd-46e1-88cd-738e95748fcb",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3117,7 +3602,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "1ef87c84-de80-4771-8b94-0e4c64901844",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3152,7 +3636,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "472ed792-2ce4-43ff-a30b-f2b238ce93aa",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3187,17 +3670,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "529b33c4-480c-47e5-a92e-2b0f5c8f5dae",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3215,7 +3697,6 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "84a3e9b8-630b-4c8a-a0b8-ab48748383ab",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -3243,17 +3724,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "a66f11b4-87ed-4079-aac4-202da8673e4b",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3271,17 +3751,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "8ff49969-42c9-4255-b4d6-2f396e314e71",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3299,17 +3778,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "531ca8ce-4af0-4ef6-922c-5031bf8934a8",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3327,7 +3805,6 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "52483911-5400-4bea-b003-7ba512691f45",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -3355,17 +3832,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "a012f706-31a6-47a7-80c2-3d54008b27a4",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3383,7 +3859,6 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "12d55c68-0da3-41e3-a40f-a50e9ac82622",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -3411,17 +3886,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "cde37174-94c5-4a5e-aeb1-df84fe0af01f",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3439,7 +3913,6 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "0734a87b-210e-449a-b20f-2dce15deef25",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -3467,17 +3940,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "ba3c8e78-58ab-412c-a976-339caa1f0824",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3495,7 +3967,6 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "aebe2971-0396-4fac-8e39-95f5971042a8",
-      "udi": null,
       "values": [
         {
           "alias": "backgroundColour",
@@ -3523,17 +3994,16 @@
     {
       "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
       "key": "3a660ba0-ee5c-4ba3-ae4c-09e346fe8aae",
-      "udi": null,
       "values": [
         {
-          "alias": "backgroundColour",
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
           "value": ""
         },
         {
-          "alias": "cssClasses",
+          "alias": "backgroundColour",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3551,7 +4021,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "07d83623-92f5-4474-992a-19ebb60c4541",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3586,7 +4055,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "b2982613-0c84-4d21-aec6-6e038f65cd83",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3642,7 +4110,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "a90b554c-4716-463d-b8bd-72165e281216",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3677,7 +4144,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "09cb0dc6-4f2a-4078-8c69-3a839cf869bc",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3733,7 +4199,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "1120baa4-41d4-49d9-a15e-32152dc90480",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3768,7 +4233,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "81ec84aa-fdd8-45bc-a9e1-2c49436236a1",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3785,13 +4249,6 @@
           "value": ""
         },
         {
-          "alias": "cssClasses",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "cssClassesForColumn",
           "culture": null,
           "editorAlias": null,
@@ -3800,6 +4257,13 @@
         },
         {
           "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3824,7 +4288,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "abf5df78-7737-495b-97c9-9790de693d6d",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3859,7 +4322,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "dbf26e0c-bd0c-4527-a091-91d9b0e70cb4",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3915,7 +4377,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "47136876-fe2c-4cb3-9cf7-fde40b8275ed",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -3932,13 +4393,6 @@
           "value": ""
         },
         {
-          "alias": "cssClasses",
-          "culture": null,
-          "editorAlias": null,
-          "segment": null,
-          "value": ""
-        },
-        {
           "alias": "cssClassesForColumn",
           "culture": null,
           "editorAlias": null,
@@ -3947,6 +4401,13 @@
         },
         {
           "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClasses",
           "culture": null,
           "editorAlias": null,
           "segment": null,
@@ -3971,7 +4432,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "81bec98a-a807-4691-a098-a056e8da9aa9",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4006,7 +4466,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "0281d0d1-9a6f-41c4-b7d5-4e2b4d087317",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4041,7 +4500,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "85c31105-be5d-4667-b952-0cc7b96ee487",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4097,7 +4555,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "8f758863-0fa7-4d8b-8d39-459aae9d2ba1",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4132,7 +4589,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "b8e70013-7930-4f25-be0a-30b01ee03750",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4188,7 +4644,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "9fa426ef-7866-4801-b8f5-a0215e8a95cd",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4223,7 +4678,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "00dd3380-4087-4fd5-a927-1612655a1e78",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4279,7 +4733,6 @@
     {
       "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
       "key": "09f7bcf0-993c-474c-83fe-8b4797f1c8a8",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4314,7 +4767,6 @@
     {
       "contentTypeKey": "9581b375-d5f1-4fcf-affd-9d80883d7812",
       "key": "960874ff-d1f9-4413-9c71-d9c08368e83a",
-      "udi": null,
       "values": [
         {
           "alias": "columnSize",
@@ -4364,6 +4816,226 @@
           "editorAlias": null,
           "segment": null,
           "value": "Extra large"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
+      "key": "4c7c5b34-122a-40fd-a5c2-13f2a66d30bb",
+      "values": [
+        {
+          "alias": "backgroundColour",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "label": "Grey",
+            "value": "#ededed"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
+      "key": "3a20b4e2-66d4-449f-9a1d-7af536a3379e",
+      "values": []
+    },
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "key": "8b34af5d-6ffc-4f81-a9d8-b350f326c600",
+      "values": []
+    },
+    {
+      "contentTypeKey": "29d9a3c9-4047-484a-8816-e233e161fcb0",
+      "key": "ff971dd1-41b9-4ed2-ac42-7e1bc6b2350a",
+      "values": []
+    },
+    {
+      "contentTypeKey": "0bac8213-4607-4547-902a-6a9d84b92633",
+      "key": "42d36832-49b2-443f-b4bd-3bb1c60ce329",
+      "values": []
+    },
+    {
+      "contentTypeKey": "a6689021-cc6e-4d94-8c37-235906ebeff1",
+      "key": "9ea9e4f4-50cb-49c0-9e74-bf91c6e06556",
+      "values": []
+    },
+    {
+      "contentTypeKey": "d43b72b5-edac-42e0-aa09-1b080d7bd6eb",
+      "key": "93b291d7-7a23-4a42-a44f-dbab5e3f1578",
+      "values": []
+    },
+    {
+      "contentTypeKey": "7c697ad4-e2f8-4aab-857e-fb1b26c2a295",
+      "key": "f3de4194-2b2e-4e97-af88-0f389f2c83dd",
+      "values": [
+        {
+          "alias": "backgroundColour",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "label": "Royal Blue",
+            "value": "#006ebc"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "13177471-0bf1-49c4-a723-6c7e8d764ba6",
+      "key": "63b5fcea-7729-4cd9-81cb-d998ade598d4",
+      "values": []
+    },
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "key": "689fc250-42dc-4b46-b863-9612da975083",
+      "values": []
+    },
+    {
+      "contentTypeKey": "29d9a3c9-4047-484a-8816-e233e161fcb0",
+      "key": "5b003cd7-edd6-4863-b9b0-a7281a5dd8e1",
+      "values": []
+    },
+    {
+      "contentTypeKey": "0bac8213-4607-4547-902a-6a9d84b92633",
+      "key": "05d9bc6f-e7d6-4562-9168-5d1504962430",
+      "values": []
+    },
+    {
+      "contentTypeKey": "a6689021-cc6e-4d94-8c37-235906ebeff1",
+      "key": "09beb16c-7a41-4e95-bc14-41d83e45e8b0",
+      "values": []
+    },
+    {
+      "contentTypeKey": "d43b72b5-edac-42e0-aa09-1b080d7bd6eb",
+      "key": "92b3e3af-64d8-4235-8a08-9a06a379d28d",
+      "values": []
+    },
+    {
+      "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
+      "key": "521099b3-bfc5-4609-aaec-7d8a5c5983f1",
+      "values": [
+        {
+          "alias": "cssClasses",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "backgroundColour",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "label": "Blue",
+            "value": "#ebf5f7"
+          }
+        },
+        {
+          "alias": "styleOfBox",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Solid"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "key": "2e45520d-963b-4e6e-a74e-4b908c1dd60b",
+      "values": [
+        {
+          "alias": "columnSize",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "columnSizeFromDesktop",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForColumn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "c5b53811-a546-4c46-bf33-298c48719838",
+      "key": "7b6b80ee-d905-4e16-8b8f-e04f42127433",
+      "values": [
+        {
+          "alias": "cssClasses",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "backgroundColour",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "label": "Royal Blue",
+            "value": "#006ebc"
+          }
+        },
+        {
+          "alias": "styleOfBox",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Solid"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "21721e40-fe18-447b-bbd6-00c02bd5539b",
+      "key": "ea46d4f2-dff3-4485-9758-1b0f93291f87",
+      "values": [
+        {
+          "alias": "columnSize",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "columnSizeFromDesktop",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForColumn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "cssClassesForRow",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
         }
       ]
     }
@@ -4708,6 +5380,126 @@
       "contentKey": "195eacae-f506-4828-b60d-3b145c5b6778",
       "culture": null,
       "segment": null
+    },
+    {
+      "contentKey": "5dc864f7-f7b2-4314-8a1f-2c2e0bcbb37c",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "51ddb88f-d5e5-43cc-a971-327105e32071",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e5843c7-a468-4c55-a39b-9ed481a1dcbb",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "721fff13-c687-49bc-a285-0ff70d75ec39",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "4010bb9c-a74a-4b47-a01d-3d426996d943",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "df7fe90c-09b9-47c8-be90-fe610e701d75",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "cdef66f9-3bc4-48ff-b6be-9429c034bfd7",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "119523ec-db2b-45e6-9cb5-03603ff22ce7",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "df290159-c2c6-402c-9af2-0f4b80e35e4b",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "ceaa5ea7-7f3f-4c7c-8884-c37bb9a5c7b7",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "896ff51a-7453-45a9-bef3-5288ba3b7207",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "f2b2fbb3-5824-4d82-a98d-2520f4968343",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "ec5a3fcc-4002-4e5e-ab9f-972c1707b96d",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "b7730a85-1717-45dd-b61a-2b4ccf09e3ff",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "694bdc0b-4f73-4e58-a1ff-9a77b56475ea",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "cae47173-9f60-42e0-99da-9e24258ab548",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "5c700189-e747-4b15-ae4b-79f5b0541026",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "9d2927ae-1426-4b70-a8b5-89acc7e45412",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "f9136709-726f-4076-ad16-6229e92d2cec",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "25a49c40-645d-4177-8279-3b933345289e",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "1c1fd83c-8d3f-4fc1-ae96-ddd6afaa0a33",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "dc4064ae-9aa4-4658-a964-bb4a55e8d506",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "f13977dc-2fed-4769-ba5d-6b4351100fb2",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "38f6c7cb-a426-43a1-8037-85c351676f53",
+      "culture": null,
+      "segment": null
     }
   ],
   "Layout": {
@@ -4763,12 +5555,7 @@
                 "rowSpan": 1,
                 "settingsKey": "84a3e9b8-630b-4c8a-a0b8-ab48748383ab",
                 "settingsUdi": null
-              }
-            ],
-            "key": "8a7ba895-ae96-4928-8a2e-4fae19cf400e"
-          },
-          {
-            "items": [
+              },
               {
                 "areas": [
                   {
@@ -4791,6 +5578,59 @@
                 "contentUdi": null,
                 "rowSpan": 1,
                 "settingsKey": "a66f11b4-87ed-4079-aac4-202da8673e4b",
+                "settingsUdi": null
+              }
+            ],
+            "key": "8a7ba895-ae96-4928-8a2e-4fae19cf400e"
+          },
+          {
+            "items": [
+              {
+                "areas": [
+                  {
+                    "items": [
+                      {
+                        "areas": [],
+                        "columnSpan": 12,
+                        "contentKey": "dc4064ae-9aa4-4658-a964-bb4a55e8d506",
+                        "contentUdi": null,
+                        "rowSpan": 1,
+                        "settingsKey": "2e45520d-963b-4e6e-a74e-4b908c1dd60b",
+                        "settingsUdi": null
+                      }
+                    ],
+                    "key": "e3d17c0e-a303-4d7e-9cbb-52752a355127"
+                  }
+                ],
+                "columnSpan": 6,
+                "contentKey": "1c1fd83c-8d3f-4fc1-ae96-ddd6afaa0a33",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "521099b3-bfc5-4609-aaec-7d8a5c5983f1",
+                "settingsUdi": null
+              },
+              {
+                "areas": [
+                  {
+                    "items": [
+                      {
+                        "areas": [],
+                        "columnSpan": 12,
+                        "contentKey": "38f6c7cb-a426-43a1-8037-85c351676f53",
+                        "contentUdi": null,
+                        "rowSpan": 1,
+                        "settingsKey": "ea46d4f2-dff3-4485-9758-1b0f93291f87",
+                        "settingsUdi": null
+                      }
+                    ],
+                    "key": "e3d17c0e-a303-4d7e-9cbb-52752a355127"
+                  }
+                ],
+                "columnSpan": 6,
+                "contentKey": "f13977dc-2fed-4769-ba5d-6b4351100fb2",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "7b6b80ee-d905-4e16-8b8f-e04f42127433",
                 "settingsUdi": null
               }
             ],
@@ -5367,6 +6207,144 @@
         "contentUdi": null,
         "rowSpan": 1,
         "settingsKey": "551a4255-5b81-4137-b3ea-5abf4f2a79fe",
+        "settingsUdi": null
+      },
+      {
+        "areas": [
+          {
+            "items": [
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "119523ec-db2b-45e6-9cb5-03603ff22ce7",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "3a20b4e2-66d4-449f-9a1d-7af536a3379e",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "df290159-c2c6-402c-9af2-0f4b80e35e4b",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "8b34af5d-6ffc-4f81-a9d8-b350f326c600",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "ceaa5ea7-7f3f-4c7c-8884-c37bb9a5c7b7",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "ff971dd1-41b9-4ed2-ac42-7e1bc6b2350a",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "896ff51a-7453-45a9-bef3-5288ba3b7207",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "42d36832-49b2-443f-b4bd-3bb1c60ce329",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "f2b2fbb3-5824-4d82-a98d-2520f4968343",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "9ea9e4f4-50cb-49c0-9e74-bf91c6e06556",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "ec5a3fcc-4002-4e5e-ab9f-972c1707b96d",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "93b291d7-7a23-4a42-a44f-dbab5e3f1578",
+                "settingsUdi": null
+              }
+            ],
+            "key": "b50dd71c-b7a2-408b-9d23-10d5752470bf"
+          }
+        ],
+        "columnSpan": 12,
+        "contentKey": "cdef66f9-3bc4-48ff-b6be-9429c034bfd7",
+        "contentUdi": null,
+        "rowSpan": 1,
+        "settingsKey": "4c7c5b34-122a-40fd-a5c2-13f2a66d30bb",
+        "settingsUdi": null
+      },
+      {
+        "areas": [
+          {
+            "items": [
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "694bdc0b-4f73-4e58-a1ff-9a77b56475ea",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "63b5fcea-7729-4cd9-81cb-d998ade598d4",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "cae47173-9f60-42e0-99da-9e24258ab548",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "689fc250-42dc-4b46-b863-9612da975083",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "5c700189-e747-4b15-ae4b-79f5b0541026",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "5b003cd7-edd6-4863-b9b0-a7281a5dd8e1",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "9d2927ae-1426-4b70-a8b5-89acc7e45412",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "05d9bc6f-e7d6-4562-9168-5d1504962430",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "f9136709-726f-4076-ad16-6229e92d2cec",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "09beb16c-7a41-4e95-bc14-41d83e45e8b0",
+                "settingsUdi": null
+              },
+              {
+                "areas": [],
+                "columnSpan": 12,
+                "contentKey": "25a49c40-645d-4177-8279-3b933345289e",
+                "contentUdi": null,
+                "rowSpan": 1,
+                "settingsKey": "92b3e3af-64d8-4235-8a08-9a06a379d28d",
+                "settingsUdi": null
+              }
+            ],
+            "key": "b50dd71c-b7a2-408b-9d23-10d5752470bf"
+          }
+        ],
+        "columnSpan": 12,
+        "contentKey": "b7730a85-1717-45dd-b61a-2b4ccf09e3ff",
+        "contentUdi": null,
+        "rowSpan": 1,
+        "settingsKey": "f3de4194-2b2e-4e97-af88-0f389f2c83dd",
         "settingsUdi": null
       },
       {

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBoxColour.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBoxColour.config
@@ -15,6 +15,10 @@
     {
       "value": "ebf5f7",
       "label": "Blue"
+    },
+    {
+      "value": "006ebc",
+      "label": "Royal Blue"
     }
   ],
   "umbMigrationV14": "2025-12-12T16:38:55.4051986\u002B00:00",

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBoxColour.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/DataTypes/TPRBoxColour.config
@@ -19,6 +19,10 @@
     {
       "value": "006ebc",
       "label": "Royal Blue"
+    },
+    {
+      "value": "1e7e34",
+      "label": "Green"
     }
   ],
   "umbMigrationV14": "2025-12-12T16:38:55.4051986\u002B00:00",

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-box.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-box.ts
@@ -34,7 +34,11 @@ export class TprBoxView extends UmbElementMixin(LitElement) implements UmbBlockE
     }
 
     override render() {
-        const cssClasses = this.settings?.styleOfBox === 'Bordered' ? ' tpr-box--bordered' : (this.settings?.backgroundColour.label === 'Blue' ? ' tpr-box--blue' : null);
+        let backgroundClass = '';
+        if (this.settings?.backgroundColour?.label && this.settings?.backgroundColour?.label !== "Grey") {
+            backgroundClass = ` tpr-box--${this.settings?.backgroundColour?.label.toLowerCase().replace(/\s+/g, '-')}`;
+        }
+        const cssClasses = this.settings?.styleOfBox === 'Bordered' ? ' tpr-box--bordered' : backgroundClass;
         const isNestedBox = this.blockType?.contentElementTypeKey == "2e831668-9e36-44d9-95f4-de209f9a35d0";
 
         return html`

--- a/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
+++ b/ThePensionsRegulator.Frontend.Umbraco/Styles/govuk-umbraco-backoffice.scss
@@ -19,7 +19,17 @@ p.tpr-add-link {
     margin: 5px;
 }
 
-// Box and nested box blocks
+/* Tables do not have the extra class that applies TPR styles */
+.backoffice-block-view .govuk-table {
+    @extend .govuk-table--tpr-default;
+}
+
+.backoffice-block-view .govuk-table .govuk-table__cell,
+.backoffice-block-view .govuk-table .govuk-table__cell:last-child {
+    padding: 20px;
+    border-bottom-width: .125rem;
+}
+
 .backoffice-block-header {
     display: block;
     padding: 15px;

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRBox.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRBox.cshtml
@@ -1,5 +1,6 @@
 ﻿@using GovUk.Frontend.Umbraco;
 @using GovUkPropertyAliases = ThePensionsRegulator.GovUk.Frontend.Umbraco.PropertyAliases
+@using Humanizer
 @using Microsoft.Extensions.Options
 @using ThePensionsRegulator.Frontend.Umbraco
 @using ThePensionsRegulator.GovUk.Frontend.Umbraco
@@ -15,11 +16,15 @@
     var styleOfBox = Model.Settings?.Value<string>(TprPropertyAliases.BoxStyle);
     var isSolid = string.IsNullOrEmpty(styleOfBox) || styleOfBox == TprBoxStyles.Solid;
     var isFullWidth = styleOfBox == TprBoxStyles.FullWidth;
-    var boxClass = (string.IsNullOrEmpty(styleOfBox) || isSolid) ? null : " tpr-box--" + styleOfBox.ToLowerInvariant();
+    var boxClass = (string.IsNullOrEmpty(styleOfBox) || isSolid) ? null : $" tpr-box--{styleOfBox.ToLowerInvariant()}";
     var cssClasses = (" " + Model.Settings?.Value<string>(GovUkPropertyAliases.CssClasses)).TrimEnd();
     if (isSolid || isFullWidth)
     {
-        cssClasses += Model.Settings?.Value<ColorPickerValueConverter.PickedColor>(TprPropertyAliases.BoxBackgroundColour)?.Label == "Blue" ? " tpr-box--blue" : null;
+        var backgroundColour = Model.Settings?.Value<ColorPickerValueConverter.PickedColor>(TprPropertyAliases.BoxBackgroundColour)?.Label;
+        if (!string.IsNullOrEmpty(backgroundColour) && backgroundColour != "Grey")
+        {
+            cssClasses += $" tpr-box--{backgroundColour.Kebaberize()}";
+        };
     }
     <div class="tpr-box@(boxClass)@(cssClasses)">
         @if (isFullWidth)

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-caption.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-caption.scss
@@ -11,3 +11,10 @@
 .govuk-caption-xl {
     @include govuk-responsive-margin(3, "bottom");
 }
+
+// Display in inverse colours on a dark background, otherwise use the default colours.
+.govuk-caption-xl,
+.govuk-caption-l,
+.govuk-caption-m {
+    color: var(--tpr-secondary-text-colour--inverse, govuk-functional-colour(secondary-text));
+}

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-details.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-details.scss
@@ -8,3 +8,16 @@
 .govuk-form-group .govuk-form-group:last-of-type + .govuk-details {
     @include govuk-responsive-margin(6, "top");
 }
+
+// Display in inverse colours on a dark background, otherwise use the default colours.
+.govuk-details {
+    color: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
+}
+
+.govuk-details__summary {
+    color: var(--tpr-link-colour--inverse, govuk-functional-colour(link));
+}
+
+.govuk-details__summary:hover:not(:focus) {
+    color: var(--tpr-link-colour--inverse, govuk-functional-colour(link-hover));
+}

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
@@ -68,17 +68,24 @@
 .tpr-box--royal-blue {
     background-color: $tpr-colour-royal-blue;
     color: $tpr-colour-white;
-    
-    /* When used in the Umbraco backoffice the elements that need to be inverted are blocks that are descendants 
-       of the box block. Each block has its own shadow root, so we need styles in a descendant shadow root to adapt 
-       to a class applied in an ancestor shadow root. CSS variables are the only method that can cross this 
-       boundary and work in the backoffice as well as on the final rendered component. 
+}
 
-       Each element that needs to update has its colour(s) set to the variables defined here, with a fallback to the
-       default colour for that element. These variables are normally undefined, so the fallback default is used.
-       When this selector defines the variables, the variable value is used instead of the fallback and the colours 
-       are inverted.
-    */ 
+.tpr-box--green {
+    background-color: $tpr-colour-camarone;
+    color: $tpr-colour-white;
+}
+
+/*  When used in the Umbraco backoffice the elements that need to be inverted are blocks that are descendants 
+    of the box block. Each block has its own shadow root, so we need styles in a descendant shadow root to adapt 
+    to a class applied in an ancestor shadow root. CSS variables are the only method that can cross this 
+    boundary and work in the backoffice as well as on the final rendered component. 
+
+    Each element that needs to update has its colour(s) set to the variables defined here, with a fallback to the
+    default colour for that element. These variables are normally undefined, so the fallback default is used.
+    When this selector defines the variables, the variable value is used instead of the fallback and the colours 
+    are inverted.
+*/
+.tpr-box--royal-blue, .tpr-box--green {
     --tpr-text-colour--inverse: $tpr-colour-white;
     --tpr-secondary-text-colour--inverse: $tpr-colour-white;
     --tpr-link-colour--inverse: $tpr-colour-white;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-grid.scss
@@ -64,6 +64,28 @@
     background-color: $tpr-colour-regent-st-blue-tint-75;
 }
 
+// Where a box has a darker background, the colour of elements inside it should be inverted to maintain contrast.
+.tpr-box--royal-blue {
+    background-color: $tpr-colour-royal-blue;
+    color: $tpr-colour-white;
+    
+    /* When used in the Umbraco backoffice the elements that need to be inverted are blocks that are descendants 
+       of the box block. Each block has its own shadow root, so we need styles in a descendant shadow root to adapt 
+       to a class applied in an ancestor shadow root. CSS variables are the only method that can cross this 
+       boundary and work in the backoffice as well as on the final rendered component. 
+
+       Each element that needs to update has its colour(s) set to the variables defined here, with a fallback to the
+       default colour for that element. These variables are normally undefined, so the fallback default is used.
+       When this selector defines the variables, the variable value is used instead of the fallback and the colours 
+       are inverted.
+    */ 
+    --tpr-text-colour--inverse: $tpr-colour-white;
+    --tpr-secondary-text-colour--inverse: $tpr-colour-white;
+    --tpr-link-colour--inverse: $tpr-colour-white;
+    --tpr-warning-icon--inverse: $tpr-colour-white;
+    --tpr-border-colour--inverse: $tpr-colour-white;
+}
+
 .tpr-box.govuk-grid-row {
     padding: 0 $govuk-gutter-half;
     background: none;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-hint.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-hint.scss
@@ -1,6 +1,11 @@
 ﻿@import '_tpr-variables.scss';
 @import 'govuk/base';
 
+// Display in inverse colours on a dark background, otherwise use the default colours.
+.govuk-hint {
+    color: var(--tpr-secondary-text-colour--inverse, govuk-functional-colour(secondary-text));
+}
+
 // GOV.UK warning text don't account for the possibility of multiple paragraphs within.
 .govuk-hint > p.govuk-body {
     @extend .govuk-hint;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-inset-text.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-inset-text.scss
@@ -2,7 +2,9 @@
 @import 'govuk/base';
 
 // Change GOV.UK inset text styles where the TPR brand diverges from the GOV.UK Design System.
+// Display in inverse colours on a dark background, otherwise use the default colours.
 .govuk-inset-text {
+    color: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
     margin-top: 0;
     border-left-width: govuk-px-to-rem(10px);
     font-weight: $tpr-font-weight-semi-bold;

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-link.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-link.scss
@@ -5,3 +5,20 @@
 .govuk-link {
     font-weight: $tpr-font-weight-semi-bold; 
 }
+
+// Display in inverse colours on a dark background, otherwise use the default colours.
+.govuk-link:link:not(:focus) {
+    color: var(--tpr-link-colour--inverse, govuk-functional-colour(link));
+}
+
+.govuk-link:visited:not(:focus) {
+    color: var(--tpr-link-colour--inverse, govuk-functional-colour(link-visited));
+}
+
+.govuk-link:active:not(:focus) {
+    color: var(--tpr-link-colour--inverse, govuk-functional-colour(link-active));
+}
+
+.govuk-link:hover:not(:focus) {
+    color: var(--tpr-link-colour--inverse, govuk-functional-colour(link-hover));
+}

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-table.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-table.scss
@@ -7,10 +7,16 @@
 }
 .govuk-table--tpr-default .govuk-table__header, .govuk-table--tpr-default .govuk-table__header:last-child {
     @include govuk-responsive-padding(4);
+    color: govuk-functional-colour(text);
     background-color: $tpr-colour-whisper;
     border: solid govuk-px-to-rem(2) $tpr-colour-very-light-grey;
 }
 .govuk-table--tpr-default .govuk-table__cell, .govuk-table--tpr-default .govuk-table__cell:last-child {
     @include govuk-responsive-padding(4);
     border: solid govuk-px-to-rem(2) $tpr-colour-very-light-grey;
+}
+
+// Display in inverse colours on a dark background, otherwise use the default colours.
+.govuk-table--tpr-default {
+    color: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-typography.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-typography.scss
@@ -1,12 +1,15 @@
 ﻿@import '_tpr-variables.scss';
 @import 'govuk/base';
 
-// Change GOV.UK styles where the TPR brand diverges from the GOV.UK Design System.
-.govuk-summary-list__key {
-    font-weight: $tpr-font-weight-semi-bold;
-}
-
 // Display in inverse colours on a dark background, otherwise use the default colours.
-.govuk-summary-list {
+.govuk-heading-xl,
+.govuk-heading-l,
+.govuk-heading-m,
+.govuk-heading-s,
+.govuk-body,
+.govuk-body-l,
+.govuk-body-m,
+.govuk-body-s,
+.govuk-list {
     color: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
 }

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-warning-text.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-warning-text.scss
@@ -9,3 +9,14 @@
 .govuk-warning-text__text > p.govuk-body:last-of-type {
     margin-bottom: 0;
 }
+
+// Display in inverse colours if it appears on a dark background, otherwise use the default colours.
+.govuk-warning-text__text {
+    color: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
+}
+
+.govuk-warning-text__icon {
+    color: var(--tpr-warning-icon--inverse, govuk-functional-colour(body-background));
+    background: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
+    border-color: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
+}

--- a/ThePensionsRegulator.Frontend/Styles/tpr.scss
+++ b/ThePensionsRegulator.Frontend/Styles/tpr.scss
@@ -78,6 +78,7 @@
 @import '_tpr-table.scss';
 @import '_tpr-tag.scss';
 @import '_tpr-textarea.scss';
+@import '_tpr-typography.scss';
 @import '_tpr-warning-text.scss';
 
 // Add different components and customisations that are not part of the GOV.UK Design System (or are in a later version than the one we're targeting)

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Styles/_backoffice-block-views.scss
@@ -7,7 +7,7 @@
     padding-top: .1px;
     display: block;
     cursor: pointer;
-    color: govuk-functional-colour(text);
+    color: var(--tpr-text-colour--inverse, govuk-functional-colour(text));
 }
 
 .backoffice-block-view:link, .backoffice-block-view:visited {
@@ -115,7 +115,7 @@
 
 /* Links are disabled by converting them to span, but should still look like links. */
 .backoffice-block-view span.govuk-link {
-    color: govuk-functional-colour(link);
+    color: var(--tpr-link-colour--inverse, govuk-functional-colour(link));
     cursor: pointer;
 }
 .backoffice-block-view .govuk-error-summary span.govuk-link {


### PR DESCRIPTION
TPR designs are using royal blue and green boxes to reflect statuses. We need to support these colour options for the 'TPR box' and 'TPR nested box' components.

<img width="1480" height="359" alt="Green, royal blue and grey boxes indicating statuses" src="https://github.com/user-attachments/assets/9136a78d-ce29-497f-b9d0-fdcd1e159bea" />

## Changes in this PR

- updates the 'TPR Box colour' data type in Umbraco with the new options
- adds new CSS classes, and updates views to map the selection in Umbraco to the expanded range of classes
- inverts the colour of content within the new boxes to maintain contrast
- adds examples to both example apps, including an example of all supported content within a box
- fixes the display of tables in the backoffice, which had regressed from showing TPR styles to showing GOV.UK styles

There would be several ways to invert the colour of the content inside these boxes in the final rendered output. However, when used in the Umbraco backoffice the elements that need to be inverted are blocks that are descendants of the box block. Each block has its own shadow root, so we need styles in a descendant shadow root to adapt to a class applied in an ancestor shadow root. CSS variables are the only method that can cross this boundary and work in the backoffice as well as on the final rendered component. 

Each element that needs to update has its colour(s) set to the variables defined here, with a fallback to the default colour for that element. These variables are normally undefined, so the fallback default is used. When a selector for the new box colours defines the variables, the variable value is used instead of the fallback and the colours are inverted.

Due to the complexity of inverting all styles for all components I have created examples of content within boxes and called that the supported components within a coloured box. We may need to add more later, but the range I've added support for should cover all common scenarios.

## Examples of box colours

<img width="1484" height="510" alt="Example showing the range of box colours" src="https://github.com/user-attachments/assets/e98664fb-5a81-4250-9636-3ab6c477569a" />

<img width="1469" height="1486" alt="Content colours within a grey box" src="https://github.com/user-attachments/assets/4bfdaa24-8b21-4a08-b1b4-cf7b890f65a8" />

<img width="1461" height="1546" alt="Content colours within a royal blue box" src="https://github.com/user-attachments/assets/a980c9d5-c3d1-4b46-923d-bbedd72b7aa6" />

<img width="1465" height="1546" alt="Content colours within a green box" src="https://github.com/user-attachments/assets/39f79ee4-c8fd-40f5-9a55-ddca0f637cfb" />

## Examples in Umbraco backoffice

<img width="1604" height="1552" alt="Content colours within a grey box in Umbraco" src="https://github.com/user-attachments/assets/92f4a54e-1161-4205-b31e-a69934d9489f" />

<img width="1596" height="1571" alt="Content colours within a royal blue box in Umbraco" src="https://github.com/user-attachments/assets/7fc965f1-191a-4546-857b-f8d3c90bc62d" />

<img width="1591" height="1580" alt="Content colours within a green box in Umbraco" src="https://github.com/user-attachments/assets/c8d58115-acba-431c-87e0-1db1a0efd424" />


Closes #746. 