### PR TITLE
Support more variants of .Value() extension method (v13)

### DIFF
--- a/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoPublishedElementExtensionsTests.cs
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoPublishedElementExtensionsTests.cs
@@ -11,33 +11,88 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
     {
         private const string PAGE_ALIAS = "myPage";
         private const string PROPERTY_ALIAS = "myProperty";
+        private UmbracoTestContext _testContext = new();
 
-        public UmbracoPublishedElementExtensionsTests()
-        {
-            _ = new UmbracoTestContext(); // Sets up DI
-        }
-
-        private static void TestSetupUmbracoTypedPropertyValue<T>(Func<T> createPropertyValue, Action<IPublishedContent, string, T> act, string expectedPropertyEditorAlias)
+        private void TestSetupUmbracoTypedPropertyValue<TContentType, TValue>(Func<TValue> createPropertyValue, Action<TContentType, string, TValue> act, string expectedPropertyEditorAlias)
+            where TContentType : class, IPublishedElement
         {
             // Arrange
-            var targetElement = UmbracoContentFactory.CreateContent<IPublishedContent>(PAGE_ALIAS);
-            T propertyValue = createPropertyValue();
+            var targetElement = UmbracoContentFactory.CreateContent<TContentType>(PAGE_ALIAS);
+            TValue propertyValue = createPropertyValue();
 
             // Act
             act(targetElement.Object, PROPERTY_ALIAS, propertyValue);
 
             // Assert
-            Assert.Equal(propertyValue, targetElement.Object.Value<T>(PROPERTY_ALIAS));
             Assert.NotNull(targetElement.Object.Properties.SingleOrDefault(x => x.Alias == PROPERTY_ALIAS)); // returns PublishedElementPropertyBase
             Assert.Equal(propertyValue, targetElement.Object.GetProperty(PROPERTY_ALIAS)?.GetValue());
             Assert.Equal(expectedPropertyEditorAlias, targetElement.Object.GetProperty(PROPERTY_ALIAS)?.PropertyType?.EditorAlias);
+
+            // Assert value via Umbraco's IPublishedElement extension methods (even when TContentType is IOverridablePublishedElement, because C# uses the method constraint IPublishedElement instead)
+            Assert.Equal(propertyValue, targetElement.Object.Value<TValue>(PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement.Object.Value<TValue>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+
+            // Assert value via IOverridablePublishedElement extension methods (direct call, not extension method, as C# would use the method constraint IPublishedElement instead)
+            if (targetElement.Object is IOverridablePublishedElement overridable)
+            {
+                Assert.Equal(propertyValue, overridable.Value<TValue>(PROPERTY_ALIAS));
+                Assert.Equal(propertyValue, overridable.Value<TValue>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+            }
+        }
+
+        // Overload that additionally asserts via TNullableValue, which must be supplied as a concrete type argument (e.g. int?) so it
+        // produces a genuine Nullable<T> generic instantiation at the IL level rather than the annotation-only TValue? inside a generic method.
+        private void TestSetupUmbracoTypedPropertyValue<TContentType, TValue, TNullableValue>(Func<TValue> createPropertyValue, Action<TContentType, string, TValue> act, string expectedPropertyEditorAlias)
+            where TContentType : class, IPublishedElement
+        {
+            TestSetupUmbracoTypedPropertyValue(createPropertyValue, act, expectedPropertyEditorAlias);
+
+            // Arrange
+            var targetElement = UmbracoContentFactory.CreateContent<TContentType>(PAGE_ALIAS);
+            TValue propertyValue = createPropertyValue();
+
+            // Act
+            act(targetElement.Object, PROPERTY_ALIAS, propertyValue);
+
+            // Assert value via Umbraco's IPublishedElement extension methods (covers IPublishedContent and the extension-method path for IOverridablePublishedElement)
+            Assert.Equal((object?)propertyValue, (object?)targetElement.Object.Value<TNullableValue>(PROPERTY_ALIAS)); // cast to object forces compiler to use Assert.Equal(object?, object?) overload
+            Assert.Equal((object?)propertyValue, (object?)targetElement.Object.Value<TNullableValue>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+
+            // Assert value via IOverridablePublishedElement direct methods (direct call, not extension method, as C# would use the method constraint IPublishedElement instead)
+            if (targetElement.Object is IOverridablePublishedElement overridable)
+            {
+                Assert.Equal((object?)propertyValue, (object?)overridable.Value<TNullableValue>(PROPERTY_ALIAS)); // cast to object forces compiler to use Assert.Equal(object?, object?) overload
+                Assert.Equal((object?)propertyValue, (object?)overridable.Value<TNullableValue>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+            }
         }
 
         [Fact]
         public void SetupUmbracoBlockGridPropertyValue_works()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set BlockGridModel, read BlockGridModel (reference type, so BlockGridModel is the same IL type as BlockGridModel?)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, BlockGridModel>(
                 () => new BlockGridModel(Array.Empty<BlockGridItem>(), 1),
+                (target, alias, value) => target.SetupUmbracoBlockGridPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.BlockGrid
+            );
+
+            // IOverridablePublishedElement: set BlockGridModel, read BlockGridModel
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, BlockGridModel>(
+                () => new BlockGridModel(Array.Empty<BlockGridItem>(), 1),
+                (target, alias, value) => target.SetupUmbracoBlockGridPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.BlockGrid
+            );
+
+            // IPublishedContent: set BlockGridModel?, read BlockGridModel? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, BlockGridModel?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoBlockGridPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.BlockGrid
+            );
+
+            // IOverridablePublishedElement: set BlockGridModel?, read BlockGridModel? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, BlockGridModel?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoBlockGridPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.BlockGrid
             );
@@ -46,8 +101,30 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void SetupUmbracoBlockListPropertyValue_works()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set BlockListModel, read BlockListModel (reference type, so BlockListModel is the same IL type as BlockListModel?)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, BlockListModel>(
                 () => new BlockListModel(Array.Empty<BlockListItem>()),
+                (target, alias, value) => target.SetupUmbracoBlockListPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.BlockList
+            );
+
+            // IOverridablePublishedElement: set BlockListModel, read BlockListModel
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, BlockListModel>(
+                () => new BlockListModel(Array.Empty<BlockListItem>()),
+                (target, alias, value) => target.SetupUmbracoBlockListPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.BlockList
+            );
+
+            // IPublishedContent: set BlockListModel?, read BlockListModel? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, BlockListModel?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoBlockListPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.BlockList
+            );
+
+            // IOverridablePublishedElement: set BlockListModel?, read BlockListModel? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, BlockListModel?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoBlockListPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.BlockList
             );
@@ -56,8 +133,44 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void SetupUmbracoBooleanPropertyValue_works()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set bool, read bool and bool?
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, bool, bool?>(
                 () => true,
+                (target, alias, value) => target.SetupUmbracoBooleanPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Boolean
+            );
+
+            // IPublishedContent: set bool?, read bool? and bool (non-null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, bool?, bool>(
+                () => true,
+                (target, alias, value) => target.SetupUmbracoBooleanPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Boolean
+            );
+
+            // IPublishedContent: set bool?, read bool? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, bool?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoBooleanPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Boolean
+            );
+
+            // IOverridablePublishedElement: set bool, read bool and bool?
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, bool, bool?>(
+                () => true,
+                (target, alias, value) => target.SetupUmbracoBooleanPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Boolean
+            );
+
+            // IOverridablePublishedElement: set bool?, read bool? and bool (non-null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, bool?, bool>(
+                () => true,
+                (target, alias, value) => target.SetupUmbracoBooleanPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Boolean
+            );
+
+            // IOverridablePublishedElement: set bool?, read bool? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, bool?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoBooleanPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.Boolean
             );
