### PR TITLE
ReTest - Timeline headings lack hierarchy and clear context (M) (v13)

### DIFF
--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
@@ -73,8 +73,8 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
         private static TagBuilder BuildDateTime(TprTimelineItem item)
         {
-            var timelineItemDateTime = new TagBuilder("p");
-            timelineItemDateTime.MergeCssClass("tpr-timeline__datetime");
+            var timelineItemDateTime = new TagBuilder("h3");
+            timelineItemDateTime.AddCssClass("tpr-timeline__datetime");
             timelineItemDateTime.InnerHtml.AppendHtml(item.DateTime!.ToString());
             return timelineItemDateTime;
         }
@@ -82,7 +82,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         private static TagBuilder BuildHeading(TprTimelineItem item, int headingLevel)
         {
             var timelineItemHeading = new TagBuilder($"h{headingLevel}");
-            timelineItemHeading.MergeCssClass("tpr-timeline__heading");
+            timelineItemHeading.AddCssClass("tpr-timeline__heading");
             timelineItemHeading.InnerHtml.AppendHtml(item.Heading!.ToString());
             return timelineItemHeading;
         }


### PR DESCRIPTION
Why:

- The heading structure does not follow a proper hierarchy. The main timeline heading is marked as level 2, but all subsequent timeline items are also marked as level 2 instead of being nested correctly.

In this PR;

- Updated TPR Timeline to have H3 headings instead of P headings for accessibility