### PR TITLE
Reduce flaky tests by using `IDisposable` and disabling parallel tests (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/AssemblyInfo.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInMultiUrlPickerPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInMultiUrlPickerPropertyValueFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using ThePensionsRegulator.Frontend.Services;
 using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
@@ -16,7 +16,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             var input = new Link { Url = "https://example.org" };
             var expected = "https://example.com";
 
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             var accessor = new Mock<IHttpContextAccessor>();
             accessor.Setup(x => x.HttpContext).Returns(context.HttpContext.Object);
 
@@ -42,7 +42,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             };
             var expected = "https://example.com";
 
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             var accessor = new Mock<IHttpContextAccessor>();
             accessor.Setup(x => x.HttpContext).Returns(context.HttpContext.Object);
 

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/HostNameInRichTextEditorPropertyValueFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using ThePensionsRegulator.Frontend.Services;
 using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
@@ -16,7 +16,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             const string INPUT = "<p><a href=\"https://example.org\">Example</a><a href=\"https://example.org\">Example</a></p>";
             const string EXPECTED = "<p><a href=\"https://example.com\">Example</a><a href=\"https://example.com\">Example</a></p>";
 
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             var accessor = new Mock<IHttpContextAccessor>();
             accessor.Setup(x => x.HttpContext).Returns(context.HttpContext.Object);
 
@@ -40,7 +40,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             // Arrange
             const string INPUT = "<p><a id='some-id'>Example</a></p>";
 
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             var accessor = new Mock<IHttpContextAccessor>();
             accessor.Setup(x => x.HttpContext).Returns(context.HttpContext.Object);
 