@@ -66,8 +179,30 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void SetupUmbracoContentPickerPropertyValue_works()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set IPublishedContent, read IPublishedContent (reference type, so IPublishedContent is the same IL type as IPublishedContent?)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, IPublishedContent>(
                 () => UmbracoContentFactory.CreateContent<IPublishedContent>("pickedContentAlias").Object,
+                (target, alias, value) => target.SetupUmbracoContentPickerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.ContentPicker
+            );
+
+            // IOverridablePublishedElement: set IPublishedContent, read IPublishedContent
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, IPublishedContent>(
+                () => UmbracoContentFactory.CreateContent<IPublishedContent>("pickedContentAlias").Object,
+                (target, alias, value) => target.SetupUmbracoContentPickerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.ContentPicker
+            );
+
+            // IPublishedContent: set IPublishedContent?, read IPublishedContent? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, IPublishedContent?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoContentPickerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.ContentPicker
+            );
+
+            // IOverridablePublishedElement: set IPublishedContent?, read IPublishedContent? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, IPublishedContent?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoContentPickerPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.ContentPicker
             );
@@ -76,8 +211,44 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void SetupUmbracoIntegerPropertyValue_works()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set int, read int and int?
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, int, int?>(
                 () => 5,
+                (target, alias, value) => target.SetupUmbracoIntegerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Integer
+            );
+
+            // IPublishedContent: set int?, read int? and int (non-null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, int?, int>(
+                () => 5,
+                (target, alias, value) => target.SetupUmbracoIntegerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Integer
+            );
+
+            // IPublishedContent: set int?, read int? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, int?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoIntegerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Integer
+            );
+
+            // IOverridablePublishedElement: set int, read int and int?
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, int, int?>(
+                () => 5,
+                (target, alias, value) => target.SetupUmbracoIntegerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Integer
+            );
+
+            // IOverridablePublishedElement: set int?, read int? and int (non-null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, int?, int>(
+                () => 5,
+                (target, alias, value) => target.SetupUmbracoIntegerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.Integer
+            );
+
+            // IOverridablePublishedElement: set int?, read int? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, int?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoIntegerPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.Integer
             );
