### PR TITLE
#260858 - Menu triggers darkened background that confuses users (v13)

### DIFF
--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -157,7 +157,7 @@ function handleOutsideClick(e) {
 
 let desktopSubMenuObserver = null;
 
-function observeSubMenuVisibility(item, subMenu, overlay) {
+function observeSubMenuVisibilityDesktop(item, subMenu, overlay) {
 
     if (!("IntersectionObserver" in window)) return;
 
@@ -179,6 +179,29 @@ function observeSubMenuVisibility(item, subMenu, overlay) {
     desktopSubMenuObserver.observe(subMenu);
 }
 
+let mobileSubMenuObserver = null;
+function observeSubMenuVisibilityMobile(menu) {
+
+    if (!("IntersectionObserver" in window)) return;
+
+    if (mobileSubMenuObserver) {
+        mobileSubMenuObserver.disconnect();
+    }
+
+    mobileSubMenuObserver = new IntersectionObserver(([entry]) => {
+        if (!entry.isIntersecting) {
+            closeMobileMenu()
+        }
+    },
+        {
+            root: null,
+            threshold: 0
+        }
+
+    );
+    mobileSubMenuObserver.observe(menu);
+}
+
 function closeSubMenuDesktop(item, subMenu, overlay) {
     subMenu.style.display = 'none';
     item.setAttribute("aria-expanded", "false");
@@ -198,7 +221,7 @@ function openSubMenuDesktop(item, subMenu, overlay) {
     subMenu.querySelector(".tpr-header-menu__nav-sub-menu-item").removeAttribute("style");
     overlay?.classList.add("tpr-header-menu__nav-overlay--visible");
 
-    observeSubMenuVisibility(item, subMenu, overlay);
+    observeSubMenuVisibilityDesktop(item, subMenu, overlay);
 }
 
 function keyboardToggleMobileMenu(e) {
@@ -361,6 +384,32 @@ function restoreDefaultMenuState(e) {
     });
 }
 
+function closeMobileMenu() {
+    const toggle = document.querySelector(".tpr-header-menu__button");
+    toggle.classList.remove("tpr-header-menu__button--open");
+
+    const svgs = document.querySelectorAll(".tpr-mobile-menu__svg");
+    svgs.forEach(s => s.classList.remove("tpr-mobile-menu__svg--hide"));
+
+    const button = document.querySelector(".tpr-header-menu__button-inner");
+    if (button) {
+        const closeButtonText = button.getAttribute("data-close-label");
+
+        button.textContent = closeButtonText;
+        button.classList.remove("tpr-header-menu__button-inner--opened")
+
+        toggle.setAttribute("aria-expanded", false);
+    }
+
+    document.querySelectorAll(".tpr-header-menu__nav-container").forEach((nav) => {
+        nav.classList.remove("tpr-header-menu__nav-container--active");
+        const arrow = nav.querySelector(".tpr-header-menu__arrow");
+        arrow.classList.remove("tpr-header-menu__arrow-down");
+        arrow.setAttribute("aria-expanded", false);
+        const subMenu = nav.querySelector(".tpr-header-menu__nav-sub-menu").classList.remove("tpr-header-menu__nav-sub-menu--active")
+    });
+
+}
 function toggleMobileMenu() {
 
     const toggle = document.querySelector(".tpr-header-menu__button");
@@ -383,6 +432,7 @@ function toggleMobileMenu() {
 
     document.querySelectorAll(".tpr-header-menu__nav-container").forEach((nav) => {
         nav.classList.toggle("tpr-header-menu__nav-container--active");
+        observeSubMenuVisibilityMobile(nav)
     });
 }
 

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -1,5 +1,4 @@
-﻿
-document.addEventListener("DOMContentLoaded", function () {
+﻿document.addEventListener("DOMContentLoaded", function () {
 
 
     highlightCurrentSection();
@@ -22,7 +21,7 @@ document.addEventListener("DOMContentLoaded", function () {
         if (isMobile) {
 
             mobileMenuInnerContainers.forEach(m => m.classList.add("tpr-mobile-menu__container-inner--hidden"));
-            toggles.forEach(t => t.classList.remove("tpr-header-menu__button--hidden")); 
+            toggles.forEach(t => t.classList.remove("tpr-header-menu__button--hidden"));
             noJsLinks.forEach(l => l.classList.add("tpr-mobile-menu__no-js-link--hidden"))
             toggles.forEach(t => t.addEventListener("click", toggleMobileMenu));
             toggles.forEach(t => t.addEventListener("keydown", keyboardToggleMobileMenu));
@@ -155,51 +154,40 @@ function handleOutsideClick(e) {
     openItem.focus();
 }
 
-let desktopSubMenuObserver = null;
+let subMenuObservers = { desktop: null, mobile: null };
 
-function observeSubMenuVisibilityDesktop(item, subMenu, overlay) {
-
-    if (!("IntersectionObserver" in window)) return;
-
-    if (desktopSubMenuObserver) {
-        desktopSubMenuObserver.disconnect();
-    }
-
-    desktopSubMenuObserver = new IntersectionObserver(([entry]) => {
-        if (!entry.isIntersecting) {
-            closeSubMenuDesktop(item, subMenu, overlay);
-        }
-    },
-        {
-            root: null,
-            threshold: 0
-        }
-
-    );
-    desktopSubMenuObserver.observe(subMenu);
-}
-
-let mobileSubMenuObserver = null;
-function observeSubMenuVisibilityMobile(menu) {
+function observeSubMenuVisibility(type, element, onExit) {
 
     if (!("IntersectionObserver" in window)) return;
 
-    if (mobileSubMenuObserver) {
-        mobileSubMenuObserver.disconnect();
+    if (subMenuObservers[type]) {
+        subMenuObservers[type].disconnect();
     }
 
-    mobileSubMenuObserver = new IntersectionObserver(([entry]) => {
+    subMenuObservers[type] = new IntersectionObserver(([entry]) => {
         if (!entry.isIntersecting) {
-            closeMobileMenu()
-        }
-    },
-        {
-            root: null,
-            threshold: 0
-        }
 
-    );
-    mobileSubMenuObserver.observe(menu);
+            if (type === 'mobile') {
+               
+                const mobileIsOpen = document.querySelector(".tpr-header-menu__nav-container--active") !== null;
+                if (!mobileIsOpen) return;
+            }
+
+            try {
+                subMenuObservers[type]?.disconnect();
+                subMenuObservers[type] = null;
+                onExit()
+            } catch (err) {
+                
+                console.error(err);
+            }
+        }
+    }, {
+        root: null,
+        threshold: 0
+    });
+
+    subMenuObservers[type].observe(element);
 }
 
 function closeSubMenuDesktop(item, subMenu, overlay) {
@@ -207,11 +195,6 @@ function closeSubMenuDesktop(item, subMenu, overlay) {
     item.setAttribute("aria-expanded", "false");
     item.classList.remove("tpr-header-menu__arrow-up");
     overlay?.classList.remove("tpr-header-menu__nav-overlay--visible");
-
-    if (desktopSubMenuObserver) {
-        desktopSubMenuObserver.disconnect();
-        desktopSubMenuObserver = null;
-    }
 }
 
 function openSubMenuDesktop(item, subMenu, overlay) {
@@ -221,7 +204,7 @@ function openSubMenuDesktop(item, subMenu, overlay) {
     subMenu.querySelector(".tpr-header-menu__nav-sub-menu-item").removeAttribute("style");
     overlay?.classList.add("tpr-header-menu__nav-overlay--visible");
 
-    observeSubMenuVisibilityDesktop(item, subMenu, overlay);
+    observeSubMenuVisibility('desktop', subMenu, () => closeSubMenuDesktop(item, subMenu, overlay));
 }
 
 function keyboardToggleMobileMenu(e) {
@@ -410,30 +393,41 @@ function closeMobileMenu() {
     });
 
 }
-function toggleMobileMenu() {
 
+function openMobileMenu() {
     const toggle = document.querySelector(".tpr-header-menu__button");
-    toggle.classList.toggle("tpr-header-menu__button--open");
+    if (!toggle) return;
+    if (toggle.classList.contains("tpr-header-menu__button--open")) return;
+
+    toggle.classList.add("tpr-header-menu__button--open");
 
     const svgs = document.querySelectorAll(".tpr-mobile-menu__svg");
-    svgs.forEach(s => s.classList.toggle("tpr-mobile-menu__svg--hide"));
+    svgs.forEach(s => s.classList.add("tpr-mobile-menu__svg--hide"));
 
     const button = document.querySelector(".tpr-header-menu__button-inner");
     if (button) {
-        const closeButtonText = button.getAttribute("data-close-label");
-        const openButtonText = button.getAttribute("data-open-label")
-        const isMenu = button.textContent === closeButtonText;
-        button.textContent = isMenu ? openButtonText : closeButtonText;
-        button.classList.toggle("tpr-header-menu__button-inner--opened")
+        const openButtonText = button.getAttribute("data-open-label");
+        button.textContent = openButtonText;
+        button.classList.add("tpr-header-menu__button-inner--opened")
 
-        const expanded = toggle.getAttribute("aria-expanded") === "true";
-        toggle.setAttribute("aria-expanded", !expanded);
+        toggle.setAttribute("aria-expanded", true);
     }
 
     document.querySelectorAll(".tpr-header-menu__nav-container").forEach((nav) => {
-        nav.classList.toggle("tpr-header-menu__nav-container--active");
-        observeSubMenuVisibilityMobile(nav)
+        nav.classList.add("tpr-header-menu__nav-container--active");
+        observeSubMenuVisibility('mobile', nav, closeMobileMenu)
     });
+}
+
+function toggleMobileMenu() {
+    const toggle = document.querySelector(".tpr-header-menu__button");
+    if (!toggle) return;
+    const expanded = toggle.getAttribute("aria-expanded") === "true";
+    if (expanded) {
+        closeMobileMenu();
+    } else {
+        openMobileMenu();
+    }
 }
 
 function expandMobileMenuSubMenu(e) {

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/headermenu.js
@@ -386,10 +386,17 @@ function closeMobileMenu() {
 
     document.querySelectorAll(".tpr-header-menu__nav-container").forEach((nav) => {
         nav.classList.remove("tpr-header-menu__nav-container--active");
-        const arrow = nav.querySelector(".tpr-header-menu__arrow");
-        arrow.classList.remove("tpr-header-menu__arrow-down");
-        arrow.setAttribute("aria-expanded", false);
-        const subMenu = nav.querySelector(".tpr-header-menu__nav-sub-menu").classList.remove("tpr-header-menu__nav-sub-menu--active")
+
+        nav.querySelectorAll(".tpr-header-menu__arrow").forEach(arrow => {
+            arrow.classList.remove("tpr-header-menu__arrow-down");
+            arrow.classList.add("tpr-header-menu__arrow-right");
+            arrow.setAttribute("aria-expanded", "false");
+        });
+
+        nav.querySelectorAll(".tpr-header-menu__nav-sub-menu").forEach(subMenu => {
+            subMenu.classList.remove("tpr-header-menu__nav-sub-menu--active");
+        });
+
     });
 
 }


### PR DESCRIPTION
Why:

- Raised in [ #AB260858](https://dev.azure.com/thepensionsregulator/TPR/_boards/board/t/Web%20Platform%20Team/Stories?System.Tags=Corp%20Web%20Accessibility%2CCorp%20Website%20Migration&workitem=260858) that the darkened background used as part of the mobile menu still remains an issue of users who use VoiceOver (iPad/iPhone) and TalkBack (Android), users navigating with swipe gestures can move outside the menu while the rest of the page remains darkened, reducing colour contrast and readability.

In this PR:

- Extended `IntersectionObserver` functionality to support use with mobile menu - ensuring when a user scrolls out of view of the mobile menu, overlay is removed and menu is closed. 