### PR TITLE
Pass IPublishedValueFallback to OverridableBlockListModel and OverridableBlockGridModel (v13)

### DIFF
--- a/GovUk.Frontend.Umbraco.Tests/Blocks/BlockViewServiceTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Blocks/BlockViewServiceTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using ThePensionsRegulator.Umbraco;
 using ThePensionsRegulator.Umbraco.Blocks;
 using ThePensionsRegulator.Umbraco.Testing;
+using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace GovUk.Frontend.Umbraco.Tests.Blocks
 {
@@ -40,7 +41,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                 ]);
             model.Filter = block => block.Content.ContentType.Alias == ALLOWED;
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -63,7 +64,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                 ], "area");
             model.Filter = block => block.Content.ContentType.Alias == ALLOWED;
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -86,7 +87,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                 ]);
             model.Filter = block => block.Content.ContentType.Alias == ALLOWED;
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -102,7 +103,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             // Arrange
             var model = UmbracoBlockGridFactory.CreateOverridableBlockGridModel([]);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -117,7 +118,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             // Arrange
             var model = UmbracoBlockGridFactory.CreateOverridableBlockGridArea([], "area");
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -136,7 +137,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                 UmbracoBlockGridFactory.CreateOverridableBlock("three")
                 ]);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary()).ToList();
@@ -163,7 +164,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                 UmbracoBlockGridFactory.CreateOverridableBlock("three")
                 ], "area");
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary()).ToList();
@@ -186,7 +187,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             // Arrange
             var model = UmbracoBlockListFactory.CreateOverridableBlockListModel([]);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -205,7 +206,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
                 UmbracoBlockListFactory.CreateOverridableBlock("three")
                 ]);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary()).ToList();
@@ -258,7 +259,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = renderWidthContainerForBlocksEnabled });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -304,7 +305,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = renderWidthContainerForBlocksEnabled });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -325,7 +326,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = renderWidthContainerForBlocksEnabled });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -346,7 +347,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = renderWidthContainerForBlocksEnabled });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -404,7 +405,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = renderWidthContainerForSiteEnabled });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -462,7 +463,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = renderWidthContainerForSiteEnabled });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -506,7 +507,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = true });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -550,7 +551,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = true });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -594,7 +595,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = true });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -638,7 +639,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = true });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -686,7 +687,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = true });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -734,7 +735,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
 
             var options = Options.Create(new GovUkFrontendUmbracoOptions { RenderWidthContainerForBlocks = true });
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, options, [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -763,7 +764,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             var errors = hasErrors ? [UmbracoBlockGridFactory.CreateOverridableBlock(ElementTypeAliases.ErrorMessage)] : Array.Empty<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>();
             _ = _fieldsetErrorFinder.Setup(x => x.FindErrors(model.First(), modelState)).Returns(errors);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, modelState);
@@ -803,7 +804,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             var errors = hasErrors ? [UmbracoBlockListFactory.CreateOverridableBlock(ElementTypeAliases.ErrorMessage)] : Array.Empty<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>>();
             _ = _fieldsetErrorFinder.Setup(x => x.FindErrors(model.First(), modelState)).Returns(errors);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, modelState);
@@ -836,7 +837,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             _ = _gridClassBuilder.Setup(x => x.BuildGridRowClasses(null)).Returns(ROW_CLASS);
             _ = _gridClassBuilder.Setup(x => x.BuildGridColumnClasses(null, null, null, "alias", false)).Returns(COLUMN_CLASS);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());
@@ -859,7 +860,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Blocks
             _ = _gridClassBuilder.Setup(x => x.BuildGridRowClasses(null)).Returns(ROW_CLASS);
             _ = _gridClassBuilder.Setup(x => x.BuildGridColumnClasses(null, null, null, "alias", false)).Returns(COLUMN_CLASS);
 
-            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), []);
+            var blockViewService = new BlockViewService(_gridClassBuilder.Object, _fieldsetErrorFinder.Object, Options.Create(new GovUkFrontendUmbracoOptions()), [], Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = blockViewService.PrepareBlockViewModels(model, new ModelStateDictionary());

--- a/GovUk.Frontend.Umbraco.Tests/Services/GovUkFieldsetErrorFinderTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/Services/GovUkFieldsetErrorFinderTests.cs
@@ -123,7 +123,7 @@ namespace GovUk.Frontend.Umbraco.Tests.Services
                 OverridableBlockListItem.NoopPublishedElementFactory
                 );
 
-            var fieldsetBlocks = new OverridableBlockListModel(new[] { errorMessageBlock }, null, OverridableBlockListItem.NoopPublishedElementFactory);
+            var fieldsetBlocks = new OverridableBlockListModel(Mock.Of<IPublishedValueFallback>(), new[] { errorMessageBlock }, null, OverridableBlockListItem.NoopPublishedElementFactory);
             var fieldsetContentProperties = new[] { UmbracoPropertyFactory.CreateBlockListProperty(PropertyAliases.FieldsetBlocks, fieldsetBlocks) };
             fieldsetContent.SetupGet(x => x.Properties).Returns(fieldsetContentProperties);
             fieldsetContent.Setup(x => x.GetProperty(PropertyAliases.FieldsetBlocks)).Returns(fieldsetContentProperties[0]);

--- a/GovUk.Frontend.Umbraco/Blocks/BlockViewService.cs
+++ b/GovUk.Frontend.Umbraco/Blocks/BlockViewService.cs
@@ -1,15 +1,19 @@
 ﻿using GovUk.Frontend.Umbraco.Services;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
-using System.Collections.Generic;
-using System.Linq;
 using ThePensionsRegulator.Umbraco;
 using ThePensionsRegulator.Umbraco.Blocks;
 using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace GovUk.Frontend.Umbraco.Blocks
 {
-    public class BlockViewService(IGovUkGridClassBuilder _gridClassBuilder, IGovUkFieldsetErrorFinder _fieldsetErrorFinder, IOptions<GovUkFrontendUmbracoOptions> _options, IEnumerable<IBlockViewInterceptor> _interceptors)
+    public class BlockViewService(
+        IGovUkGridClassBuilder _gridClassBuilder,
+        IGovUkFieldsetErrorFinder _fieldsetErrorFinder,
+        IOptions<GovUkFrontendUmbracoOptions> _options,
+        IEnumerable<IBlockViewInterceptor> _interceptors,
+        IPublishedValueFallback _publishedValueFallback)
     {
         /// <summary>
         /// Builds details of the HTML required to render each block in a block grid.
@@ -26,7 +30,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
             var wrappedModel = blockGridItems as BlockGridViewModel;
             var gridModel = blockGridItems as OverridableBlockGridModel ?? wrappedModel?.BlockGrid;
             var areaModel = blockGridItems as OverridableBlockGridArea;
-            var blocks = (gridModel?.FilteredBlocks() ?? areaModel?.FilteredBlocks() ?? new OverridableBlockGridModel(blockGridItems, null)).ToList();
+            var blocks = (gridModel?.FilteredBlocks() ?? areaModel?.FilteredBlocks() ?? new OverridableBlockGridModel(_publishedValueFallback, blockGridItems)).ToList();
             if (!blocks.Any()) { return blocksToReturn; }
 
             string? previousRowClass = null, previousColumnClass = null;
@@ -153,7 +157,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
         {
             var blocksToReturn = new List<BlockViewModel>();
             var wrappedModel = blockListItems as BlockListViewModel;
-            var filteredModel = blockListItems as OverridableBlockListModel ?? wrappedModel?.BlockList ?? new OverridableBlockListModel(blockListItems, null);
+            var filteredModel = blockListItems as OverridableBlockListModel ?? wrappedModel?.BlockList ?? new OverridableBlockListModel(_publishedValueFallback, blockListItems);
             var renderGrid = (wrappedModel?.RenderGrid ?? true);
             var blocks = filteredModel.FilteredBlocks().ToList();
             if (!blocks.Any()) { return blocksToReturn; }

--- a/GovUk.Frontend.Umbraco/Blocks/IOverridablePublishedElementExtensions.cs
+++ b/GovUk.Frontend.Umbraco/Blocks/IOverridablePublishedElementExtensions.cs
@@ -219,7 +219,6 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <param name="publishedValueFallback">The published value fallback provider.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
             IEnumerable<SelectOption> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,

--- a/GovUk.Frontend.Umbraco/Blocks/IOverridablePublishedElementExtensions.cs
+++ b/GovUk.Frontend.Umbraco/Blocks/IOverridablePublishedElementExtensions.cs
@@ -1,10 +1,9 @@
 ﻿using GovUk.Frontend.Umbraco.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using ThePensionsRegulator.Umbraco;
 using ThePensionsRegulator.Umbraco.Blocks;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -21,12 +20,25 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="items">The checkboxes.</param>
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideCheckboxes(this IOverridablePublishedElement blockContent,
             IEnumerable<CheckboxItemBase> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor)
-        {
-            blockContent.OverrideCheckboxes(items, publishedSnapshotAccessor, null);
-        }
+            => blockContent.OverrideCheckboxes(items, publishedSnapshotAccessor, filter: null);
+
+        /// <summary>
+        /// Replaces the checkboxes configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Checkboxes component.</param>
+        /// <param name="items">The checkboxes.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        public static void OverrideCheckboxes(this IOverridablePublishedElement blockContent,
+            IEnumerable<CheckboxItemBase> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback)
+            => blockContent.OverrideCheckboxes(items, publishedSnapshotAccessor, publishedValueFallback, null);
 
         /// <summary>
         /// Replaces the checkboxes configured in Umbraco with those supplied as an argument.
@@ -36,9 +48,26 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideCheckboxes(this IOverridablePublishedElement blockContent,
             IEnumerable<CheckboxItemBase> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
+            => blockContent.OverrideCheckboxes(items, publishedSnapshotAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>(), filter);
+
+        /// <summary>
+        /// Replaces the checkboxes configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Checkboxes component.</param>
+        /// <param name="items">The checkboxes.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        public static void OverrideCheckboxes(this IOverridablePublishedElement blockContent,
+            IEnumerable<CheckboxItemBase> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback,
             Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideCheckboxes), new List<string> { ElementTypeAliases.Checkboxes }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
@@ -74,7 +103,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
                 }
             }
 
