### PR TITLE
#268154 Download table data button is duplicated in the html table component (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
@@ -229,6 +229,25 @@ describe("initTableCsvDownload", () => {
         expect(buttons.length).toBe(1);
     });
 
+    test("should not create a button on tables with an exsisting hardcoded button", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table">
+                 <thead><tr><th>Name</th><th>Age</th></tr></thead>
+                 <tbody><tr><td>Alice</td><td>30</td></tr></tbody>
+            </table> 
+            <form action="/example" class="tpr-table-download-form">
+                <input type="hidden">
+                 <input type="hidden">
+                 <input type="hidden">
+                 <button class="govuk-button">Existing Button</button>
+            </form>`
+        initTableCsvDownload();
+        const buttons = document.querySelectorAll(
+            'button'
+        );
+        expect(buttons.length).toBe(1);
+    });
+
     test("uses custom button text from body data attribute", () => {
         document.body.setAttribute("data-tpr-table-csv-download-text", "Lawrlwytho data tabl (CSV)");
         document.body.innerHTML = `

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
@@ -115,14 +115,15 @@ export function initTableCsvDownload() {
 
     for (let i = 0; i < tables.length; i++) {
         const table = tables[i];
+        const nextElement = table.nextElementSibling;
 
         // Skip tables with merged cells — CSV cannot represent them reliably
         if (hasMergedCells(table)) continue;
 
         // Skip if a CSV download button has already been added (idempotency)
         if (
-            table.nextElementSibling &&
-            table.nextElementSibling.hasAttribute("data-tpr-table-csv-button")
+            nextElement &&
+            nextElement.hasAttribute("data-tpr-table-csv-button") || nextElement && nextElement.matches('form[class="tpr-table-download-form"]') && nextElement.querySelector("button")
         ) {
             continue;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1905,9 +1905,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5169,9 +5169,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Why:

- When a content editor would use the TPR table component within a page an additional download button would be provided.

In this PR:

- Ensure that tables that already have a download button provided do not receive a duplicate.