@@ -86,8 +257,30 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void SetupUmbracoMultiUrlPickerPropertyValue_works()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set Link, read Link (reference type, so Link is the same IL type as Link?)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, Link>(
                 () => new Link { Name = "Example", Url = "https://example.org" },
+                (target, alias, value) => target.SetupUmbracoMultiUrlPickerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.MultiUrlPicker
+            );
+
+            // IOverridablePublishedElement: set Link, read Link
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, Link>(
+                () => new Link { Name = "Example", Url = "https://example.org" },
+                (target, alias, value) => target.SetupUmbracoMultiUrlPickerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.MultiUrlPicker
+            );
+
+            // IPublishedContent: set Link?, read Link? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, Link?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoMultiUrlPickerPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.MultiUrlPicker
+            );
+
+            // IOverridablePublishedElement: set Link?, read Link? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, Link?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoMultiUrlPickerPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.MultiUrlPicker
             );
@@ -96,8 +289,30 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void SetupUmbracoRichTextPropertyValue_works_with_HtmlEncodedString()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set HtmlEncodedString, read HtmlEncodedString (reference type, so HtmlEncodedString is the same IL type as HtmlEncodedString?)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, HtmlEncodedString>(
                 () => new HtmlEncodedString("<p>Some value</p>"),
+                (target, alias, value) => target.SetupUmbracoRichTextPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.TinyMce
+            );
+
+            // IOverridablePublishedElement: set HtmlEncodedString, read HtmlEncodedString
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, HtmlEncodedString>(
+                () => new HtmlEncodedString("<p>Some value</p>"),
+                (target, alias, value) => target.SetupUmbracoRichTextPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.TinyMce
+            );
+
+            // IPublishedContent: set HtmlEncodedString?, read HtmlEncodedString? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, HtmlEncodedString?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoRichTextPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.TinyMce
+            );
+
+            // IOverridablePublishedElement: set HtmlEncodedString?, read HtmlEncodedString? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, HtmlEncodedString?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoRichTextPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.TinyMce
             );
