### PR TITLE
#252204 - minor fixes for iframes

### DIFF
--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-youtube-video.ts
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/src/blocks/views/tpr-youtube-video.ts
@@ -71,15 +71,16 @@ export class TprYouTubeVideoView extends UmbElementMixin(LitElement) implements 
 
     override render() {
         const parseUrlResult = this.#tryParseVideoUrl(this.content?.url);
+        const headingAndIframeTitle = this.content?.title ? `${this.content.title} (video)` : '(video)';
 
         return html`
         <link rel="stylesheet" href="/css/govuk-umbraco-backoffice.css?v=${PACKAGE_VERSION}" />
         <a href="${this.config?.editContentPath ?? ''}" class="backoffice-block-view">
             <div class="tpr-video-wrapper-no-cookies ${this.settings?.cssClasses}">
-                ${this.#renderHeading(this.content?.title, this.settings?.headingClass?.[0], this.settings?.headingLevel?.[0])}
+                ${this.#renderHeading(this.content?.title ? headingAndIframeTitle : undefined, this.settings?.headingClass?.[0], this.settings?.headingLevel?.[0])}
                 ${this.content?.description?.markup ? html`<div class="govuk-body tpr-video-wrapper-no-cookies__description">${unsafeHTML(disableLinks(this.content?.description?.markup))}</div>` : null}
                 <div class="tpr-video-wrapper-no-cookies__video-container">
-                    <iframe referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube-nocookie.com/embed/${parseUrlResult.videoId}" title="${this.content?.title ? `${this.content.title} (video)` : '(video)'}"></iframe>
+                    <iframe referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube-nocookie.com/embed/${parseUrlResult.videoId}" title="${headingAndIframeTitle}"></iframe>
                 </div>
                 ${this.content?.transcriptUrl?.length ? html`<div class="tpr-video-wrapper-no-cookies__transcript-container"><span class="tpr-video-wrapper-no-cookies__transcript-link">${this.content?.transcriptUrl?.[0]?.name || (this.content?.title ? `View transcript for '${this.content.title}'` : 'View transcript for video')}</span></div>` : null}
              </div>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRYouTubeVideo.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRYouTubeVideo.cshtml
@@ -37,7 +37,7 @@
     }
     string id = Model.Content.Key.ToString();
     var title = Model.Content.Value<string>(TprPropertyAliases.VideoTitle) ?? string.Empty;
-    var cssClasses = Model.Settings.Value<string?>(PropertyAliases.CssClasses);
+    var cssClasses = Model.Settings?.Value<string?>(PropertyAliases.CssClasses);
     var transcriptLink = Model.Content.Value<Link>(TprPropertyAliases.VideoTranscriptUrl);
     var transcriptUrl = string.Empty;
     var transcriptTarget = string.Empty;
@@ -61,11 +61,11 @@
     }
     transcriptTitle = transcriptTitle.Replace("{{title}}", title);
 
-    var autoplay = Model.Settings.Value<bool?>(TprPropertyAliases.VideoAutoplay) ?? false;
-    bool playsInline = Model.Settings.Value<bool?>(TprPropertyAliases.VideoPlaysInline) ?? true;
+    var autoplay = Model.Settings?.Value<bool?>(TprPropertyAliases.VideoAutoplay) ?? false;
+    bool playsInline = Model.Settings?.Value<bool?>(TprPropertyAliases.VideoPlaysInline) ?? true;
     var description = Model.Content.Value<string?>(TprPropertyAliases.VideoDescription) ?? string.Empty;
 
-    var headingLevelProperty = Model.Settings.Value<string>(TprPropertyAliases.VideoHeadingLevel) ?? string.Empty;
+    var headingLevelProperty = Model.Settings?.Value<string>(TprPropertyAliases.VideoHeadingLevel) ?? string.Empty;
     var headingLevelNumber = headingLevelProperty.Replace("heading ", string.Empty, StringComparison.OrdinalIgnoreCase).Trim();
     if (!int.TryParse(headingLevelNumber, out int numericHeadingLevel) || numericHeadingLevel < 2 || numericHeadingLevel > 5)
     {
@@ -73,7 +73,7 @@
     }
 
     var headingClasses = headingClassProvider.HeadingClasses(Umbraco.AssignedContentItem);
-    var headingClass = Model.Settings.Value<string>(TprPropertyAliases.VideoHeadingSize);
+    var headingClass = Model.Settings?.Value<string>(TprPropertyAliases.VideoHeadingSize);
     if (string.IsNullOrWhiteSpace(headingClass))
     {
         headingClass = numericHeadingLevel switch


### PR DESCRIPTION
This PR follows up with some outstanding requested changes from a [previous PR](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/pull/668).

PR includes minor improvements to the handling of optional settings and the consistency of video title usage in both the TypeScript and Razor components for the YouTube video block. The changes ensure safer access to settings and improve the clarity of the video title used for headings and iframe titles.

Enhancements to handling settings and video titles:

* Made all accesses to `Model.Settings` properties in `TPRYouTubeVideo.cshtml` null-safe, preventing potential errors if `Settings` is not present. [[1]](diffhunk://#diff-552f0d99b6776d3592ca3665472adf8444c5b3d1f2fdb9396d39999db354b318L40-R40) [[2]](diffhunk://#diff-552f0d99b6776d3592ca3665472adf8444c5b3d1f2fdb9396d39999db354b318L64-R76)
* In `tpr-youtube-video.ts`, standardized the logic for generating the video heading and iframe title by introducing a `headingAndIframeTitle` variable, ensuring consistent and descriptive titles for improved accessibility.