### PR TITLE
Reduce flaky tests by maintaining the same static service provider (v17)

### DIFF
--- a/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Moq;
 using System.Security.Claims;
 using System.Security.Principal;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using DI = Umbraco.Cms.Core.DependencyInjection;
 
 namespace ThePensionsRegulator.Umbraco.Testing.Tests
 {
@@ -125,6 +127,18 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
             testContext.Session.Object.Clear();
 
             Assert.Empty(testContext.Session.Object.Keys);
+        }
+
+        [Fact]
+        public void Does_not_replace_static_service_provider()
+        {
+            var originalProvider = Mock.Of<IServiceProvider>();
+
+            DI.StaticServiceProvider.Instance = originalProvider;
+
+            _ = new UmbracoTestContext();
+
+            Assert.Equal(originalProvider, DI.StaticServiceProvider.Instance);
         }
     }
 }

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
@@ -524,6 +524,26 @@ namespace ThePensionsRegulator.Umbraco.Testing
 
         private void SetupServices()
         {
+            // Umbraco falls back to the static service provider when services are not provided at the call site.
+            // Since there is only one static service provider shared by many tests, we have a choice of potential issues.
+
+            // If each instance of the test context replaces it the static service provider, we get a race condition where
+            // one test may replace the service provider while another test is using it, causing unpredictable results
+            // (usually services that aren't set up yet). 
+
+            // If we keep the instance set by the first test context to execute, then all subsequent test contexts will use
+            // the services set up by the first test context. If the tests do not do any custom setup on the services (either
+            // the first test or the currently executing test) then the tests will pass. However if a test relies on custom
+            // setup for a service and uses the static service provider to resolve it then it may display unpredicable
+            // behaviour depending on the order of test execution.
+
+            // The second approach is used because it causes fewer random test failures, but the only way to avoid test failures
+            // completely is to always provide service instances at the call site so that Umbraco does not fall back to the
+            // static service provider.
+            if (DI.StaticServiceProvider.Instance is null)
+            {
+                DI.StaticServiceProvider.Instance = ServiceProvider.Object;
+            }
             HttpContext.Setup(x => x.RequestServices).Returns(ServiceProvider.Object);
             SetupService(ApiElementBuilder.Object);
             SetupService(ApiRichTextElementParser.Object);


### PR DESCRIPTION
Umbraco falls back to the static service provider when services are not provided at the call site. Since there is only one static service provider shared by many tests, we have a choice of potential issues.

If each instance of the test context replaces it the static service provider, we get a race condition where one test may replace the service provider while another test is using it, causing unpredictable results (usually services that aren't set up yet). This is how our test library works today.

If we keep the instance set by the first test context to execute, then all subsequent test contexts will use the services set up by the first test context. If the tests do not do any custom setup on the services (either the first test or the currently executing test) then the tests will pass. However if a test relies on custom setup for a service and uses the static service provider to resolve it then it may display unpredictable behaviour depending on the order of test execution.

This PR switches to the second approach because it causes fewer random test failures. However it is still a race condition, and the only way to avoid test failures completely is to always provide service instances at the call site so that Umbraco does not fall back to the static service provider.

[AB#269110](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/269110)