@@ -110,21 +325,67 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         public void SetupUmbracoRichTextPropertyValue_works_with_string()
         {
             // Arrange
-            var targetElement = UmbracoContentFactory.CreateContent<IPublishedContent>(PAGE_ALIAS);
+            var targetElement1 = UmbracoContentFactory.CreateContent<IPublishedContent>(PAGE_ALIAS);
+            var targetElement2 = UmbracoContentFactory.CreateContent<IOverridablePublishedElement>(PAGE_ALIAS);
+            var targetElement3 = UmbracoContentFactory.CreateContent<IPublishedContent>(PAGE_ALIAS);
+            var targetElement4 = UmbracoContentFactory.CreateContent<IOverridablePublishedElement>(PAGE_ALIAS);
             var propertyValue = "Some value";
 
             // Act
-            targetElement.Object.SetupUmbracoRichTextPropertyValue(PROPERTY_ALIAS, propertyValue);
+            targetElement1.Object.SetupUmbracoRichTextPropertyValue(PROPERTY_ALIAS, propertyValue);
+            targetElement2.Object.SetupUmbracoRichTextPropertyValue(PROPERTY_ALIAS, propertyValue);
+            targetElement3.Object.SetupUmbracoRichTextPropertyValue(PROPERTY_ALIAS, (string?)null);
+            targetElement4.Object.SetupUmbracoRichTextPropertyValue(PROPERTY_ALIAS, (string?)null);
 
             // Assert
-            Assert.Equal(propertyValue, targetElement.Object.Value<string>(PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement1.Object.Value<string>(PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement1.Object.Value<string>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement1.Object.Value<string?>(PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement1.Object.Value<string?>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+
+            Assert.Equal(propertyValue, targetElement2.Object.Value<string>(PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement2.Object.Value<string>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement2.Object.Value<string?>(PROPERTY_ALIAS));
+            Assert.Equal(propertyValue, targetElement2.Object.Value<string?>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+
+            Assert.Null(targetElement3.Object.Value<string>(PROPERTY_ALIAS));
+            Assert.Null(targetElement3.Object.Value<string>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+            Assert.Null(targetElement3.Object.Value<string?>(PROPERTY_ALIAS));
+            Assert.Null(targetElement3.Object.Value<string?>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+
+            Assert.Null(targetElement4.Object.Value<string>(PROPERTY_ALIAS));
+            Assert.Null(targetElement4.Object.Value<string>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
+            Assert.Null(targetElement4.Object.Value<string?>(PROPERTY_ALIAS));
+            Assert.Null(targetElement4.Object.Value<string?>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS));
         }
 
         [Fact]
         public void SetupUmbracoTextboxPropertyValue_works()
         {
-            TestSetupUmbracoTypedPropertyValue(
+            // IPublishedContent: set string, read string (reference type, so string is the same IL type as string?)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, string>(
                 () => "Some value",
+                (target, alias, value) => target.SetupUmbracoTextboxPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.TextBox
+            );
+
+            // IOverridablePublishedElement: set string, read string
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, string>(
+                () => "Some value",
+                (target, alias, value) => target.SetupUmbracoTextboxPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.TextBox
+            );
+
+            // IPublishedContent: set string?, read string? (null)
+            TestSetupUmbracoTypedPropertyValue<IPublishedContent, string?>(
+                () => null,
+                (target, alias, value) => target.SetupUmbracoTextboxPropertyValue(alias, value),
+                Constants.PropertyEditors.Aliases.TextBox
+            );
+
+            // IOverridablePublishedElement: set string?, read string? (null)
+            TestSetupUmbracoTypedPropertyValue<IOverridablePublishedElement, string?>(
+                () => null,
                 (target, alias, value) => target.SetupUmbracoTextboxPropertyValue(alias, value),
                 Constants.PropertyEditors.Aliases.TextBox
             );

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoContentFactory.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoContentFactory.cs
@@ -38,6 +38,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
         private static void SetupOverriddenValue<T>(string alias, T overriddenValue, Mock<IOverridablePublishedElement> overridablePublishedElement)
         {
             overridablePublishedElement.Setup(element => element.Value<T>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(overriddenValue);
+            overridablePublishedElement.Setup(element => element.Value<T>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(overriddenValue);
         }
     }
 }

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoPublishedElementExtensions.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoPublishedElementExtensions.cs
@@ -44,7 +44,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <returns>The <see cref="Mock&lt;IPublishedElement&gt;"/> this method was called on.</returns>
         public static Mock<TModel> SetupUmbracoPropertyValue<TModel, TProperty>(this Mock<TModel> publishedElement, string alias, TProperty value) where TModel : class, IPublishedElement
         {
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, (alias, value) => UmbracoPropertyFactory.CreateProperty(alias, null, value));
+            return SetupUmbracoReferenceTypePropertyValue(publishedElement, alias, value, (alias, value) => UmbracoPropertyFactory.CreateProperty(alias, null, value));
         }
 
         /// <summary>
@@ -71,10 +71,13 @@ namespace ThePensionsRegulator.Umbraco.Testing
             var overridablePublishedElement = publishedElement as Mock<IOverridablePublishedElement>;
             if (overridablePublishedElement != null)
             {
-                overridablePublishedElement.Setup(x => x.Value<string?>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value.ToString());
+                // Value<string?> is not set up separately because string is a reference type — string? and string are the same IL type,
+                // so Value<string> and Value<string?> resolve to the same generic instantiation and a single setup covers both.
+                overridablePublishedElement.Setup(x => x.Value<string>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value?.ToString());
+                overridablePublishedElement.Setup(x => x.Value<string>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value?.ToString());
             }
 
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateRichTextProperty);
+            return SetupUmbracoReferenceTypePropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateRichTextProperty);
         }
 
         /// <summary>
@@ -119,7 +122,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <returns>The <see cref="Mock&lt;IPublishedElement&gt;"/> this method was called on.</returns>
         public static Mock<T> SetupUmbracoTextboxPropertyValue<T>(this Mock<T> publishedElement, string alias, string? value) where T : class, IPublishedElement
         {
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateTextboxProperty);
+            return SetupUmbracoReferenceTypePropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateTextboxProperty);
         }
 
         /// <summary>
@@ -142,7 +145,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <returns>The <see cref="Mock&lt;IPublishedElement&gt;"/> this method was called on.</returns>
         public static Mock<T> SetupUmbracoIntegerPropertyValue<T>(this Mock<T> publishedElement, string alias, int? value) where T : class, IPublishedElement
         {
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateIntegerProperty);
+            return SetupUmbracoNullableValueTypePropertyValue<T, int>(publishedElement, alias, value, UmbracoPropertyFactory.CreateIntegerProperty);
         }
 
         /// <summary>
@@ -178,7 +181,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
 
         public static Mock<T> SetupUmbracoBooleanPropertyValue<T>(this Mock<T> publishedElement, string alias, bool? value) where T : class, IPublishedElement
         {
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateBooleanProperty);
+            return SetupUmbracoNullableValueTypePropertyValue<T, bool>(publishedElement, alias, value, UmbracoPropertyFactory.CreateBooleanProperty);
         }
 
         /// <summary>
@@ -190,7 +193,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
 
         public static Mock<T> SetupUmbracoBooleanPropertyValue<T>(this Mock<T> publishedElement, string alias, bool value) where T : class, IPublishedElement
         {
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateBooleanProperty);
+            return SetupUmbracoNullableValueTypePropertyValue<T, bool>(publishedElement, alias, value, UmbracoPropertyFactory.CreateBooleanProperty);
         }
 
         /// <summary>
