### PR TITLE
ReTest - Timeline headings lack hierarchy and clear context (M) (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprTimeline.cs
@@ -67,7 +67,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
         private static TagBuilder BuildDateTime(TprTimelineItem item)
         {
-            var timelineItemDateTime = new TagBuilder("p");
+            var timelineItemDateTime = new TagBuilder("h3");
             timelineItemDateTime.AddCssClass("tpr-timeline__datetime");
             timelineItemDateTime.InnerHtml.AppendHtml(item.DateTime!.ToString());
             return timelineItemDateTime;


### PR DESCRIPTION
Why:

- The heading structure does not follow a proper hierarchy. The main timeline heading is marked as level 2, but all subsequent timeline items are also marked as level 2 instead of being nested correctly.

In this PR;

- Updated TPR Timeline to have H3 headings instead of P headings for accessibility