### PR TITLE
#268154 Download table data button is duplicated in the html table component (v13)

### DIFF
--- a/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
@@ -298,7 +298,7 @@ describe("initTableCsvDownload", () => {
     });
 
     it("should create only one button on tables with an exsisting hardcoded button", () => {
-    document.body.innerHTML = `${createTable()} <form action="/example" name="tableHtml"><button class="govuk-button">Existing Button</button></form>`
+        document.body.innerHTML = `${createTable()} <form action="/example" class="tpr-table-download-form"><input type="hidden"><input type="hidden"><input type="hidden"><button class="govuk-button">Existing Button</button></form>`
     initTableCsvDownload();
     const buttons = document.querySelectorAll(
         'button'

--- a/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
@@ -201,99 +201,110 @@ describe("sanitizeFileName", () => {
 });
 
 describe("initTableCsvDownload", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-    delete document.body.dataset.tprTableCsvDownloadText;
-  });
+    afterEach(() => {
+        document.body.innerHTML = "";
+        delete document.body.dataset.tprTableCsvDownloadText;
+    });
 
-  it("should add a download button after each .govuk-table", () => {
-    document.body.innerHTML = createTable();
-    initTableCsvDownload();
-    const button = document.querySelector(
-      'button[data-tpr-table-csv-button="true"]'
-    );
-    expect(button).not.toBeNull();
-    expect(button.textContent).toBe(DEFAULT_BUTTON_TEXT);
-    expect(button.className).toBe("govuk-button govuk-button--secondary");
-  });
+    it("should add a download button after each .govuk-table", () => {
+        document.body.innerHTML = createTable();
+        initTableCsvDownload();
+        const button = document.querySelector(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(button).not.toBeNull();
+        expect(button.textContent).toBe(DEFAULT_BUTTON_TEXT);
+        expect(button.className).toBe("govuk-button govuk-button--secondary");
+    });
 
-  it("should not add a button to non-.govuk-table tables", () => {
-    document.body.innerHTML = createTable({ className: "other-table" });
-    initTableCsvDownload();
-    const button = document.querySelector(
-      'button[data-tpr-table-csv-button="true"]'
-    );
-    expect(button).toBeNull();
-  });
+    it("should not add a button to non-.govuk-table tables", () => {
+        document.body.innerHTML = createTable({ className: "other-table" });
+        initTableCsvDownload();
+        const button = document.querySelector(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(button).toBeNull();
+    });
 
-  it("should not add a button to tables with merged cells", () => {
-    document.body.innerHTML = createTable({ mergedCells: true });
-    initTableCsvDownload();
-    const button = document.querySelector(
-      'button[data-tpr-table-csv-button="true"]'
-    );
-    expect(button).toBeNull();
-  });
+    it("should not add a button to tables with merged cells", () => {
+        document.body.innerHTML = createTable({ mergedCells: true });
+        initTableCsvDownload();
+        const button = document.querySelector(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(button).toBeNull();
+    });
 
-  it("should not create duplicate buttons when called twice", () => {
-    document.body.innerHTML = createTable();
-    initTableCsvDownload();
+    it("should not create duplicate buttons when called twice", () => {
+        document.body.innerHTML = createTable();
+        initTableCsvDownload();
+        initTableCsvDownload();
+        const buttons = document.querySelectorAll(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(buttons.length).toBe(1);
+    });
+
+    it("should use custom button text from data attribute", () => {
+        document.body.dataset.tprTableCsvDownloadText = "Custom text";
+        document.body.innerHTML = createTable();
+        initTableCsvDownload();
+        const button = document.querySelector(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(button.textContent).toBe("Custom text");
+    });
+
+    it("should handle multiple tables on the page", () => {
+        document.body.innerHTML = createTable({ caption: "Table 1" }) +
+            createTable({ caption: "Table 2" });
+        initTableCsvDownload();
+        const buttons = document.querySelectorAll(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(buttons.length).toBe(2);
+    });
+
+    it("should place the button immediately after the table", () => {
+        document.body.innerHTML = `<div>${createTable()}</div>`;
+        initTableCsvDownload();
+        const table = document.querySelector(".govuk-table");
+        const button = table.nextElementSibling;
+        expect(button).not.toBeNull();
+        expect(button.hasAttribute("data-tpr-table-csv-button")).toBe(true);
+    });
+
+    it("should derive the file name from the table caption", () => {
+        document.body.innerHTML = createTable({ caption: "My Report 2024" });
+        initTableCsvDownload();
+        const button = document.querySelector(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(button).not.toBeNull();
+        expect(button.getAttribute("data-tpr-table-csv-filename")).toBe(
+            "my-report-2024"
+        );
+    });
+
+    it("should skip tables with merged cells but still process simple tables", () => {
+        document.body.innerHTML =
+            createTable({ mergedCells: true, caption: "Merged" }) +
+            createTable({ caption: "Simple" });
+        initTableCsvDownload();
+        const buttons = document.querySelectorAll(
+            'button[data-tpr-table-csv-button="true"]'
+        );
+        expect(buttons.length).toBe(1);
+    });
+
+    it("should create only one button on tables with an exsisting hardcoded button", () => {
+    document.body.innerHTML = `${createTable()} <form action="/example" name="tableHtml"><button class="govuk-button">Existing Button</button></form>`
     initTableCsvDownload();
     const buttons = document.querySelectorAll(
-      'button[data-tpr-table-csv-button="true"]'
+        'button'
     );
     expect(buttons.length).toBe(1);
-  });
-
-  it("should use custom button text from data attribute", () => {
-    document.body.dataset.tprTableCsvDownloadText = "Custom text";
-    document.body.innerHTML = createTable();
-    initTableCsvDownload();
-    const button = document.querySelector(
-      'button[data-tpr-table-csv-button="true"]'
-    );
-    expect(button.textContent).toBe("Custom text");
-  });
-
-  it("should handle multiple tables on the page", () => {
-    document.body.innerHTML = createTable({ caption: "Table 1" }) +
-      createTable({ caption: "Table 2" });
-    initTableCsvDownload();
-    const buttons = document.querySelectorAll(
-      'button[data-tpr-table-csv-button="true"]'
-    );
-    expect(buttons.length).toBe(2);
-  });
-
-  it("should place the button immediately after the table", () => {
-    document.body.innerHTML = `<div>${createTable()}</div>`;
-    initTableCsvDownload();
-    const table = document.querySelector(".govuk-table");
-    const button = table.nextElementSibling;
-    expect(button).not.toBeNull();
-    expect(button.hasAttribute("data-tpr-table-csv-button")).toBe(true);
-  });
-
-  it("should derive the file name from the table caption", () => {
-    document.body.innerHTML = createTable({ caption: "My Report 2024" });
-    initTableCsvDownload();
-    const button = document.querySelector(
-      'button[data-tpr-table-csv-button="true"]'
-    );
-    expect(button).not.toBeNull();
-    expect(button.getAttribute("data-tpr-table-csv-filename")).toBe(
-      "my-report-2024"
-    );
-  });
-
-  it("should skip tables with merged cells but still process simple tables", () => {
-    document.body.innerHTML =
-      createTable({ mergedCells: true, caption: "Merged" }) +
-      createTable({ caption: "Simple" });
-    initTableCsvDownload();
-    const buttons = document.querySelectorAll(
-      'button[data-tpr-table-csv-button="true"]'
-    );
-    expect(buttons.length).toBe(1);
-  });
 });
+});
+
+

--- a/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
@@ -297,7 +297,7 @@ describe("initTableCsvDownload", () => {
         expect(buttons.length).toBe(1);
     });
 
-    it("should create only one button on tables with an exsisting hardcoded button", () => {
+    it("should not create a button on tables with an exsisting hardcoded button", () => {
         document.body.innerHTML = `${createTable()} <form action="/example" class="tpr-table-download-form"><input type="hidden"><input type="hidden"><input type="hidden"><button class="govuk-button">Existing Button</button></form>`
     initTableCsvDownload();
     const buttons = document.querySelectorAll(

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-table-csv-download.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-table-csv-download.js
@@ -106,7 +106,7 @@ function initTableCsvDownload() {
       // Skip if a CSV download button has already been added (idempotency)
     if (
       nextElement &&
-        nextElement.hasAttribute("data-tpr-table-csv-button") || nextElement && nextElement.matches('form[name="tableHtml"]') && nextElement.querySelector("button")
+        nextElement.hasAttribute("data-tpr-table-csv-button") || nextElement && nextElement.matches('form[class="tpr-table-download-form"]') && nextElement.querySelector("button")
     ) {
       continue;
     }

--- a/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-table-csv-download.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/tpr/tpr-table-csv-download.js
@@ -92,20 +92,21 @@ function downloadCsv(csvContent, fileName) {
 
 function initTableCsvDownload() {
   const buttonText = getButtonText();
-  const tables = document.querySelectorAll(".govuk-table");
+    const tables = document.querySelectorAll(".govuk-table");
 
   for (let i = 0; i < tables.length; i++) {
     const table = tables[i];
+      const nextElement = table.nextElementSibling;
 
     // Skip tables with merged cells — CSV cannot represent them reliably
     if (hasMergedCells(table)) {
       continue;
     }
 
-    // Skip if a CSV download button has already been added (idempotency)
+      // Skip if a CSV download button has already been added (idempotency)
     if (
-      table.nextElementSibling &&
-      table.nextElementSibling.hasAttribute("data-tpr-table-csv-button")
+      nextElement &&
+        nextElement.hasAttribute("data-tpr-table-csv-button") || nextElement && nextElement.matches('form[name="tableHtml"]') && nextElement.querySelector("button")
     ) {
       continue;
     }


### PR DESCRIPTION
Why:

- When a content editor would use the TPR table component within a page an additional download button would be provided.

In this PR:

- Ensure that tables that already have a download button provided do not receive a duplicate. 