-            blockContent.OverrideValue(PropertyAliases.Checkboxes, new OverridableBlockListModel(blockListItems, filter));
+            blockContent.OverrideValue(PropertyAliases.Checkboxes, new OverridableBlockListModel(publishedValueFallback, blockListItems, filter));
         }
 
         /// <summary>
@@ -84,10 +113,24 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="items">The radio buttons.</param>
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent, IEnumerable<RadioItemBase> items, IPublishedSnapshotAccessor publishedSnapshotAccessor)
-        {
-            blockContent.OverrideRadioButtons(items, publishedSnapshotAccessor, null);
-        }
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
+        public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent,
+            IEnumerable<RadioItemBase> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor)
+            => blockContent.OverrideRadioButtons(items, publishedSnapshotAccessor, filter: null);
+
+        /// <summary>
+        /// Replaces the radio buttons configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Radios component.</param>
+        /// <param name="items">The radio buttons.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent,
+            IEnumerable<RadioItemBase> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback)
+            => blockContent.OverrideRadioButtons(items, publishedSnapshotAccessor, publishedValueFallback, null);
 
         /// <summary>
         /// Replaces the radio buttons configured in Umbraco with those supplied as an argument.
@@ -97,9 +140,26 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent,
             IEnumerable<RadioItemBase> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
+            => blockContent.OverrideRadioButtons(items, publishedSnapshotAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>(), filter);
+
+        /// <summary>
+        /// Replaces the radio buttons configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Radios component.</param>
+        /// <param name="items">The radio buttons.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent,
+            IEnumerable<RadioItemBase> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback,
             Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideRadioButtons), new List<string> { ElementTypeAliases.Radios }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
@@ -135,7 +195,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
                 }
             }
 
-            blockContent.OverrideValue(PropertyAliases.RadioButtons, new OverridableBlockListModel(blockListItems, filter));
+            blockContent.OverrideValue(PropertyAliases.RadioButtons, new OverridableBlockListModel(publishedValueFallback, blockListItems, filter));
         }
 
         /// <summary>
@@ -145,10 +205,26 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="items">The select options.</param>
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent, IEnumerable<SelectOption> items, IPublishedSnapshotAccessor publishedSnapshotAccessor)
-        {
-            blockContent.OverrideSelectOptions(items, publishedSnapshotAccessor, null);
-        }
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
+        public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
+            IEnumerable<SelectOption> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor)
+            => blockContent.OverrideSelectOptions(items, publishedSnapshotAccessor, filter: null);
+
+        /// <summary>
+        /// Replaces the select options configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Select component.</param>
+        /// <param name="items">The select options.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
+        public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
+            IEnumerable<SelectOption> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback)
+            => blockContent.OverrideSelectOptions(items, publishedSnapshotAccessor, publishedValueFallback, null);
 
         /// <summary>
         /// Replaces the select options configured in Umbraco with those supplied as an argument.
@@ -158,9 +234,27 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
             IEnumerable<SelectOption> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
+            => blockContent.OverrideSelectOptions(items, publishedSnapshotAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>(), filter);
+
+
+        /// <summary>
+        /// Replaces the select options configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Select component.</param>
+        /// <param name="items">The select options.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
+            IEnumerable<SelectOption> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback,
             Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideSelectOptions), new List<string> { ElementTypeAliases.Select }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
@@ -177,7 +271,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
                 blockListItems.Add(CreateBlockListItem(ElementTypeAliases.SelectOption, contentFields, null, null, publishedSnapshotAccessor));
             }
 
-            blockContent.OverrideValue(PropertyAliases.SelectOptions, new OverridableBlockListModel(blockListItems, filter));
+            blockContent.OverrideValue(PropertyAliases.SelectOptions, new OverridableBlockListModel(publishedValueFallback, blockListItems, filter));
         }
 
         /// <summary>
@@ -187,10 +281,11 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="items">The summary card actions.</param>
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent, IEnumerable<SummaryListAction> items, IPublishedSnapshotAccessor publishedSnapshotAccessor)
-        {
-            blockContent.OverrideSummaryCardActions(items, publishedSnapshotAccessor, null);
-        }
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
+        public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent,
+            IEnumerable<SummaryListAction> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor)
+            => blockContent.OverrideSummaryCardActions(items, publishedSnapshotAccessor, filter: null);
 
         /// <summary>
         /// Replaces the summary card actions configured in Umbraco with those supplied as an argument.
@@ -198,16 +293,47 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="blockContent">The content of a block list item based on the GOV.UK Summary card component.</param>
         /// <param name="items">The summary card actions.</param>
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent,
+            IEnumerable<SummaryListAction> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback)
+            => blockContent.OverrideSummaryCardActions(items, publishedSnapshotAccessor, publishedValueFallback, null);
+
+        /// <summary>
+        /// Replaces the summary card actions configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Summary card component.</param>
+        /// <param name="items">The summary card actions.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
+        public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent,
+            IEnumerable<SummaryListAction> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
+            => OverrideSummaryCardActions(blockContent, items, publishedSnapshotAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>(), filter);
+
+        /// <summary>
+        /// Replaces the summary card actions configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Summary card component.</param>
+        /// <param name="items">The summary card actions.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
         public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListAction> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback,
             Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideSummaryListItems), new List<string> { ElementTypeAliases.SummaryCard }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
 
-            blockContent.OverrideValue(PropertyAliases.SummaryCardActions, CreateSummaryListActionBlocks(items, publishedSnapshotAccessor, filter));
+            blockContent.OverrideValue(PropertyAliases.SummaryCardActions, CreateSummaryListActionBlocks(items, publishedSnapshotAccessor, publishedValueFallback, filter));
         }
 
         /// <summary>
@@ -217,10 +343,25 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="items">The summary list items.</param>
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent, IEnumerable<SummaryListItem> items, IPublishedSnapshotAccessor publishedSnapshotAccessor)
-        {
-            blockContent.OverrideSummaryListItems(items, publishedSnapshotAccessor, null);
-        }
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
+        public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent,
+            IEnumerable<SummaryListItem> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor)
+             => blockContent.OverrideSummaryListItems(items, publishedSnapshotAccessor, filter: null);
+
+        /// <summary>
+        /// Replaces the summary list items configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Summary list component.</param>
+        /// <param name="items">The summary list items.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent,
+            IEnumerable<SummaryListItem> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback)
+            => blockContent.OverrideSummaryListItems(items, publishedSnapshotAccessor, publishedValueFallback, null);
 
         /// <summary>
         /// Replaces the summary list items configured in Umbraco with those supplied as an argument.