@@ -65,7 +65,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             // Arrange
             string INPUT = $"<p><a href='{hrefValue}'>Example</a></p>";
 
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             var accessor = new Mock<IHttpContextAccessor>();
             accessor.Setup(x => x.HttpContext).Returns(context.HttpContext.Object);
 

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprGlobalNavigationTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/TprGlobalNavigationTests.cs
@@ -9,15 +9,16 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
 {
-    public class TprGlobalNavigationTests
+    public class TprGlobalNavigationTests : IDisposable
     {
+        private readonly UmbracoTestContext _testContext;
         private Mock<IPublishedContent> _settingsNode;
         private TprGlobalNavigationService _sut;
         private TprHeaderMenuViewModel _menuViewModel;
 
         public TprGlobalNavigationTests()
         {
-            var testContext = new UmbracoTestContext();
+            _testContext = new UmbracoTestContext();
 
             var children = new List<TprHeaderMenuChildItem>
             {
@@ -80,6 +81,8 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
             //Arrange
             Assert.Empty(result);
         }
+
+        public void Dispose() => _testContext.Dispose();
 
         private OverridableBlockListItem CreateMenuBlock(string linkText, string linkUrl, List<TprHeaderMenuChildItem>? childItems = null)
         {

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/UmbracoSideNavigationLinksServiceTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Services/UmbracoSideNavigationLinksServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+using Moq;
 using ThePensionsRegulator.Frontend.Umbraco.Services;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Testing;
@@ -11,7 +11,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Returns_null_when_root_is_not_visible()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.Setup(x => x.Level).Returns(1);
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
             context.CurrentPage.SetupUmbracoBooleanPropertyValue("umbracoNaviHide", true);
@@ -29,7 +29,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Returns_title_link_based_on_root_node()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
 
             var root = UmbracoContentFactory.CreateContent<IPublishedContent>("page", "Root page");
             root.Setup(x => x.Level).Returns(1);
@@ -54,7 +54,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Title_link_is_current_page_when_current_page_is_root()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.Setup(x => x.Level).Returns(1);
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
             context.PublishedUrlProvider.Setup(x => x.GetUrl(context.CurrentPage.Object, UrlMode.Default, null)).Returns("/");
@@ -73,7 +73,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Title_link_is_not_current_page_when_current_page_is_a_child()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
 
             var root = UmbracoContentFactory.CreateContent<IPublishedContent>("page", "Root page");
             root.Setup(x => x.Level).Returns(1);
@@ -97,7 +97,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Returns_empty_navigation_links_when_root_has_no_children()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.Setup(x => x.Level).Returns(1);
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
             context.PublishedUrlProvider.Setup(x => x.GetUrl(context.CurrentPage.Object, UrlMode.Default, null)).Returns("/");
@@ -116,7 +116,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Returns_navigation_links_for_children_of_root()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.Setup(x => x.Level).Returns(1);
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
             context.PublishedUrlProvider.Setup(x => x.GetUrl(context.CurrentPage.Object, UrlMode.Default, null)).Returns("/");
@@ -149,7 +149,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Excludes_hidden_children_from_navigation_links()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.Setup(x => x.Level).Returns(1);
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
             context.PublishedUrlProvider.Setup(x => x.GetUrl(context.CurrentPage.Object, UrlMode.Default, null)).Returns("/");
@@ -179,7 +179,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Returns_nested_navigation_links()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.Setup(x => x.Level).Returns(1);
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
             context.PublishedUrlProvider.Setup(x => x.GetUrl(context.CurrentPage.Object, UrlMode.Default, null)).Returns("/");
@@ -212,7 +212,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Marks_current_page_in_navigation_links()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
 
             var root = UmbracoContentFactory.CreateContent<IPublishedContent>("page", "Root");
             root.Setup(x => x.Level).Returns(1);
@@ -240,7 +240,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Expands_ancestor_of_current_page_in_navigation_links()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
 
             var root = UmbracoContentFactory.CreateContent<IPublishedContent>("page", "Root");
             root.Setup(x => x.Level).Returns(1);
@@ -273,7 +273,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Does_not_expand_non_ancestor_of_current_page_in_navigation_links()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
 
             var root = UmbracoContentFactory.CreateContent<IPublishedContent>("page", "Root");
             root.Setup(x => x.Level).Returns(1);
@@ -305,7 +305,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Sets_parent_on_child_navigation_links()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.Setup(x => x.Level).Returns(1);
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
             context.PublishedUrlProvider.Setup(x => x.GetUrl(context.CurrentPage.Object, UrlMode.Default, null)).Returns("/");

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/AssemblyInfo.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Blocks/IOverridablePublishedElementExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         [InlineData(ElementTypeAliases.Radios, true)]
         public void OverrideCheckboxes_throws_ArgumentException_if_block_is_not_Checkboxes_component(string elementTypeAlias, bool exceptionExpected)
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             var content = UmbracoBlockListFactory.CreateContentOrSettings(elementTypeAlias);
 
             if (exceptionExpected)
@@ -35,7 +35,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         public void OverrideCheckboxes_replaces_checkboxes()
         {
             // Arrange
-            var testContext = new UmbracoTestContext()
+            using var testContext = new UmbracoTestContext()
                 .SetupContentType(ElementTypeAliases.Checkbox)
                 .SetupContentType(ElementTypeAliases.CheckboxesDivider)
                 .SetupContentType(ElementTypeAliases.CheckboxSettings);
@@ -95,7 +95,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         [InlineData(ElementTypeAliases.Radios, false)]
         public void OverrideRadioButtons_throws_ArgumentException_if_block_is_not_Radios_component(string elementTypeAlias, bool exceptionExpected)
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             var content = UmbracoBlockListFactory.CreateContentOrSettings(elementTypeAlias);
 
             if (exceptionExpected)
@@ -113,7 +113,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         public void OverrideRadioButtons_replaces_radio_buttons()
         {
             // Arrange
-            var testContext = new UmbracoTestContext()
+            using var testContext = new UmbracoTestContext()
                 .SetupContentType(ElementTypeAliases.Radio)
                 .SetupContentType(ElementTypeAliases.RadiosDivider)
                 .SetupContentType(ElementTypeAliases.RadioSettings);
@@ -172,7 +172,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         [InlineData(ElementTypeAliases.Radios, true)]
         public void OverrideSelectOptions_throws_ArgumentException_if_block_is_not_Select_component(string elementTypeAlias, bool exceptionExpected)
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             var content = UmbracoBlockListFactory.CreateContentOrSettings(elementTypeAlias);
 
             if (exceptionExpected)
@@ -190,7 +190,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         public void OverrideSelectOptions_replaces_options()
         {
             // Arrange
-            var testContext = new UmbracoTestContext()
+            using var testContext = new UmbracoTestContext()
                 .SetupContentType(ElementTypeAliases.SelectOption);
 
             var originalOptions = UmbracoBlockListFactory.CreateOverridableBlockListModel(new[]
@@ -237,7 +237,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         [InlineData(ElementTypeAliases.SummaryList, true)]
         public void OverrideSummaryCardActions_throws_ArgumentException_if_block_is_not_Summary_card_component(string elementTypeAlias, bool exceptionExpected)
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             var content = UmbracoBlockListFactory.CreateContentOrSettings(elementTypeAlias);
 
             if (exceptionExpected)
@@ -255,7 +255,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         public void OverrideSummaryCardActions_replaces_actions()
         {
             // Arrange
-            var testContext = new UmbracoTestContext()
+            using var testContext = new UmbracoTestContext()
                 .SetupContentType(ElementTypeAliases.SummaryListAction);
 
             var originalItems = UmbracoBlockListFactory.CreateOverridableBlockListModel(new[]
@@ -304,7 +304,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         [InlineData(ElementTypeAliases.Radios, true)]
         public void OverrideSummaryListItems_throws_ArgumentException_if_block_is_not_Summary_card_or_Summary_list_component(string elementTypeAlias, bool exceptionExpected)
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             var content = UmbracoBlockListFactory.CreateContentOrSettings(elementTypeAlias);
 
             if (exceptionExpected)
@@ -324,7 +324,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Blocks
         public void OverrideSummaryListItems_replaces_items(string componentAlias, string listItemsPropertyAlias)
         {
             // Arrange
-            var testContext = new UmbracoTestContext()
+            using var testContext = new UmbracoTestContext()
                 .SetupContentType(ElementTypeAliases.SummaryListItem)
                 .SetupContentType(ElementTypeAliases.SummaryListItemSettings)
                 .SetupContentType(ElementTypeAliases.SummaryListAction);

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Services/DefaultBreadcrumbLinksServiceTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Services/DefaultBreadcrumbLinksServiceTests.cs
@@ -11,7 +11,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Returns_empty_collection_when_a_page_has_no_parent()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
             context.CurrentPage.SetupAncestors(context.DocumentNavigationQueryService, context.PublishedContentStatusFilteringService, []);
 
             var service = new DefaultBreadcrumbLinksService(context.DocumentNavigationQueryService.Object, context.PublishedContentStatusFilteringService.Object);
@@ -25,7 +25,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Services
         [Fact]
         public void Returns_collection_based_on_ancestors_ordered_by_level()
         {
-            var context = new UmbracoTestContext();
+            using var context = new UmbracoTestContext();
 
             var greatGrandparent = UmbracoContentFactory.CreateContent<IPublishedContent>("example", "great grandparent");
             greatGrandparent.Setup(x => x.Level).Returns(1);

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/DependentFieldsActionFilterTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/Validation/DependentFieldsActionFilterTests.cs
@@ -22,7 +22,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
         public void Invalid_ModelState_remains_invalid_for_non_dependent_field()
         {
             // Arrange
-            UmbracoTestContext testContext = CreateTestContext();
+            using var testContext = CreateTestContext();
 
             testContext.CurrentPage.Object.SetupUmbracoBlockListPropertyValue("blocks", BlockListWithOneTextInput(DEPENDENT_MODEL_PROPERTY));
 
@@ -47,7 +47,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
         public void Invalid_ModelState_set_to_skipped_when_parent_field_is_invalid()
         {
             // Arrange
-            UmbracoTestContext testContext = CreateTestContext();
+            using var testContext = CreateTestContext();
 
             testContext.CurrentPage.Object.SetupUmbracoBlockListPropertyValue("blocks", BlockListWithRadiosWithOneDependentField());
 
@@ -72,7 +72,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
         public void Invalid_ModelState_set_to_skipped_when_parent_field_is_valid_but_parent_option_not_selected()
         {
             // Arrange
-            UmbracoTestContext testContext = CreateTestContext();
+            using var testContext = CreateTestContext();
 
             testContext.CurrentPage.Object.SetupUmbracoBlockListPropertyValue("blocks", BlockListWithRadiosWithOneDependentField());
 
@@ -98,7 +98,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.Validation
         public void Invalid_ModelState_remains_invalid_when_parent_field_is_valid_and_parent_option_selected()
         {
             // Arrange
-            UmbracoTestContext testContext = CreateTestContext();
+            using var testContext = CreateTestContext();
 
             testContext.CurrentPage.Object.SetupUmbracoBlockListPropertyValue("blocks", BlockListWithRadiosWithOneDependentField());
 

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Blocks/IOverridablePublishedElementExtensions.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Blocks/IOverridablePublishedElementExtensions.cs
@@ -20,7 +20,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedContentTypeCache">Accessor for the cache of content types.</param>
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideCheckboxes(
             this IOverridablePublishedElement blockContent,
             IEnumerable<CheckboxItemBase> items,
@@ -54,7 +53,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideCheckboxes(
             this IOverridablePublishedElement blockContent,
             IEnumerable<CheckboxItemBase> items,
@@ -124,7 +122,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedContentTypeCache">Accessor for the cache of content types.</param>
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent,
             IEnumerable<RadioItemBase> items,
             IPublishedContentTypeCache publishedContentTypeCache,
@@ -155,7 +152,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideRadioButtons(this IOverridablePublishedElement blockContent,
             IEnumerable<RadioItemBase> items,
             IPublishedContentTypeCache publishedContentTypeCache,
@@ -224,7 +220,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedContentTypeCache">Accessor for the cache of content types.</param>
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
             IEnumerable<SelectOption> items,
             IPublishedContentTypeCache publishedContentTypeCache,
@@ -255,7 +250,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSelectOptions(this IOverridablePublishedElement blockContent,
             IEnumerable<SelectOption> items,
             IPublishedContentTypeCache publishedContentTypeCache,
@@ -306,7 +300,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedContentTypeCache">Accessor for the cache of content types.</param>
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListAction> items,
             IPublishedContentTypeCache publishedContentTypeCache,
@@ -338,7 +331,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSummaryCardActions(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListAction> items,
             IPublishedContentTypeCache publishedContentTypeCache,
@@ -377,7 +369,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="publishedContentTypeCache">Accessor for the cache of content types.</param>
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListItem> items,
             IPublishedContentTypeCache publishedContentTypeCache,
@@ -409,7 +400,6 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks
         /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
         /// <param name="filter">The filter which will be applied to blocks when retrieved using <see cref="FilteredBlocks"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if any argument is <c>null</c>.</exception>
-        [Obsolete("Use an overload which specifies an IPublishedValueFallback.")]
         public static void OverrideSummaryListItems(this IOverridablePublishedElement blockContent,
             IEnumerable<SummaryListItem> items,
             IPublishedContentTypeCache publishedContentTypeCache,

--- a/ThePensionsRegulator.Umbraco.Core.Tests/AssemblyInfo.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockGridModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockGridModelTests.cs
@@ -8,11 +8,10 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace ThePensionsRegulator.Umbraco.Core.Tests.Blocks
 {
-    public class OverridableBlockGridModelTests
+    public class OverridableBlockGridModelTests(UmbracoTestContext _testContext) : IClassFixture<UmbracoTestContext>
     {
         private const string DOCUMENT_TYPE_ALIAS_CHILD_BLOCKS = "docTypeChildBlocks";
         private const string PROPERTY_ALIAS_CHILD_BLOCKS = "childBlocks";
-        private UmbracoTestContext _testContext = new();
 
         private static (OverridableBlockGridModel ParentBlockGrid, OverridableBlockListModel ChildBlockList, OverridableBlockListModel GrandChildBlockList) CreateOverridableBlockGridModelWithTwoNestedOverridableBlockLists()
         {

--- a/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockListModelTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockListModelTests.cs
@@ -8,11 +8,10 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace ThePensionsRegulator.Umbraco.Core.Tests.Blocks
 {
-    public class OverridableBlockListModelTests
+    public class OverridableBlockListModelTests(UmbracoTestContext _testContext) : IClassFixture<UmbracoTestContext>
     {
         private const string DOCUMENT_TYPE_ALIAS_CHILD_BLOCKS = "docTypeChildBlocks";
         private const string PROPERTY_ALIAS_CHILD_BLOCKS = "childBlocks";
-        private UmbracoTestContext _testContext = new();
 
         private static (OverridableBlockListModel ParentBlockList, OverridableBlockListModel ChildBlockList, OverridableBlockListModel GrandChildBlockList) CreateThreeNestedOverridableBlockLists()
         {

--- a/ThePensionsRegulator.Umbraco.Core.Tests/OverridablePublishedElementTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/OverridablePublishedElementTests.cs
@@ -4,16 +4,18 @@ using Umbraco.Cms.Core.Strings;
 
 namespace ThePensionsRegulator.Umbraco.Core.Tests
 {
-    public class OverridablePublishedElementTests
+    public class OverridablePublishedElementTests : IDisposable
     {
         private const string PROPERTY_ALIAS = "property";
         private const string ELEMENT_TYPE_ALIAS = "elementType";
+        private readonly UmbracoTestContext _testContext;
 
         public OverridablePublishedElementTests()
         {
-            var testContext = new UmbracoTestContext()
-                .SetupContentType(ELEMENT_TYPE_ALIAS);
+            _testContext = new UmbracoTestContext().SetupContentType(ELEMENT_TYPE_ALIAS);
         }
+
+        public void Dispose() => _testContext.Dispose();
 
         [Fact]
         public void OverrideValue_works_for_HtmlEncodedString()

--- a/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverterTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverterTests.cs
@@ -16,14 +16,13 @@ using Umbraco.Cms.Core.Templates;
 
 namespace ThePensionsRegulator.Umbraco.Core.Tests.PropertyEditors.ValueConverters
 {
-    
     public class RichTextEditorPropertyValueConverterTests
     {
         [Fact]
         public void Applies_PropertyValueFormatters()
         {
             // Arrange
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             var propertyType = UmbracoPropertyFactory.CreateRichTextProperty("myAlias", "contentTypeAlias", new HtmlEncodedString(string.Empty)).PropertyType;
             var urlProvider = testContext.PublishedUrlProvider.Object;
 

--- a/ThePensionsRegulator.Umbraco.Testing.Tests/AssemblyInfo.cs
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoPublishedElementExtensionsTests.cs
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoPublishedElementExtensionsTests.cs
@@ -8,11 +8,10 @@ using Umbraco.Extensions;
 
 namespace ThePensionsRegulator.Umbraco.Testing.Tests
 {
-    public class UmbracoPublishedElementExtensionsTests
+    public class UmbracoPublishedElementExtensionsTests(UmbracoTestContext _testContext) : IClassFixture<UmbracoTestContext>
     {
         private const string PAGE_ALIAS = "myPage";
         private const string PROPERTY_ALIAS = "myProperty";
-        private UmbracoTestContext _testContext = new();
 
         private void TestSetupUmbracoTypedPropertyValue<TContentType, TValue>(Func<TValue> createPropertyValue, Action<TContentType, string, TValue> act, string expectedPropertyEditorAlias)
             where TContentType : class, IPublishedElement

--- a/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/UmbracoTestContextTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 using System.Security.Principal;
@@ -12,7 +12,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         public void Can_add_content_type()
         {
             // Arrange
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             const string contentTypeAlias = "MyContentType2";
 
             // Act
@@ -31,7 +31,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void Can_mock_authenticated_HttpContext_User()
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
 
             testContext.CurrentIdentity.Setup(x => x.IsAuthenticated).Returns(true);
 
@@ -41,7 +41,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void Can_mock_authenticated_HttpContext_User_with_claims()
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
 
             var identity = new ClaimsIdentity(new Claim[] { new Claim("type1", "value1"), new Claim("type2", "value2") }, "any string makes IsAuthenticated return true");
             testContext.CurrentPrincipal = new GenericPrincipal(identity, Array.Empty<string>());
@@ -57,7 +57,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void Can_call_claims_from_controller()
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
 
             var identity = new ClaimsIdentity(new Claim[] { new Claim("type1", "value1"), new Claim("type2", "value2") }, "any string makes IsAuthenticated return true");
             testContext.CurrentPrincipal = new GenericPrincipal(identity, Array.Empty<string>());
@@ -75,7 +75,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void Can_set_and_get_session_data()
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             const string key = "test";
             const string data = "hello world";
 
@@ -90,7 +90,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void Key_not_in_session_returns_null()
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             const string key = "test";
 
             Assert.DoesNotContain(key, testContext.Session.Object.Keys);
@@ -102,7 +102,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void Can_remove_session_data()
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             const string key = "test";
             const string data = "hello world";
 
@@ -115,7 +115,7 @@ namespace ThePensionsRegulator.Umbraco.Testing.Tests
         [Fact]
         public void Can_clear_session_data()
         {
-            var testContext = new UmbracoTestContext();
+            using var testContext = new UmbracoTestContext();
             const string key1 = "test1";
             const string key2 = "test2";
             const string data = "hello world";

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
@@ -40,11 +40,39 @@ using DI = Umbraco.Cms.Core.DependencyInjection;
 namespace ThePensionsRegulator.Umbraco.Testing
 {
     /// <summary>
-    /// A mock Umbraco environment with a current page request
+    /// A mock Umbraco environment with a current page request.
     /// </summary>
-    public class UmbracoTestContext
+    /// <remarks>
+    /// <para>
+    /// <see cref="UmbracoTestContext"/> writes to the process-wide static
+    /// <see cref="Umbraco.Cms.Core.DependencyInjection.StaticServiceProvider.Instance"/> on construction and
+    /// restores the previous value on <see cref="Dispose"/>. Because this state is shared across all threads,
+    /// two rules must be followed to avoid flaky tests:
+    /// </para>
+    /// <list type="number">
+    ///   <item>
+    ///     <description>
+    ///       Always dispose the context after use. In xUnit use <c>using var ctx = new UmbracoTestContext()</c>
+    ///       for test-level contexts, or implement <c>IClassFixture&lt;UmbracoTestContext&gt;</c> for
+    ///       class-level contexts. In NUnit use <c>using var ctx = new UmbracoTestContext()</c> for test-level
+    ///       contexts, or <c>[OneTimeSetUp]</c>/<c>[OneTimeTearDown]</c> with an explicit <c>Dispose()</c> call
+    ///       for class-level contexts.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///       Prevent parallel execution between test classes that use this type. In xUnit add an
+    ///       <c>AssemblyInfo.cs</c> file containing
+    ///       <c>[assembly: CollectionBehavior(DisableTestParallelization = true)]</c> to each test project.
+    ///       In NUnit apply <c>[NonParallelizable]</c> to every such test fixture.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    public class UmbracoTestContext : IDisposable
     {
         private const string TEMPLATE_NAME = "MockTemplate";
+        private IServiceProvider? _previousStaticServiceProvider;
         private ClaimsPrincipal _currentPrincipal;
         private UmbracoHelper _umbracoHelper;
         private DistributedSession _sessionState = new(new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())), Guid.NewGuid().ToString(), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30), () => true, Mock.Of<ILoggerFactory>(), true);
@@ -586,6 +614,13 @@ namespace ThePensionsRegulator.Umbraco.Testing
             SetupService(UserService.Object);
             SetupService(VariationContextAccessor.Object);
             SetupService(Options.Create(WebRoutingSettings));
+
+            // Each test context saves the previous static provider and unconditionally replaces it, then restores it on
+            // Dispose(). Callers should use 'using var ctx = new UmbracoTestContext()' (or IClassFixture<T> in xUnit)
+            // so the provider is always restored after each test. Test classes that share this static state must also
+            // be serialised (xUnit [Collection], NUnit [NonParallelizable]) to prevent mid-test overwrites from
+            // parallel threads.
+            _previousStaticServiceProvider = DI.StaticServiceProvider.Instance;
             DI.StaticServiceProvider.Instance = ServiceProvider.Object;
         }
 
@@ -646,6 +681,11 @@ namespace ThePensionsRegulator.Umbraco.Testing
             PublishedContentTypeCache.Setup(x => x.Get(publishedItemType, contentTypeAlias)).Returns(ContentTypes[contentTypeAlias].Object);
 
             return this;
+        }
+
+        public void Dispose()
+        {
+            DI.StaticServiceProvider.Instance = _previousStaticServiceProvider!;
         }
     }
 }

--- a/docs/umbraco/unit-testing.md
+++ b/docs/umbraco/unit-testing.md
@@ -2,30 +2,122 @@
 
 Add `ThePensionsRegulator.Umbraco.Testing` NuGet package.
 
-Examples on this page are shown with XUnit, but these helper classes should work with any testing framework. However [Moq](https://github.com/moq/moq4) is required for mocking with these helper classes.
+Most examples on this page are shown with XUnit, but these helper classes should work with any testing framework. However [Moq](https://github.com/moq/moq4) is required for mocking with these helper classes.
 
 ## Create an Umbraco context
 
-Create an instance of `UmbracoTestContext` in your setup method. This will give you access to an Umbraco context that mocks a page request.
+Create an instance of `UmbracoTestContext` to get access to a mock Umbraco page request. Because `UmbracoTestContext` writes to a process-wide static field it **must always be disposed** and test classes that use it **must not run in parallel** with each other. See [Avoiding flaky tests](#avoiding-flaky-tests) for details.
+
+### One context per test
+
+Use `using var` so the context is disposed automatically at the end of the test. You can customise the context mocks with no side-effects.
 
 ```csharp
-using ThePensionsRegulator.Umbraco.Testing;
-
-private UmbracoTestContext _testContext;
-private ExampleController _controllerUnderTest;
-
-public MyTestClass()
+[Fact]
+public void My_test()
 {
-    _testContext = new();
+    using var testContext = new UmbracoTestContext();
 
-    _controllerUnderTest = new(
+    var controller = new ExampleController(
         Mock.Of<ILogger<ExampleController>>(),
-        _testContext.CompositeViewEngine.Object,
-        _testContext.UmbracoContextAccessor.Object
-        )
+        testContext.CompositeViewEngine.Object,
+        testContext.UmbracoContextAccessor.Object,
+        testContext.VariationContextAccessor.Object,
+        testContext.ServiceContext)
     {
-        ControllerContext = _testContext.ControllerContext
+        ControllerContext = testContext.ControllerContext
     };
+}
+```
+
+### One context per test, with setup (xUnit)
+
+If all tests in the class need the same setup (for example a `SetupContentType` call), implement `IDisposable` and create the context in the constructor. xUnit creates a new instance of the test class per test, so `Dispose` is called after each test:
+
+```csharp
+public class ExampleTests : IDisposable
+{
+    private readonly UmbracoTestContext _testContext;
+
+    public ExampleTests()
+    {
+        _testContext = new UmbracoTestContext().SetupContentType("myContentTypeAlias");
+    }
+
+    public void Dispose() => _testContext.Dispose();
+
+    [Fact]
+    public void My_test()
+    {
+        var element = UmbracoContentFactory.CreateContent<IPublishedElement>("myContentTypeAlias");
+    }
+}
+```
+
+### One context per test, with setup (NUnit)
+
+If all tests in the class need the same setup (for example a `SetupContentType` call), use `[SetUp]` and `[TearDown]`. NUnit calls these before and after each individual test:
+
+```csharp
+[TestFixture]
+[NonParallelizable]
+public class ExampleTests
+{
+    private UmbracoTestContext _testContext;
+
+    [SetUp]
+    public void SetUp() => _testContext = new UmbracoTestContext().SetupContentType("myContentTypeAlias");
+
+    [TearDown]
+    public void TearDown() => _testContext.Dispose();
+
+    [Test]
+    public void My_test()
+    {
+        var element = UmbracoContentFactory.CreateContent<IPublishedElement>("myContentTypeAlias");
+    }
+}
+```
+
+### One context per class (xUnit)
+
+Implement `IClassFixture<UmbracoTestContext>`. xUnit creates one instance for the class and disposes it after all tests have run:
+
+```csharp
+public class ExampleTests(UmbracoTestContext _testContext) : IClassFixture<UmbracoTestContext>
+{
+    [Fact]
+    public void My_test()
+    {
+        var controller = new ExampleController(
+            Mock.Of<ILogger<ExampleController>>(),
+            _testContext.CompositeViewEngine.Object,
+            _testContext.UmbracoContextAccessor.Object,
+            _testContext.VariationContextAccessor.Object,
+            _testContext.ServiceContext)
+        {
+            ControllerContext = _testContext.ControllerContext
+        };
+    }
+}
+```
+
+### One context per class (NUnit)
+
+Use `[OneTimeSetUp]` and `[OneTimeTearDown]`:
+
+```csharp
+[TestFixture]
+[NonParallelizable]
+public class ExampleTests
+{
+    private UmbracoTestContext _testContext;
+
+    [OneTimeSetUp]
+    public void SetUp() => _testContext = new UmbracoTestContext();
+
+    [OneTimeTearDown]
+    public void TearDown() => _testContext.Dispose();
 }
 ```
 
@@ -237,10 +329,33 @@ UmbracoContentFactory.CreateContent<IPublishedElement>();
 UmbracoContentFactory.CreateContent<IOverridablePublishedElement>();
 ```
 
-### Tests pass on their own but fail when others are run
+## Avoiding flaky tests
 
-Umbraco uses internally a static service locator at `Umbraco.Cms.Core.DependencyInjection.StaticServiceProvider.Instance`.
+`UmbracoTestContext` sets `Umbraco.Cms.Core.DependencyInjection.StaticServiceProvider.Instance` — a single static field shared by every thread in the process. Two things can go wrong if this is not managed carefully:
 
-`UmbracoTestContext` registers implementations with this service locator to support Umbraco methods that expect it. However, because it's static, this instance is shared across all tests in a run. In some cases this is fine, but in cases where you update the mocks this can cause problems in other tests.
+- **Stale provider after a test** — if the context is not disposed the static field retains its value and the next test may resolve services from the wrong context.
+- **Mid-test overwrite** — if two test classes run in parallel on different threads, one thread can overwrite the static field while the other thread's test is still using it.
+
+`UmbracoTestContext` addresses the first problem by implementing `IDisposable`: construction saves the current value of the static field and `Dispose` restores it. The second problem requires serialising test execution so that only one test class that uses `UmbracoTestContext` runs at a time.
+
+### xUnit
+
+Add an `AssemblyInfo.cs` file to each xUnit test project that contains tests using `UmbracoTestContext`:
+
+```csharp
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+```
+
+This prevents all test classes within the assembly from running in parallel with each other, which is sufficient to protect the static field.
+
+### NUnit
+
+Apply `[NonParallelizable]` to every `[TestFixture]` that uses `UmbracoTestContext`.
+
+### Resolving flaky tests when multiple test projects are run together
+
+After disabling parallel tests as described above the remaining risk is cross-assembly: `dotnet test` runs multiple test projects in parallel by default, and the configuration above has no effect on that. `IDisposable` on `UmbracoTestContext` minimises the window during which that cross-assembly race can occur.
 
 The best solution is to look into the Umbraco code to find out which services are using the static service locator, and then look for overloads that avoid it. For example `IPublishedContent.Parent()` uses the static service locator and is difficult to test, but `IPublishedContent.Parent<T>(IDocumentNavigationQueryService, IPublishedContentStatusFilteringService)` does not and can be tested.


### PR DESCRIPTION
Umbraco falls back to the static service provider when services are not provided at the call site. When each instance of the test context replaces the static service provider we get a race condition where one test may replace the service provider while another test is using it, causing unpredictable results (usually services that aren't set up yet). This is how our test library works today.

Following some AI analysis this PR now proposes a new approach which properly fixes the problem.

- Tests using `UmbracoTestContext` have parallel execution disabled. This is done by using an assembly attribute in XUnit. This mostly fixes the main cause of the flaky test problem we've seen, but would have to be implemented by consuming projects. The code here serves as an example. However flakiness between test projects executing in parallel is still possible.

- `UmbracoTestContext` now implements `IDisposable` which restores the state of the static service provider. This means a test which relies on the static service provider but does not create an UmbracoTestContext does not accidentally pass due to setup done in another test. This also reduces the time window for flakiness between test projects executing in parallel.

Methods marked [Obsolete] in a previous PR are no longer marked as [Obsolete] because they're now much less likely to cause a problem, given recommended use of UmbracoTestContext.

[AB#269110](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/269110)