### PR TITLE
#269398 Accordion header sizing looks bigger than usual

### DIFF
--- a/ThePensionsRegulator.GovUk.Frontend/Styles/_govuk-accordion.scss
+++ b/ThePensionsRegulator.GovUk.Frontend/Styles/_govuk-accordion.scss
@@ -4,4 +4,8 @@
     .govuk-accordion__section-button {
         font-size: inherit;
     }
+
+    .govuk-accordion__section-heading {
+        font-size: inherit;
+    }
 }


### PR DESCRIPTION
In the Umbraco v17 version of the Accordion, one of our testers noted that the heading looked bigger than usual when running it's default settings - the default `<h2>` and `govuk-heading-m` displayed a heading text which looks closer to the size of `govuk-heading-l`. After I looked into it further I noticed that whatever govuk heading class was applied - the visible heading text would appear closer in size to the one above it (`govuk-heading-m` looked like `govuk-heading-l` and `govuk-heading-s` looked like `govuk-heading-m` etc...).

In this PR:
- Added `font-size: inherit;` to the `.govuk-accordion__section-heading` class, which makes the heading text look in the correct place for it's sizing when combined with pre-existing css.

This is related to the work item [AB#269398](https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/269398).