@@ -230,9 +371,26 @@ namespace GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListItem> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
+            => OverrideSummaryListItems(blockContent, items, publishedSnapshotAccessor, StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>(), filter);
+
+        /// <summary>
+        /// Replaces the summary list items configured in Umbraco with those supplied as an argument.
+        /// </summary>
+        /// <param name="blockContent">The content of a block list item based on the GOV.UK Summary list component.</param>
+        /// <param name="items">The summary list items.</param>
+        /// <param name="publishedSnapshotAccessor">Accessor for a published snapshot, which is a point-in-time capture of the current state of everything that is "published".</param>
+        /// <param name="publishedValueFallback">The published value fallback provider.</param>
+        /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
+        public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent,
+            IEnumerable<SummaryListItem> items,
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback,
             Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
         {
             GuardOverrideChildBlocks(nameof(OverrideSummaryListItems), new List<string> { ElementTypeAliases.SummaryList, ElementTypeAliases.SummaryCard }, blockContent.ContentType?.Alias, publishedSnapshotAccessor);
@@ -244,7 +402,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
                 {
                     { PropertyAliases.SummaryListItemKey, item.Key },
                     { PropertyAliases.SummaryListItemValue, item.Value },
-                    { PropertyAliases.SummaryListItemActions, CreateSummaryListActionBlocks(item.Actions, publishedSnapshotAccessor, filter) }
+                    { PropertyAliases.SummaryListItemActions, CreateSummaryListActionBlocks(item.Actions, publishedSnapshotAccessor, publishedValueFallback, filter) }
                 };
 
                 var settingsFields = new Dictionary<string, object?>()
@@ -256,11 +414,12 @@ namespace GovUk.Frontend.Umbraco.Blocks
             }
 
             var listItemPropertyAlias = blockContent.ContentType!.Alias == ElementTypeAliases.SummaryList ? PropertyAliases.SummaryListItems : PropertyAliases.SummaryCardListItems;
-            blockContent.OverrideValue(listItemPropertyAlias, new OverridableBlockListModel(blockListItems, filter));
+            blockContent.OverrideValue(listItemPropertyAlias, new OverridableBlockListModel(publishedValueFallback, blockListItems, filter));
         }
 
         private static OverridableBlockListModel CreateSummaryListActionBlocks(IEnumerable<SummaryListAction> items,
             IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IPublishedValueFallback publishedValueFallback,
             Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter)
         {
             var blockListItems = new List<OverridableBlockListItem>();
@@ -275,7 +434,7 @@ namespace GovUk.Frontend.Umbraco.Blocks
                 blockListItems.Add(CreateBlockListItem(ElementTypeAliases.SummaryListAction, actionFields, null, null, publishedSnapshotAccessor));
             }
 
-            return new OverridableBlockListModel(blockListItems, filter);
+            return new OverridableBlockListModel(publishedValueFallback, blockListItems, filter);
         }
 
         private static OverridableBlockListItem CreateBlockListItem(

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoBlockGridFactory.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoBlockGridFactory.cs
@@ -46,6 +46,14 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <summary>
         /// Create an <see cref="OverridableBlockGridModel"/> containing a single <see cref="BlockGridItem"/> which can have its property values overridden at runtime.
         /// </summary>
+        public static OverridableBlockGridModel CreateOverridableBlockGridModel(IPublishedValueFallback publishedValueFallback, BlockGridItem blockGridItem)
+        {
+            return CreateOverridableBlockGridModel(publishedValueFallback, [blockGridItem]);
+        }
+
+        /// <summary>
+        /// Create an <see cref="OverridableBlockGridModel"/> containing a single <see cref="BlockGridItem"/> which can have its property values overridden at runtime.
+        /// </summary>
         public static OverridableBlockGridModel CreateOverridableBlockGridModel(BlockGridItem blockGridItem)
         {
             return CreateOverridableBlockGridModel([blockGridItem]);
@@ -54,10 +62,16 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <summary>
         /// Create an <see cref="OverridableBlockGridModel"/> containing multiple instances of <see cref="BlockGridItem"/> which can have their property values overridden at runtime.
         /// </summary>
-        public static OverridableBlockGridModel CreateOverridableBlockGridModel(IEnumerable<BlockGridItem> blockGridItems)
+        public static OverridableBlockGridModel CreateOverridableBlockGridModel(IPublishedValueFallback publishedValueFallback, IEnumerable<BlockGridItem> blockGridItems)
         {
-            return new OverridableBlockGridModel(blockGridItems, null, OverridableBlockGridItem.NoopPublishedElementFactory);
+            return new OverridableBlockGridModel(publishedValueFallback, blockGridItems, null, OverridableBlockGridItem.NoopPublishedElementFactory);
         }
+
+        /// <summary>
+        /// Create an <see cref="OverridableBlockGridModel"/> containing multiple instances of <see cref="BlockGridItem"/> which can have their property values overridden at runtime.
+        /// </summary>
+        public static OverridableBlockGridModel CreateOverridableBlockGridModel(IEnumerable<BlockGridItem> blockGridItems)
+            => CreateOverridableBlockGridModel(Mock.Of<IPublishedValueFallback>(), blockGridItems);
 
         /// <summary>
         /// Create an <see cref="OverridableBlockGridArea"/> containing a single <see cref="BlockGridItem"/> which can have its property values overridden at runtime.

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoBlockListFactory.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoBlockListFactory.cs
@@ -30,18 +30,30 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// <summary>
         /// Create an <see cref="OverridableBlockListModel"/> containing a single <see cref="BlockListItem"/> which can have its property values overridden at runtime.
         /// </summary>
-        public static OverridableBlockListModel CreateOverridableBlockListModel(BlockListItem blockListItem)
+        public static OverridableBlockListModel CreateOverridableBlockListModel(IPublishedValueFallback publishedValueFallback, BlockListItem blockListItem)
         {
-            return CreateOverridableBlockListModel(new[] { blockListItem });
+            return CreateOverridableBlockListModel(publishedValueFallback, new[] { blockListItem });
+        }
+
+        /// <summary>
+        /// Create an <see cref="OverridableBlockListModel"/> containing a single <see cref="BlockListItem"/> which can have its property values overridden at runtime.
+        /// </summary>
+        public static OverridableBlockListModel CreateOverridableBlockListModel(BlockListItem blockListItem)
+            => CreateOverridableBlockListModel(Mock.Of<IPublishedValueFallback>(), blockListItem);
+
+        /// <summary>
+        /// Create an <see cref="OverridableBlockListModel"/> containing multiple instances of <see cref="BlockListItem"/> which can have their property values overridden at runtime.
+        /// </summary>
+        public static OverridableBlockListModel CreateOverridableBlockListModel(IPublishedValueFallback publishedValueFallback, IEnumerable<BlockListItem> blockListItems)
+        {
+            return new OverridableBlockListModel(publishedValueFallback, blockListItems, null, OverridableBlockListItem.NoopPublishedElementFactory);
         }
 
         /// <summary>
         /// Create an <see cref="OverridableBlockListModel"/> containing multiple instances of <see cref="BlockListItem"/> which can have their property values overridden at runtime.
         /// </summary>
         public static OverridableBlockListModel CreateOverridableBlockListModel(IEnumerable<BlockListItem> blockListItems)
-        {
-            return new OverridableBlockListModel(blockListItems, null, OverridableBlockListItem.NoopPublishedElementFactory);
-        }
+            => CreateOverridableBlockListModel(Mock.Of<IPublishedValueFallback>(), blockListItems);
 
         /// <summary>
         /// Create a read-only Umbraco <see cref="BlockListItem"/> with the specified content, and no settings.

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockGridModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockGridModelTests.cs
@@ -12,34 +12,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
     {
         private const string DOCUMENT_TYPE_ALIAS_CHILD_BLOCKS = "docTypeChildBlocks";
         private const string PROPERTY_ALIAS_CHILD_BLOCKS = "childBlocks";
-
-        public OverridableBlockGridModelTests()
-        {
-            _ = new UmbracoTestContext(); // Sets up Umbraco dependency injection
-        }
-
-        private static (OverridableBlockGridModel ParentBlockGrid, OverridableBlockGridModel ChildBlockGrid, OverridableBlockGridModel GrandChildBlockGrid) CreateThreeNestedOverridableBlockGrids()
-        {
-            var grandChildBlockGrid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(Array.Empty<BlockGridItem>());
-
-            var childContent = UmbracoBlockGridFactory.CreateContentOrSettings(DOCUMENT_TYPE_ALIAS_CHILD_BLOCKS)
-                    .SetupUmbracoBlockGridPropertyValue(PROPERTY_ALIAS_CHILD_BLOCKS, grandChildBlockGrid)
-                    .Object;
-
-            var childBlockGrid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(
-                UmbracoBlockGridFactory.CreateOverridableBlock(childContent)
-                );
-
-            var parentContent = UmbracoBlockGridFactory.CreateContentOrSettings(DOCUMENT_TYPE_ALIAS_CHILD_BLOCKS)
-                    .SetupUmbracoBlockGridPropertyValue(PROPERTY_ALIAS_CHILD_BLOCKS, childBlockGrid)
-                    .Object;
-
-            var parentBlockGrid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(
-                UmbracoBlockGridFactory.CreateOverridableBlock(parentContent)
-                );
-
-            return (parentBlockGrid, childBlockGrid, grandChildBlockGrid);
-        }
+        private UmbracoTestContext _testContext = new();
 
         private static (OverridableBlockGridModel ParentBlockGrid, OverridableBlockListModel ChildBlockList, OverridableBlockListModel GrandChildBlockList) CreateOverridableBlockGridModelWithTwoNestedOverridableBlockLists()
         {
@@ -99,7 +72,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
                 convertedChildBlockGrid = value as OverridableBlockGridModel;
             });
             parentBlockGridContent.Setup(x => x.Properties).Returns(parentBlockGrid[0].Content.Properties);
-            parentBlockGridContent.Setup(x => x.Value<BlockGridModel>(PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(childBlockGrid);
+            parentBlockGridContent.Setup(x => x.Value<BlockGridModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(childBlockGrid);
 
             var childBlockGridContent = new Mock<IOverridablePublishedElement>();
             childBlockGridContent.Setup(x => x.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, It.IsAny<object>())).Callback<string, object>((alias, value) =>
@@ -107,7 +80,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
                 convertedGrandChildBlockGrid = value as OverridableBlockGridModel;
             });
             childBlockGridContent.Setup(x => x.Properties).Returns(childBlockGrid[0].Content.Properties);
-            childBlockGridContent.Setup(x => x.Value<BlockGridModel>(PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(grandChildBlockGrid);
+            childBlockGridContent.Setup(x => x.Value<BlockGridModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(grandChildBlockGrid);
 
             var factoryCalls = 0;
             Func<IPublishedElement?, IOverridablePublishedElement?> factory = x =>
@@ -126,7 +99,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             };
 
             // Act
-            _ = new OverridableBlockGridModel(parentBlockGrid, null, factory);
+            _ = new OverridableBlockGridModel(_testContext.PublishedValueFallback.Object, parentBlockGrid, null, factory);
 
             // Assert
             Assert.NotNull(convertedChildBlockGrid);
@@ -161,7 +134,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
                 convertedChildBlockList = value as OverridableBlockListModel;
             });
             parentBlockGridContent.Setup(x => x.Properties).Returns(parentBlockGrid[0].Content.Properties);
-            parentBlockGridContent.Setup(x => x.Value<BlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(childBlockList);
+            parentBlockGridContent.Setup(x => x.Value<BlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(childBlockList);
 
             var childBlockListContent = new Mock<IOverridablePublishedElement>();
             childBlockListContent.Setup(x => x.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, It.IsAny<object>())).Callback<string, object>((alias, value) =>
@@ -169,7 +142,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
                 convertedGrandChildBlockList = value as OverridableBlockListModel;
             });
             childBlockListContent.Setup(x => x.Properties).Returns(childBlockList[0].Content.Properties);
-            childBlockListContent.Setup(x => x.Value<BlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(grandChildBlockList);
+            childBlockListContent.Setup(x => x.Value<BlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(grandChildBlockList);
 
             var factoryCalls = 0;
             Func<IPublishedElement?, IOverridablePublishedElement?> factory = x =>
@@ -188,7 +161,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             };
 
             // Act
-            _ = new OverridableBlockGridModel(parentBlockGrid, null, factory);
+            _ = new OverridableBlockGridModel(_testContext.PublishedValueFallback.Object, parentBlockGrid, null, factory);
 
             // Assert
             Assert.NotNull(convertedChildBlockList);
@@ -222,12 +195,12 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             parentBlockGrid[0].Content.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, overriddenChildBlockList);
 
             // Act
-            var model = new OverridableBlockGridModel(parentBlockGrid);
+            var model = new OverridableBlockGridModel(_testContext.PublishedValueFallback.Object, parentBlockGrid);
 
             // Assert
             var overriddenBlock = model.FindBlockByContentTypeAlias(OVERRIDDEN_BLOCK_TYPE_ALIAS);
             Assert.NotNull(overriddenBlock);
-            Assert.Equal(OVERRIDDEN_TEXT_VALUE, overriddenBlock.Content.Value<string>(OVERRIDDEN_TEXT_PROPERTY));
+            Assert.Equal(OVERRIDDEN_TEXT_VALUE, overriddenBlock.Content.Value<string>(_testContext.PublishedValueFallback.Object, OVERRIDDEN_TEXT_PROPERTY));
         }
 
         [Fact]
@@ -253,7 +226,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             };
 
             // Act
-            var result = new OverridableBlockGridModel(blockGrid);
+            var result = new OverridableBlockGridModel(_testContext.PublishedValueFallback.Object, blockGrid);
 
             // Assert
             Assert.Single(result[0].Areas);
@@ -277,23 +250,23 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             var filter = new Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>(block => true);
 
             // Act
-            var model = new OverridableBlockGridModel(blockGrids.ParentBlockGrid, filter);
+            var model = new OverridableBlockGridModel(_testContext.PublishedValueFallback.Object, blockGrids.ParentBlockGrid, filter);
 
             // Assert
             Assert.Equal(filter, model.Filter);
 
-            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, childBlockList!.Filter);
 
