### PR TITLE
Upgrade to govuk-frontend-aspnetcore v4.1.0 and GOV.UK Frontend v6.1.0

### DIFF
--- a/GovUk.Frontend.ExampleApp/GovUk.Frontend.ExampleApp.csproj
+++ b/GovUk.Frontend.ExampleApp/GovUk.Frontend.ExampleApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We add support for:
   - [Back link](https://github.com/x-govuk/govuk-frontend-aspnetcore/blob/main/docs/components/back-link.md)
   - [Breadcrumbs](/docs/components/breadcrumbs.md)
 
-We target [GOV.UK Frontend v6.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0) in line with James Gunn's base project.
+We target [GOV.UK Frontend v6.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.1.0) in line with James Gunn's base project.
 
 ## ASP.NET projects without Umbraco
 

--- a/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
@@ -9,10 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -20,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -56,7 +56,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
 		<PackageReference Include="MailKit" Version="4.16.0" />
 		<PackageReference Include="uSync.BackOffice" Version="17.0.4" />
 	</ItemGroup>

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -30,9 +30,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.1" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 	</ItemGroup>
 

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-search-results.js
@@ -1,4 +1,4 @@
-﻿import { Accordion } from '/govuk-frontend.min.js?v=6.0.0';
+﻿import { Accordion } from '/govuk-frontend.min.js?v=6.1.0';
 
 let searchResults = [];
 let popularContentApiUrl = "";

--- a/ThePensionsRegulator.GovUk.Frontend.ConformanceTests/ThePensionsRegulator.GovUk.Frontend.ConformanceTests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.ConformanceTests/ThePensionsRegulator.GovUk.Frontend.ConformanceTests.csproj
@@ -12,13 +12,13 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
@@ -61,7 +61,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
 		<PackageReference Include="MailKit" Version="4.16.0" />
 		<PackageReference Include="TinyMCE.Umbraco" Version="17.2.0" />
 		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.2.2" />

--- a/ThePensionsRegulator.GovUk.Frontend.UnitTests/ThePensionsRegulator.GovUk.Frontend.UnitTests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.UnitTests/ThePensionsRegulator.GovUk.Frontend.UnitTests.csproj
@@ -12,10 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="FakeLocalTimeZone" Version="0.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -23,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
@@ -39,10 +39,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.98.0" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="FileSignatures" Version="7.0.0" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.0.1" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 		<PackageReference Include="OpenMcdf" Version="3.1.3" />
 	</ItemGroup>

--- a/ThePensionsRegulator.GovUk.Frontend/wwwroot/ThePensionsRegulator.GovUk.Frontend/js/govuk-js-init.js
+++ b/ThePensionsRegulator.GovUk.Frontend/wwwroot/ThePensionsRegulator.GovUk.Frontend/js/govuk-js-init.js
@@ -1,4 +1,4 @@
-﻿import { initAll } from '/govuk-frontend.min.js?v=6.0.0';
+﻿import { initAll } from '/govuk-frontend.min.js?v=6.1.0';
 const [html] = document.getElementsByTagName("html");
 const lang = html.getAttribute("lang");
 const config = lang === 'cy' || lang === 'cy-GB' ? {

--- a/ThePensionsRegulator.Umbraco.Core.Tests/ThePensionsRegulator.Umbraco.Core.Tests.csproj
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/ThePensionsRegulator.Umbraco.Core.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
+++ b/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.16.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.2.2" />
   </ItemGroup>
 

--- a/ThePensionsRegulator.Umbraco.Testing.Tests/ThePensionsRegulator.Umbraco.Testing.Tests.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/ThePensionsRegulator.Umbraco.Testing.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "brace-expansion": "^5.0.5",
-        "govuk-frontend": "^6.0.0"
+        "govuk-frontend": "^6.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -2587,9 +2587,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.0.0.tgz",
-      "integrity": "sha512-n1DUbQD6coHL3UkQS0yTbd4ziIxLBzkWBODVCjXMclSY7FvOGeHcTg3c72z6u7DQECQb0tfZofhPjGxPUOIizA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
+      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "brace-expansion": "^5.0.5",
-    "govuk-frontend": "^6.0.0"
+    "govuk-frontend": "^6.1.0"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --ci --watchAll=false --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura",


### PR DESCRIPTION
Upgrade to govuk-frontend-aspnetcore v4.1.0 and GOV.UK Frontend v6.1.0, which are non-breaking changes.

At the same time upgrade other packages to latest minor versions ready for a v10.0.0 release of our packages.

Closes #610