@@ -213,7 +216,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <returns>The <see cref="Mock&lt;IPublishedElement&gt;"/> this method was called on.</returns>
         public static Mock<T> SetupUmbracoMultiUrlPickerPropertyValue<T>(this Mock<T> publishedElement, string alias, Link? value) where T : class, IPublishedElement
         {
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateMultiUrlPickerProperty);
+            return SetupUmbracoReferenceTypePropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateMultiUrlPickerProperty);
         }
 
         /// <summary>
@@ -236,7 +239,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <returns>The <see cref="Mock&lt;IPublishedElement&gt;"/> this method was called on.</returns>
         public static Mock<T> SetupUmbracoContentPickerPropertyValue<T>(this Mock<T> publishedElement, string alias, IPublishedContent? value) where T : class, IPublishedElement
         {
-            return SetupUmbracoPropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateContentPickerProperty);
+            return SetupUmbracoReferenceTypePropertyValue(publishedElement, alias, value, UmbracoPropertyFactory.CreateContentPickerProperty);
         }
 
         /// <summary>
@@ -267,12 +270,15 @@ namespace ThePensionsRegulator.Umbraco.Testing
             if (overridablePublishedElement != null)
             {
                 overridablePublishedElement.Setup(x => x.Value<TBlockList>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
+                overridablePublishedElement.Setup(x => x.Value<TBlockList>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
                 overridablePublishedElement.Setup(x => x.Value<IEnumerable<BlockListItem>>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
+                overridablePublishedElement.Setup(x => x.Value<IEnumerable<BlockListItem>>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
 
                 var readOnlyValue = value as ReadOnlyCollection<BlockListItem>;
                 if (readOnlyValue != null)
                 {
                     overridablePublishedElement.Setup(x => x.Value<ReadOnlyCollection<BlockListItem>>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(readOnlyValue);
+                    overridablePublishedElement.Setup(x => x.Value<ReadOnlyCollection<BlockListItem>>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(readOnlyValue);
                 }
             }
             return publishedElement;
@@ -306,25 +312,48 @@ namespace ThePensionsRegulator.Umbraco.Testing
             if (overridablePublishedElement != null)
             {
                 overridablePublishedElement.Setup(x => x.Value<TBlockGrid>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
+                overridablePublishedElement.Setup(x => x.Value<TBlockGrid>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
                 overridablePublishedElement.Setup(x => x.Value<IEnumerable<BlockGridItem>>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
+                overridablePublishedElement.Setup(x => x.Value<IEnumerable<BlockGridItem>>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(value);
 
                 var readOnlyValue = value as ReadOnlyCollection<BlockGridItem>;
                 if (readOnlyValue != null)
                 {
                     overridablePublishedElement.Setup(x => x.Value<ReadOnlyCollection<BlockGridItem>>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(readOnlyValue);
+                    overridablePublishedElement.Setup(x => x.Value<ReadOnlyCollection<BlockGridItem>>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, null)).Returns(readOnlyValue);
                 }
             }
             return publishedElement;
         }
 
-        private static Mock<TModel> SetupUmbracoPropertyValue<TModel, TProperty>(Mock<TModel> publishedElement, string alias, TProperty? value, Func<string, TProperty?, IPublishedProperty> createPropertyWithPropertyType)
+        private static Mock<TModel> SetupUmbracoReferenceTypePropertyValue<TModel, TProperty>(Mock<TModel> publishedElement, string alias, TProperty? value, Func<string, TProperty?, IPublishedProperty> createPropertyWithPropertyType)
             where TModel : class, IPublishedElement
         {
             publishedElement.SetupUmbracoProperty(createPropertyWithPropertyType(alias, value));
             var overridablePublishedElement = publishedElement as Mock<IOverridablePublishedElement>;
             if (overridablePublishedElement != null)
             {
+                overridablePublishedElement.Setup(x => x.Value<TProperty>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value);
+                overridablePublishedElement.Setup(x => x.Value<TProperty>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value);
+            }
+            return publishedElement;
+        }
+
+        /// <remarks>
+        /// where TProperty : struct makes this Nullable<TProperty> at the IL level, allowing both Value<TProperty> and Value<TProperty?> to be set up
+        /// </remarks>
+        private static Mock<TModel> SetupUmbracoNullableValueTypePropertyValue<TModel, TProperty>(Mock<TModel> publishedElement, string alias, TProperty? value, Func<string, TProperty?, IPublishedProperty> createProperty)
+            where TModel : class, IPublishedElement
+            where TProperty : struct
+        {
+            publishedElement.SetupUmbracoProperty(createProperty(alias, value));
+            var overridablePublishedElement = publishedElement as Mock<IOverridablePublishedElement>;
+            if (overridablePublishedElement != null)
+            {
+                overridablePublishedElement.Setup(x => x.Value<TProperty>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value.GetValueOrDefault());
+                overridablePublishedElement.Setup(x => x.Value<TProperty>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value.GetValueOrDefault());
                 overridablePublishedElement.Setup(x => x.Value<TProperty?>(It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value);
+                overridablePublishedElement.Setup(x => x.Value<TProperty?>(It.IsAny<IPublishedValueFallback>(), It.Is<string>(x => string.Equals(alias, x, StringComparison.OrdinalIgnoreCase)), null, null, default, default)).Returns(value);
             }
             return publishedElement;
         }

--- a/ThePensionsRegulator.Umbraco/IOverridablePublishedElement.cs
+++ b/ThePensionsRegulator.Umbraco/IOverridablePublishedElement.cs
@@ -9,5 +9,6 @@ namespace ThePensionsRegulator.Umbraco
     {
         void OverrideValue(string alias, object value);
         T? Value<T>(string alias, string? culture = null, string? segment = null, Fallback fallback = default, T? defaultValue = default);
+        T? Value<T>(IPublishedValueFallback publishedValueFallback, string alias, string? culture = null, string? segment = null, Fallback fallback = default, T? defaultValue = default);
     }
 }

--- a/ThePensionsRegulator.Umbraco/OverridablePublishedElement.cs
+++ b/ThePensionsRegulator.Umbraco/OverridablePublishedElement.cs
@@ -134,5 +134,34 @@ namespace ThePensionsRegulator.Umbraco
 
             return _publishedElement != null ? _publishedElement.Value(alias, culture, segment, fallback, defaultValue) : default;
         }
+
+        /// <summary>
+        /// Gets the value of a content's property identified by its alias, converted to a specified type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="publishedValueFallback">The published value fallback strategy.</param>
+        /// <param name="alias">The property alias.</param>
+        /// <param name="culture">The variation language.</param>
+        /// <param name="segment">The variation segment.</param>
+        /// <param name="fallback">Optional fallback strategy.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The value comes a value passed to <see cref="OverrideValue"/>, or from the <see cref="IPublishedProperty"/> field <c>Value</c> ie it is suitable for use when rendering content.
+        /// 
+        /// If no property with the specified alias exists, or if the property has no value, or if it could not be converted, returns <c>default(T)</c>.
+        /// 
+        /// The alias is case-insensitive.
+        /// </remarks>
+        public T? Value<T>(IPublishedValueFallback publishedValueFallback, string alias, string? culture = null, string? segment = null, Fallback fallback = default, T? defaultValue = default)
+        {
+            var key = alias.ToUpperInvariant();
+            if (_propertyValues.ContainsKey(key))
+            {
+                return (T)_propertyValues[key];
+            }
+
+            return _publishedElement != null ? _publishedElement.Value(publishedValueFallback, alias, culture, segment, fallback, defaultValue) : default;
+        }
     }
 }


### PR DESCRIPTION
We now prefer to call the overload of `.Value()` that takes `IPublishedValueFallback` because it avoids Umbraco's `StaticServiceProvider` and therefore avoids race conditions in unit testing.

#814 identified a gap in our mocking support for that overload, which this PR fixes for the v13 branch.

However, analysis of this and other flaky test results demonstrated more problems with this support. Some scenarios for value types (eg setting up a property as `int` and reading back the value as `int?`) were not supported.

This appeared to be covered by existing tests, but subtle C# behaviours meant it wasn't. 

The helper in the test class has a type constraint which means its generic parameter (was `T`, now `TContentType`) always resolves to `IPublishedElement` even when `IOverridablePublishedElement` is passed. This meant the tests were calling the built-in Umbraco method rather than our replacement for it that supports overriding values.

Testing `.Value<T>` and `.Value<T?>` together also turns out to be futile, since C# resolves both to the same type. One is tested twice and the other isn't tested. We now have extra helper methods to ensure both are supported and tested.

The test suite for `UmbracoPublishedElementExtensions` is now much more comprehensive. It tests all combinations of writing and reading nullable and non-nullable variants, for both `IPublishedContent` (properties set up on a page) and `IOverridablePublishedElement` (properties set up on a block). `UmbracoPublishedElementExtensions` itself has fixes for the bugs and omissions identified by these improved tests.