-            var grandchildBlockList = childBlockList[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var grandchildBlockList = childBlockList[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, grandchildBlockList!.Filter);
 
             Assert.Equal(filter, model[0].Areas[0].Filter);
 
-            var areaChildBlockList = model[0].Areas[0][0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var areaChildBlockList = model[0].Areas[0][0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, areaChildBlockList!.Filter);
 
-            var areaGrandchildBlockList = areaChildBlockList[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var areaGrandchildBlockList = areaChildBlockList[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, areaGrandchildBlockList!.Filter);
         }
 
@@ -316,15 +289,15 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             // Assert
             Assert.Equal(filter, model.Filter);
 
-            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, childBlockList!.Filter);
 
             Assert.Equal(filter, model[0].Areas[0].Filter);
 
-            var areaChildBlockList = model[0].Areas[0][0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var areaChildBlockList = model[0].Areas[0][0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, areaChildBlockList!.Filter);
 
-            var areaGrandchildBlockList = areaChildBlockList[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var areaGrandchildBlockList = areaChildBlockList[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, areaGrandchildBlockList!.Filter);
         }
 
@@ -405,7 +378,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             var parentBlockGrid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(
                 UmbracoBlockGridFactory.CreateOverridableBlock(
                     new OverridablePublishedElement(UmbracoBlockGridFactory.CreateContentOrSettings()
-                    .SetupUmbracoBlockListPropertyValue(PROPERTY_ALIAS_CHILD_BLOCKS, new OverridableBlockListModel(Array.Empty<OverridableBlockListItem>()))
+                    .SetupUmbracoBlockListPropertyValue(PROPERTY_ALIAS_CHILD_BLOCKS, new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, Array.Empty<OverridableBlockListItem>()))
                     .Object),
                     new OverridablePublishedElement(UmbracoBlockGridFactory.CreateContentOrSettings().Object)
                 ));
@@ -428,7 +401,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             replacementChildBlock.Content.OverrideValue(CONTENT_PROPERTY_ALIAS_TO_OVERRIDE, CONTENT_PROPERTY_VALUE);
             replacementChildBlock.Settings.OverrideValue(SETTINGS_PROPERTY_ALIAS_TO_OVERRIDE, SETTINGS_PROPERTY_VALUE);
 
-            var replacementChildBlockList = new OverridableBlockListModel(new[] { replacementChildBlock });
+            var replacementChildBlockList = new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, new[] { replacementChildBlock });
             parentBlockGrid[0].Content.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, replacementChildBlockList);
 
             // Assert
@@ -456,7 +429,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
         [Fact]
         public void Can_convert_to_BlockGridModel()
         {
-            var converter = TypeDescriptor.GetConverter(new OverridableBlockGridModel());
+            var converter = TypeDescriptor.GetConverter(new OverridableBlockGridModel(_testContext.PublishedValueFallback.Object));
 
             Assert.Equal(typeof(OverridableBlockGridTypeConverter), converter.GetType());
         }

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockListModelTests.cs
@@ -12,11 +12,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
     {
         private const string DOCUMENT_TYPE_ALIAS_CHILD_BLOCKS = "docTypeChildBlocks";
         private const string PROPERTY_ALIAS_CHILD_BLOCKS = "childBlocks";
-
-        public OverridableBlockListModelTests()
-        {
-            _ = new UmbracoTestContext(); // Sets up Umbraco dependency injection
-        }
+        private UmbracoTestContext _testContext = new();
 
         private static (OverridableBlockListModel ParentBlockList, OverridableBlockListModel ChildBlockList, OverridableBlockListModel GrandChildBlockList) CreateThreeNestedOverridableBlockLists()
         {
@@ -69,7 +65,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
                 convertedChildBlockList = value as OverridableBlockListModel;
             });
             parentBlockListContent.Setup(x => x.Properties).Returns(parentBlockList[0].Content.Properties);
-            parentBlockListContent.Setup(x => x.Value<BlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(childBlockList);
+            parentBlockListContent.Setup(x => x.Value<BlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(childBlockList);
 
             var childBlockListContent = new Mock<IOverridablePublishedElement>();
             childBlockListContent.Setup(x => x.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, It.IsAny<object>())).Callback<string, object>((alias, value) =>
@@ -77,7 +73,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
                 convertedGrandChildBlockList = value as OverridableBlockListModel;
             });
             childBlockListContent.Setup(x => x.Properties).Returns(childBlockList[0].Content.Properties);
-            childBlockListContent.Setup(x => x.Value<BlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(grandChildBlockList);
+            childBlockListContent.Setup(x => x.Value<BlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS, null, null, default, default)).Returns(grandChildBlockList);
 
             var factoryCalls = 0;
             Func<IPublishedElement?, IOverridablePublishedElement?> factory = x =>
@@ -96,7 +92,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             };
 
             // Act
-            _ = new OverridableBlockListModel(parentBlockList, null, factory);
+            _ = new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, parentBlockList, null, factory);
 
             // Assert
             Assert.NotNull(convertedChildBlockList);
@@ -131,12 +127,12 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             parentBlockList[0].Content.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, overriddenChildBlockList);
 
             // Act
-            var model = new OverridableBlockListModel(parentBlockList);
+            var model = new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, parentBlockList);
 
             // Assert
             var overriddenBlock = model.FindBlockByContentTypeAlias(OVERRIDDEN_BLOCK_TYPE_ALIAS);
             Assert.NotNull(overriddenBlock);
-            Assert.Equal(OVERRIDDEN_TEXT_VALUE, overriddenBlock.Content.Value<string>(OVERRIDDEN_TEXT_PROPERTY));
+            Assert.Equal(OVERRIDDEN_TEXT_VALUE, overriddenBlock.Content.Value<string>(_testContext.PublishedValueFallback.Object, OVERRIDDEN_TEXT_PROPERTY));
         }
 
 
@@ -149,15 +145,15 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             var filter = new Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>(block => true);
 
             // Act
-            var model = new OverridableBlockListModel(blockLists.ParentBlockList, filter);
+            var model = new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, blockLists.ParentBlockList, filter);
 
             // Assert
             Assert.Equal(filter, model.Filter);
 
-            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, childBlockList!.Filter);
 
-            var grandchildBlockList = childBlockList[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var grandchildBlockList = childBlockList[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, grandchildBlockList!.Filter);
         }
 
@@ -170,16 +166,16 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             var filter = new Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>(block => true);
 
             // Act
-            var model = new OverridableBlockListModel(blockLists.ParentBlockList, null);
+            var model = new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, blockLists.ParentBlockList, null);
             model.Filter = filter;
 
             // Assert
             Assert.Equal(filter, model.Filter);
 
-            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var childBlockList = model[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, childBlockList!.Filter);
 
-            var grandchildBlockList = childBlockList[0].Content.Value<OverridableBlockListModel>(PROPERTY_ALIAS_CHILD_BLOCKS);
+            var grandchildBlockList = childBlockList[0].Content.Value<OverridableBlockListModel>(_testContext.PublishedValueFallback.Object, PROPERTY_ALIAS_CHILD_BLOCKS);
             Assert.Equal(filter, grandchildBlockList!.Filter);
         }
 
@@ -228,7 +224,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             var parentBlockList = UmbracoBlockListFactory.CreateOverridableBlockListModel(
                 UmbracoBlockListFactory.CreateOverridableBlock(
                     new OverridablePublishedElement(UmbracoBlockListFactory.CreateContentOrSettings()
-                        .SetupUmbracoBlockListPropertyValue(PROPERTY_ALIAS_CHILD_BLOCKS, new OverridableBlockListModel(Array.Empty<OverridableBlockListItem>()))
+                        .SetupUmbracoBlockListPropertyValue(PROPERTY_ALIAS_CHILD_BLOCKS, new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, Array.Empty<OverridableBlockListItem>()))
                     .Object),
                     new OverridablePublishedElement(UmbracoBlockListFactory.CreateContentOrSettings().Object)
                 ));
@@ -251,7 +247,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             replacementChildBlock.Content.OverrideValue(CONTENT_PROPERTY_ALIAS_TO_OVERRIDE, CONTENT_PROPERTY_VALUE);
             replacementChildBlock.Settings.OverrideValue(SETTINGS_PROPERTY_ALIAS_TO_OVERRIDE, SETTINGS_PROPERTY_VALUE);
 
-            var replacementChildBlockList = new OverridableBlockListModel(new[] { replacementChildBlock });
+            var replacementChildBlockList = new OverridableBlockListModel(_testContext.PublishedValueFallback.Object, new[] { replacementChildBlock });
             parentBlockList[0].Content.OverrideValue(PROPERTY_ALIAS_CHILD_BLOCKS, replacementChildBlockList);
 
             // Assert
@@ -281,7 +277,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
         [Fact]
         public void Can_convert_to_BlockListModel()
         {
-            var converter = TypeDescriptor.GetConverter(new OverridableBlockListModel());
+            var converter = TypeDescriptor.GetConverter(new OverridableBlockListModel(_testContext.PublishedValueFallback.Object));
 
             Assert.Equal(typeof(OverridableBlockListTypeConverter), converter.GetType());
         }

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockModelExtensionsTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/OverridableBlockModelExtensionsTests.cs
@@ -201,8 +201,8 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
         [Fact]
         public void Block_is_matched_in_multiple_OverridableBlockListModels()
         {
-            var blockList1 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks();
-            var blockList2 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks();
+            var blockList1 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks(Mock.Of<IPublishedValueFallback>());
+            var blockList2 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks(Mock.Of<IPublishedValueFallback>());
 
             // Act
             var result = (new[] { blockList1.BlockList, blockList2.BlockList }).FindBlock(x => x.Content.GetProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS) != null);
@@ -257,7 +257,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
         [Fact]
         public void Multiple_matching_blocks_are_matched_in_block_list_descendant_of_OverridableBlockGridModel()
         {
-            var blockGrid = CreateOverridableBlockGridHierarchyWithMultipleMatchingBlocks();
+            var blockGrid = CreateOverridableBlockGridHierarchyWithMultipleMatchingBlocks(Mock.Of<IPublishedValueFallback>());
 
             // Act
             var results = blockGrid.BlockGrid.FindBlocks(x => x.Content.GetProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS) != null).ToList();
@@ -271,7 +271,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
         [Fact]
         public void Multiple_matching_blocks_are_matched_in_block_list_descendant_of_OverridableBlockListModel()
         {
-            var blockList = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks();
+            var blockList = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks(Mock.Of<IPublishedValueFallback>());
 
             // Act
             var results = blockList.BlockList.FindBlocks(x => x.Content.GetProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS) != null).ToList();
@@ -285,8 +285,8 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
         [Fact]
         public void Multiple_matching_blocks_are_matched_in_multiple_OverridableBlockListModels()
         {
-            var blockList1 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks();
-            var blockList2 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks();
+            var blockList1 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks(Mock.Of<IPublishedValueFallback>());
+            var blockList2 = CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks(Mock.Of<IPublishedValueFallback>());
 
             // Act
             var results = (new[] { blockList1.BlockList, blockList2.BlockList }).FindBlocks(x => x.Content.GetProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS) != null).ToList();
@@ -324,11 +324,12 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
 
         #region Helpers
 
-        private static (OverridableBlockListModel BlockList, IList<OverridableBlockListItem> BlocksToMatch) CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks()
+        private static (OverridableBlockListModel BlockList, IList<OverridableBlockListItem> BlocksToMatch) CreateOverridableBlockListHierarchyWithMultipleMatchingBlocks(IPublishedValueFallback publishedValueFallback)
         {
-            var childBlockList = CreateOverridableChildBlockListWithMultipleMatchingBlocks();
+            var childBlockList = CreateOverridableChildBlockListWithMultipleMatchingBlocks(publishedValueFallback);
 
             var parentBlockList = UmbracoBlockListFactory.CreateOverridableBlockListModel(
+                    publishedValueFallback,
                     UmbracoBlockListFactory.CreateOverridableBlock(
                         UmbracoBlockListFactory.CreateContentOrSettings()
                         .SetupUmbracoBlockListPropertyValue("childBlocks", childBlockList.BlockList)
@@ -339,11 +340,12 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             return (parentBlockList, childBlockList.BlocksToMatch);
         }
 
-        private static (OverridableBlockGridModel BlockGrid, IList<OverridableBlockListItem> BlocksToMatch) CreateOverridableBlockGridHierarchyWithMultipleMatchingBlocks()
+        private static (OverridableBlockGridModel BlockGrid, IList<OverridableBlockListItem> BlocksToMatch) CreateOverridableBlockGridHierarchyWithMultipleMatchingBlocks(IPublishedValueFallback publishedValueFallback)
         {
-            var childBlockList = CreateOverridableChildBlockListWithMultipleMatchingBlocks();
+            var childBlockList = CreateOverridableChildBlockListWithMultipleMatchingBlocks(publishedValueFallback);
 
             var parentBlockGrid = UmbracoBlockGridFactory.CreateOverridableBlockGridModel(
+                    publishedValueFallback,
                     UmbracoBlockGridFactory.CreateBlock(
                         UmbracoBlockGridFactory.CreateContentOrSettings()
                         .SetupUmbracoBlockListPropertyValue("childBlocks", childBlockList.BlockList)
@@ -354,7 +356,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
             return (parentBlockGrid, childBlockList.BlocksToMatch);
         }
 
-        private static (OverridableBlockListModel BlockList, IList<OverridableBlockListItem> BlocksToMatch) CreateOverridableChildBlockListWithMultipleMatchingBlocks()
+        private static (OverridableBlockListModel BlockList, IList<OverridableBlockListItem> BlocksToMatch) CreateOverridableChildBlockListWithMultipleMatchingBlocks(IPublishedValueFallback publishedValueFallback)
         {
             var matchingBlockContent1 = new Mock<IOverridablePublishedElement>();
             matchingBlockContent1.Setup(x => x.GetProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS)).Returns(UmbracoPropertyFactory.CreateTextboxProperty(EXAMPLE_TEXTBOX_PROPERTY_ALIAS, "value"));
@@ -374,7 +376,7 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
 #nullable enable
                         OverridableBlockListItem.NoopPublishedElementFactory
                     );
-            var grandChildBlockList = new OverridableBlockListModel(new[] { matchingBlock1, matchingBlock2 }, null, OverridableBlockListItem.NoopPublishedElementFactory);
+            var grandChildBlockList = new OverridableBlockListModel(publishedValueFallback, new[] { matchingBlock1, matchingBlock2 }, null, OverridableBlockListItem.NoopPublishedElementFactory);
 
             var childBlockList = UmbracoBlockListFactory.CreateOverridableBlockListModel(
                 UmbracoBlockListFactory.CreateOverridableBlock(

--- a/ThePensionsRegulator.Umbraco.Tests/Blocks/PublishedElementExtensionsTests.cs
+++ b/ThePensionsRegulator.Umbraco.Tests/Blocks/PublishedElementExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using ThePensionsRegulator.Umbraco.Blocks;
+﻿using Moq;
+using ThePensionsRegulator.Umbraco.Blocks;
 using ThePensionsRegulator.Umbraco.Testing;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -11,10 +12,11 @@ namespace ThePensionsRegulator.Umbraco.Tests.Blocks
         public void Finds_multiple_mixed_block_lists_and_grids()
         {
             // Arrange
-            var blockList1 = new OverridableBlockListModel(new[] { UmbracoBlockListFactory.CreateOverridableBlock(UmbracoBlockListFactory.CreateContentOrSettings("alias").Object) });
-            var blockList2 = new OverridableBlockListModel(new[] { UmbracoBlockListFactory.CreateOverridableBlock(UmbracoBlockListFactory.CreateContentOrSettings("alias").Object) });
-            var blockGrid1 = new OverridableBlockGridModel(new[] { UmbracoBlockGridFactory.CreateOverridableBlock(UmbracoBlockGridFactory.CreateContentOrSettings("alias").Object) });
-            var blockGrid2 = new OverridableBlockGridModel(new[] { UmbracoBlockGridFactory.CreateOverridableBlock(UmbracoBlockGridFactory.CreateContentOrSettings("alias").Object) });
+            var publishedValueFallback = new Mock<IPublishedValueFallback>();
+            var blockList1 = new OverridableBlockListModel(publishedValueFallback.Object, new[] { UmbracoBlockListFactory.CreateOverridableBlock(UmbracoBlockListFactory.CreateContentOrSettings("alias").Object) });
+            var blockList2 = new OverridableBlockListModel(publishedValueFallback.Object, new[] { UmbracoBlockListFactory.CreateOverridableBlock(UmbracoBlockListFactory.CreateContentOrSettings("alias").Object) });
+            var blockGrid1 = new OverridableBlockGridModel(publishedValueFallback.Object, new[] { UmbracoBlockGridFactory.CreateOverridableBlock(UmbracoBlockGridFactory.CreateContentOrSettings("alias").Object) });
+            var blockGrid2 = new OverridableBlockGridModel(publishedValueFallback.Object, new[] { UmbracoBlockGridFactory.CreateOverridableBlock(UmbracoBlockGridFactory.CreateContentOrSettings("alias").Object) });
 
             var content = UmbracoContentFactory.CreateContent<IPublishedContent>();
             content.SetupUmbracoBlockListPropertyValue("blockList1", blockList1);

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockGridModel.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockGridModel.cs
@@ -1,6 +1,8 @@
-﻿using System.ComponentModel;
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel;
 using ThePensionsRegulator.Umbraco.PropertyEditors;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -13,13 +15,19 @@ namespace ThePensionsRegulator.Umbraco.Blocks
     [TypeConverter(typeof(OverridableBlockGridTypeConverter))]
     public class OverridableBlockGridModel : OverridableBlockModel<OverridableBlockGridItem>
     {
+        private IEnumerable<IPropertyValueFormatter>? _propertyValueFormatters;
 
         /// <summary>
         /// Creates a new <see cref="OverridableBlockGridModel"/> with no items.
         /// </summary>
+        [Obsolete("Use a constructor which specifies an IPublishedValueFallback.")]
         public OverridableBlockGridModel() : this(Array.Empty<BlockGridItem>()) { }
 
-        private IEnumerable<IPropertyValueFormatter>? _propertyValueFormatters;
+        /// <summary>
+        /// Creates a new <see cref="OverridableBlockGridModel"/> with no items.
+        /// </summary>
+        /// <param name="publishedValueFallback">An <see cref="IPublishedValueFallback"/> to use when retrieving property values for the block grid items.</param>
+        public OverridableBlockGridModel(IPublishedValueFallback publishedValueFallback) : this(publishedValueFallback, Array.Empty<BlockGridItem>()) { }
 
         /// <summary>
         /// Creates a new <see cref="OverridableBlockGridModel"/>
@@ -27,7 +35,28 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         /// <param name="blockGridItems">A block grid (typically a <see cref="BlockGridModel"/>).</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <param name="publishedElementFactory">Factory method to create an <see cref="IPublishedElement"/> that supports overriding property values.</param>
-        public OverridableBlockGridModel(IEnumerable<BlockGridItem> blockGridItems, Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter = null, Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
+        [Obsolete("Use a constructor which specifies an IPublishedValueFallback.")]
+        public OverridableBlockGridModel(
+            IEnumerable<BlockGridItem> blockGridItems,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter = null,
+            Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
+            => Initialise(null, blockGridItems, filter, publishedElementFactory);
+
+        /// <summary>
+        /// Creates a new <see cref="OverridableBlockGridModel"/>
+        /// </summary>
+        /// <param name="publishedValueFallback">An <see cref="IPublishedValueFallback"/> to use when retrieving property values for the block grid items.</param>
+        /// <param name="blockGridItems">A block grid (typically a <see cref="BlockGridModel"/>).</param>
+        /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
+        /// <param name="publishedElementFactory">Factory method to create an <see cref="IPublishedElement"/> that supports overriding property values.</param>
+        public OverridableBlockGridModel(
+            IPublishedValueFallback publishedValueFallback,
+            IEnumerable<BlockGridItem> blockGridItems,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter = null,
+            Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
+            => Initialise(publishedValueFallback, blockGridItems, filter, publishedElementFactory);
+
+        private void Initialise(IPublishedValueFallback? publishedValueFallback, IEnumerable<BlockGridItem> blockGridItems, Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter, Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory)
         {
             if (blockGridItems is null)
             {
@@ -45,25 +74,32 @@ namespace ThePensionsRegulator.Umbraco.Blocks
             // Take the IEnumerable<BlockGridItem> (which is probably a BlockGridModel) and convert each item to an OverridableBlockGridItem,
             // and each nested block grid or block list to an OverridableBlockGridModel or OverridableBlockListModel
             // populated with OverridableBlockGridItems or OverridableBlockListItems.
-            foreach (var item in blockGridItems)
+            if (blockGridItems.Any())
             {
-                var overridableItem = item as OverridableBlockGridItem ?? new OverridableBlockGridItem(item, factory);
-                foreach (var property in overridableItem.Content.Properties)
+                publishedValueFallback = publishedValueFallback ?? StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>();
+
+                foreach (var item in blockGridItems)
                 {
-                    ConvertBlockModelPropertyToOverridable<BlockGridModel, OverridableBlockGridModel>(
-                        Constants.PropertyEditors.Aliases.BlockGrid,
-                        overridableItem,
-                        property,
-                        blockGrid => new OverridableBlockGridModel(blockGrid, BaseFilter, factory),
-                        () => new OverridableBlockGridModel(Array.Empty<BlockGridItem>(), BaseFilter, factory));
-                    ConvertBlockModelPropertyToOverridable<BlockListModel, OverridableBlockListModel>(
-                        Constants.PropertyEditors.Aliases.BlockList,
-                        overridableItem,
-                        property,
-                        blockList => new OverridableBlockListModel(blockList, BaseFilter, factory),
-                        () => new OverridableBlockListModel(Array.Empty<BlockListItem>(), BaseFilter, factory));
+                    var overridableItem = item as OverridableBlockGridItem ?? new OverridableBlockGridItem(item, factory);
+                    foreach (var property in overridableItem.Content.Properties)
+                    {
+                        ConvertBlockModelPropertyToOverridable<BlockGridModel, OverridableBlockGridModel>(
+                            publishedValueFallback,
+                            Constants.PropertyEditors.Aliases.BlockGrid,
+                            overridableItem,
+                            property,
+                            blockGrid => new OverridableBlockGridModel(publishedValueFallback, blockGrid, BaseFilter, factory),
+                            () => new OverridableBlockGridModel(publishedValueFallback, Array.Empty<BlockGridItem>(), BaseFilter, factory));
+                        ConvertBlockModelPropertyToOverridable<BlockListModel, OverridableBlockListModel>(
+                            publishedValueFallback,
+                            Constants.PropertyEditors.Aliases.BlockList,
+                            overridableItem,
+                            property,
+                            blockList => new OverridableBlockListModel(publishedValueFallback, blockList, BaseFilter, factory),
+                            () => new OverridableBlockListModel(publishedValueFallback, Array.Empty<BlockListItem>(), BaseFilter, factory));
+                    }
+                    Items.Add(overridableItem);
                 }
-                Items.Add(overridableItem);
             }
 
             CopyFilterToDescendantBlockLists(Items, BaseFilter);

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockGridPropertyValueConverter.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockGridPropertyValueConverter.cs
@@ -12,21 +12,16 @@ namespace ThePensionsRegulator.Umbraco.Blocks
     /// <summary>
     /// A property value converter which ensures that ModelsBuilder models represent a block grid as an <see cref="OverridableBlockGridModel" />.
     /// </summary>
-    public class OverridableBlockGridPropertyValueConverter : BlockGridPropertyValueConverter
+    public class OverridableBlockGridPropertyValueConverter(
+        IProfilingLogger _proflog,
+        BlockEditorConverter _blockConverter,
+        IJsonSerializer _jsonSerializer,
+        IEnumerable<IPropertyValueFormatter> _propertyValueFormatters,
+        IApiElementBuilder _apiElementBuilder,
+        BlockGridPropertyValueConstructorCache _constructorCache,
+        IPublishedValueFallback _publishedValueFallback)
+        : BlockGridPropertyValueConverter(_proflog, _blockConverter, _jsonSerializer, _apiElementBuilder, _constructorCache)
     {
-        private readonly IEnumerable<IPropertyValueFormatter> _propertyValueFormatters;
-
-        public OverridableBlockGridPropertyValueConverter(IProfilingLogger proflog,
-            BlockEditorConverter blockConverter,
-            IJsonSerializer jsonSerializer,
-            IEnumerable<IPropertyValueFormatter> propertyValueFormatters,
-            IApiElementBuilder apiElementBuilder,
-            BlockGridPropertyValueConstructorCache constructorCache)
-            : base(proflog, blockConverter, jsonSerializer, apiElementBuilder, constructorCache)
-        {
-            _propertyValueFormatters = propertyValueFormatters ?? throw new ArgumentNullException(nameof(propertyValueFormatters));
-        }
-
         /// <inheritdoc />
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
         {
@@ -38,7 +33,7 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
         {
             var baseModel = base.ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
-            return baseModel is BlockGridModel ? new OverridableBlockGridModel((BlockGridModel)baseModel) { PropertyValueFormatters = _propertyValueFormatters } : baseModel;
+            return baseModel is BlockGridModel ? new OverridableBlockGridModel(_publishedValueFallback, (BlockGridModel)baseModel) { PropertyValueFormatters = _propertyValueFormatters } : baseModel;
         }
 
         /// <inheritdoc />

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockListModel.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockListModel.cs
@@ -1,6 +1,8 @@
-﻿using System.ComponentModel;
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel;
 using ThePensionsRegulator.Umbraco.PropertyEditors;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -13,12 +15,19 @@ namespace ThePensionsRegulator.Umbraco.Blocks
     [TypeConverter(typeof(OverridableBlockListTypeConverter))]
     public class OverridableBlockListModel : OverridableBlockModel<OverridableBlockListItem>
     {
+        private IEnumerable<IPropertyValueFormatter>? _propertyValueFormatters;
+
         /// <summary>
         /// Creates a new <see cref="OverridableBlockListModel"/> with no items.
         /// </summary>
+        [Obsolete("Use a constructor which specifies an IPublishedValueFallback.")]
         public OverridableBlockListModel() : this(Array.Empty<BlockListItem>()) { }
 
-        private IEnumerable<IPropertyValueFormatter>? _propertyValueFormatters;
+        /// <summary>
+        /// Creates a new <see cref="OverridableBlockListModel"/> with no items.
+        /// </summary>
+        /// <param name="publishedValueFallback">An <see cref="IPublishedValueFallback"/> to use when retrieving property values for the block list items.</param>
+        public OverridableBlockListModel(IPublishedValueFallback publishedValueFallback) : this(publishedValueFallback, Array.Empty<BlockListItem>()) { }
 
         /// <summary>
         /// Creates a new <see cref="OverridableBlockListModel"/>
@@ -26,7 +35,29 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         /// <param name="blockListItems">A block list (typically a <see cref="BlockListModel"/>).</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <param name="publishedElementFactory">Factory method to create an <see cref="IPublishedElement"/> that supports overriding property values.</param>
-        public OverridableBlockListModel(IEnumerable<BlockListItem> blockListItems, Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter = null, Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
+        [Obsolete("Use a constructor which specifies an IPublishedValueFallback.")]
+        public OverridableBlockListModel(
+            IEnumerable<BlockListItem> blockListItems,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter = null,
+            Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
+            => Initialise(null, blockListItems, filter, publishedElementFactory);
+
+
+        /// <summary>
+        /// Creates a new <see cref="OverridableBlockListModel"/>
+        /// </summary>
+        /// <param name="publishedValueFallback">An <see cref="IPublishedValueFallback"/> to use when retrieving property values for the block list items.</param>
+        /// <param name="blockListItems">A block list (typically a <see cref="BlockListModel"/>).</param>
+        /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
+        /// <param name="publishedElementFactory">Factory method to create an <see cref="IPublishedElement"/> that supports overriding property values.</param>
+        public OverridableBlockListModel(
+            IPublishedValueFallback publishedValueFallback,
+            IEnumerable<BlockListItem> blockListItems,
+            Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter = null,
+            Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory = null)
+            => Initialise(publishedValueFallback, blockListItems, filter, publishedElementFactory);
+
+        private void Initialise(IPublishedValueFallback? publishedValueFallback, IEnumerable<BlockListItem> blockListItems, Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool>? filter, Func<IPublishedElement?, IOverridablePublishedElement?>? publishedElementFactory)
         {
             if (blockListItems is null)
             {
@@ -38,19 +69,25 @@ namespace ThePensionsRegulator.Umbraco.Blocks
 
             // Take the IEnumerable<BlockListItem> (which is probably a BlockListModel) and convert each item to an OverridableBlockListItem,
             // and each nested block list to an OverridableBlockListModel populated with OverridableBlockListItems.
-            foreach (var item in blockListItems)
+            if (blockListItems.Any())
             {
-                var overridableItem = item as OverridableBlockListItem ?? new OverridableBlockListItem(item, factory);
-                foreach (var property in overridableItem.Content.Properties)
+                publishedValueFallback = publishedValueFallback ?? StaticServiceProvider.Instance.GetRequiredService<IPublishedValueFallback>();
+
+                foreach (var item in blockListItems)
                 {
-                    ConvertBlockModelPropertyToOverridable<BlockListModel, OverridableBlockListModel>(
-                        Constants.PropertyEditors.Aliases.BlockList,
-                        overridableItem,
-                        property,
-                        blockList => new OverridableBlockListModel(blockList, BaseFilter, factory),
-                        () => new OverridableBlockListModel(Array.Empty<BlockListItem>(), BaseFilter, factory));
+                    var overridableItem = item as OverridableBlockListItem ?? new OverridableBlockListItem(item, factory);
+                    foreach (var property in overridableItem.Content.Properties)
+                    {
+                        ConvertBlockModelPropertyToOverridable<BlockListModel, OverridableBlockListModel>(
+                            publishedValueFallback,
+                            Constants.PropertyEditors.Aliases.BlockList,
+                            overridableItem,
+                            property,
+                            blockList => new OverridableBlockListModel(publishedValueFallback, blockList, BaseFilter, factory),
+                            () => new OverridableBlockListModel(publishedValueFallback, Array.Empty<BlockListItem>(), BaseFilter, factory));
+                    }
+                    Items.Add(overridableItem);
                 }
-                Items.Add(overridableItem);
             }
 
             CopyFilterToDescendantBlockLists(Items, BaseFilter);

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockListPropertyValueConverter.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockListPropertyValueConverter.cs
@@ -12,21 +12,16 @@ namespace ThePensionsRegulator.Umbraco.Blocks
     /// <summary>
     /// A property value converter which ensures that ModelsBuilder models represent a block list as an <see cref="OverridableBlockListModel" />.
     /// </summary>
-    public class OverridableBlockListPropertyValueConverter : BlockListPropertyValueConverter
+    public class OverridableBlockListPropertyValueConverter(
+        IProfilingLogger _proflog,
+        BlockEditorConverter _blockConverter,
+        IContentTypeService _contentTypeService,
+        IEnumerable<IPropertyValueFormatter> _propertyValueFormatters,
+        IApiElementBuilder _apiElementBuilder,
+        BlockListPropertyValueConstructorCache _constructorCache,
+        IPublishedValueFallback _publishedValueFallback)
+        : BlockListPropertyValueConverter(_proflog, _blockConverter, _contentTypeService, _apiElementBuilder, _constructorCache)
     {
-        private readonly IEnumerable<IPropertyValueFormatter> _propertyValueFormatters;
-
-        public OverridableBlockListPropertyValueConverter(IProfilingLogger proflog,
-            BlockEditorConverter blockConverter,
-            IContentTypeService contentTypeService,
-            IEnumerable<IPropertyValueFormatter> propertyValueFormatters,
-            IApiElementBuilder apiElementBuilder,
-            BlockListPropertyValueConstructorCache constructorCache)
-            : base(proflog, blockConverter, contentTypeService, apiElementBuilder, constructorCache)
-        {
-            _propertyValueFormatters = propertyValueFormatters ?? throw new ArgumentNullException(nameof(propertyValueFormatters));
-        }
-
         /// <inheritdoc />
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
         {
@@ -38,7 +33,7 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
         {
             var baseModel = base.ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
-            return baseModel is BlockListModel ? new OverridableBlockListModel((BlockListModel)baseModel) { PropertyValueFormatters = _propertyValueFormatters } : baseModel;
+            return baseModel is BlockListModel ? new OverridableBlockListModel(_publishedValueFallback, (BlockListModel)baseModel) { PropertyValueFormatters = _propertyValueFormatters } : baseModel;
         }
 
         /// <inheritdoc />

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModel.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModel.cs
@@ -11,6 +11,7 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         protected Func<IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>, bool> BaseFilter { get; set; } = DefaultFilter;
 
         protected void ConvertBlockModelPropertyToOverridable<TBaseModel, TOverridableModel>(
+            IPublishedValueFallback publishedValueFallback,
             string propertyEditorAlias,
             IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement> overridableItem,
             IPublishedProperty property,
@@ -19,11 +20,11 @@ namespace ThePensionsRegulator.Umbraco.Blocks
         {
             if (property.PropertyType.EditorAlias == propertyEditorAlias)
             {
-                var overriddenNestedBlockModel = overridableItem.Content.Value<TOverridableModel>(property.Alias);
+                var overriddenNestedBlockModel = overridableItem.Content.Value<TOverridableModel>(publishedValueFallback, property.Alias);
 
                 if (overriddenNestedBlockModel is null)
                 {
-                    var nestedBlockModel = overridableItem.Content.Value<TBaseModel>(property.Alias);
+                    var nestedBlockModel = overridableItem.Content.Value<TBaseModel>(publishedValueFallback, property.Alias);
                     if (nestedBlockModel is not null)
                     {
                         overriddenNestedBlockModel = baseToOverridableFactory(nestedBlockModel);

--- a/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModelExtensions.cs
+++ b/ThePensionsRegulator.Umbraco/Blocks/OverridableBlockModelExtensions.cs
@@ -312,6 +312,7 @@ namespace ThePensionsRegulator.Umbraco.Blocks
             }
 
             var matchedBlocks = new List<T>();
+            publishedValueFallback = publishedValueFallback ?? new NoopPublishedValueFallback();
 
             foreach (var block in blocks)
             {
@@ -327,8 +328,8 @@ namespace ThePensionsRegulator.Umbraco.Blocks
                     if (blockProperty.PropertyType.EditorAlias == Constants.PropertyEditors.Aliases.BlockList && blockProperty.HasValue())
                     {
                         var overridableBlock = block as IOverridableBlockReference<IOverridablePublishedElement, IOverridablePublishedElement>;
-                        IEnumerable<T>? childBlocks = (IEnumerable<T>?)(overridableBlock?.Content.Value<OverridableBlockListModel>(blockProperty.Alias));
-                        if (childBlocks is null) { childBlocks = (IEnumerable<T>?)blockProperty.Value<BlockListModel>(publishedValueFallback ?? new NoopPublishedValueFallback()); }
+                        IEnumerable<T>? childBlocks = (IEnumerable<T>?)(overridableBlock?.Content.Value<OverridableBlockListModel>(publishedValueFallback, blockProperty.Alias));
+                        if (childBlocks is null) { childBlocks = (IEnumerable<T>?)blockProperty.Value<BlockListModel>(publishedValueFallback); }
                         var result = RecursivelyFindBlocks(childBlocks!, matcher, returnFirstMatchOnly, publishedValueFallback);
                         if (result.Any())
                         {


### PR DESCRIPTION
Calling `.Value()` without specifying the `IPublishedValueFallback` leads to Umbraco using its `StaticServiceProvider` to get it. In unit testing this can lead to a race condition between tests, so we recommend to use the overload that specifies `IPublishedValueFallback`.

This PR refactors our existing code targeting v13 to use that, mostly in `OverridableBlockListModel` and `OverridableBlockGridModel` where `.Value()` is called in the base class.

[AB#269110](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/269110)