### PR TITLE
Simplify unit testing guidance (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
@@ -59,72 +59,121 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.2.0.tgz",
-      "integrity": "sha512-c7VjBy/8ed0EVLNgaeS9Xxams1Tuv/WK/b4xXH3Qr4wjzYeJUtxOcoP8YdwNLavqKP8pGiuctjX2Z1Pwc4jMgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=22.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/hey-api"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.5.3"
-      }
-    },
-    "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.2.0.tgz",
-      "integrity": "sha512-BMnIuhVgNmSudadw1GcTsP18Yk5l8FrYrg/OSYNxz0D2E0vf4D5e4j5nUbuY8MU6p1vp7ev0xrfP6A/NWazkzQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21"
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "c12": "3.3.4",
+        "color-support": "1.1.3"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/json-schema-ref-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3",
+        "@types/json-schema": "7.0.15",
+        "js-yaml": "4.2.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.85.2.tgz",
-      "integrity": "sha512-pNu+DOtjeXiGhMqSQ/mYadh6BuKR/QiucVunyA2P7w2uyxkfCJ9sHS20Y72KHXzB3nshKJ9r7JMirysoa50SJg==",
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "^0.2.0",
-        "@hey-api/json-schema-ref-parser": "1.2.0",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
         "ansi-colors": "4.1.3",
-        "c12": "3.3.0",
         "color-support": "1.1.3",
-        "commander": "13.0.0",
-        "handlebars": "4.7.8",
-        "open": "10.1.2",
-        "semver": "7.7.2"
+        "commander": "15.0.0",
+        "get-tsconfig": "4.14.0"
       },
       "bin": {
-        "openapi-ts": "bin/index.cjs"
+        "openapi-ts": "bin/run.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       },
       "peerDependencies": {
-        "typescript": ">=5.5.3"
+        "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc"
       }
+    },
+    "node_modules/@hey-api/shared": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "cross-spawn": "7.0.6",
+        "open": "11.0.0",
+        "semver": "7.8.4"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/spec-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/types": "0.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/types": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
@@ -151,6 +200,17 @@
       "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@microsoft/signalr": {
@@ -2290,28 +2350,28 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.0.tgz",
-      "integrity": "sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^17.2.2",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.5.1",
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
+        "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2"
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
-        "magicast": "^0.3.5"
+        "magicast": "*"
       },
       "peerDependenciesMeta": {
         "magicast": {
@@ -2320,31 +2380,20 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "consola": "^3.2.3"
       }
     },
     "node_modules/color-support": {
@@ -2367,14 +2416,14 @@
       "peer": true
     },
     "node_modules/commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/confbox": {
@@ -2385,17 +2434,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -2403,6 +2441,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -2499,9 +2553,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -2571,9 +2625,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2623,46 +2677,29 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
+        "resolve-pkg-maps": "^1.0.0"
       },
-      "bin": {
-        "giget": "dist/cli.mjs"
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+    "node_modules/giget": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
       "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/is-docker": {
@@ -2677,6 +2714,20 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2719,6 +2770,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2731,9 +2790,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -3081,14 +3140,6 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -3151,17 +3202,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -3207,14 +3247,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -3237,41 +3269,6 @@
         }
       }
     },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "citty": "^0.2.0",
-        "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -3281,20 +3278,22 @@
       "peer": true
     },
     "node_modules/open": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3307,6 +3306,17 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3345,15 +3355,15 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -3384,6 +3394,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prosemirror-changeset": {
@@ -3662,26 +3686,26 @@
       "peer": true
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -3695,6 +3719,17 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
     },
     "node_modules/rolldown": {
       "version": "1.0.3",
@@ -3764,9 +3799,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -3785,15 +3820,29 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -3804,17 +3853,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -3887,21 +3925,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -4047,13 +4070,22 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/ws": {
       "version": "7.5.11",
@@ -4076,6 +4108,24 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
@@ -59,72 +59,121 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.2.0.tgz",
-      "integrity": "sha512-c7VjBy/8ed0EVLNgaeS9Xxams1Tuv/WK/b4xXH3Qr4wjzYeJUtxOcoP8YdwNLavqKP8pGiuctjX2Z1Pwc4jMgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=22.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/hey-api"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.5.3"
-      }
-    },
-    "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.2.0.tgz",
-      "integrity": "sha512-BMnIuhVgNmSudadw1GcTsP18Yk5l8FrYrg/OSYNxz0D2E0vf4D5e4j5nUbuY8MU6p1vp7ev0xrfP6A/NWazkzQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21"
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "c12": "3.3.4",
+        "color-support": "1.1.3"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/json-schema-ref-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3",
+        "@types/json-schema": "7.0.15",
+        "js-yaml": "4.2.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.85.2.tgz",
-      "integrity": "sha512-pNu+DOtjeXiGhMqSQ/mYadh6BuKR/QiucVunyA2P7w2uyxkfCJ9sHS20Y72KHXzB3nshKJ9r7JMirysoa50SJg==",
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "^0.2.0",
-        "@hey-api/json-schema-ref-parser": "1.2.0",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
         "ansi-colors": "4.1.3",
-        "c12": "3.3.0",
         "color-support": "1.1.3",
-        "commander": "13.0.0",
-        "handlebars": "4.7.8",
-        "open": "10.1.2",
-        "semver": "7.7.2"
+        "commander": "15.0.0",
+        "get-tsconfig": "4.14.0"
       },
       "bin": {
-        "openapi-ts": "bin/index.cjs"
+        "openapi-ts": "bin/run.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       },
       "peerDependencies": {
-        "typescript": ">=5.5.3"
+        "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc"
       }
+    },
+    "node_modules/@hey-api/shared": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "cross-spawn": "7.0.6",
+        "open": "11.0.0",
+        "semver": "7.8.4"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/spec-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/types": "0.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/types": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
@@ -151,6 +200,17 @@
       "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@microsoft/signalr": {
@@ -2290,28 +2350,28 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.0.tgz",
-      "integrity": "sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^17.2.2",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.5.1",
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
+        "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2"
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
-        "magicast": "^0.3.5"
+        "magicast": "*"
       },
       "peerDependenciesMeta": {
         "magicast": {
@@ -2320,31 +2380,20 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "consola": "^3.2.3"
       }
     },
     "node_modules/color-support": {
@@ -2367,14 +2416,14 @@
       "peer": true
     },
     "node_modules/commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/confbox": {
@@ -2385,17 +2434,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -2403,6 +2441,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -2499,9 +2553,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -2571,9 +2625,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2623,46 +2677,29 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
+        "resolve-pkg-maps": "^1.0.0"
       },
-      "bin": {
-        "giget": "dist/cli.mjs"
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+    "node_modules/giget": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
       "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/is-docker": {
@@ -2677,6 +2714,20 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2719,6 +2770,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2731,9 +2790,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -3081,14 +3140,6 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -3151,17 +3202,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -3207,14 +3247,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -3237,41 +3269,6 @@
         }
       }
     },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "citty": "^0.2.0",
-        "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -3281,20 +3278,22 @@
       "peer": true
     },
     "node_modules/open": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3307,6 +3306,17 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3345,15 +3355,15 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -3384,6 +3394,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prosemirror-changeset": {
@@ -3662,26 +3686,26 @@
       "peer": true
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -3695,6 +3719,17 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
     },
     "node_modules/rolldown": {
       "version": "1.0.3",
@@ -3764,9 +3799,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -3785,15 +3820,29 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -3804,17 +3853,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -3887,21 +3925,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -4047,13 +4070,22 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/ws": {
       "version": "7.5.11",
@@ -4076,6 +4108,24 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/docs/umbraco/unit-testing.md
+++ b/docs/umbraco/unit-testing.md
@@ -6,9 +6,9 @@ Most examples on this page are shown with XUnit, but these helper classes should
 
 ## Create an Umbraco context
 
-Create an instance of `UmbracoTestContext` to get access to a mock Umbraco page request. Because `UmbracoTestContext` writes to a process-wide static field it **must always be disposed** and test classes that use it **must not run in parallel** with each other. See [Avoiding flaky tests](#avoiding-flaky-tests) for details.
+Create an instance of `UmbracoTestContext` for each test to get access to a mock Umbraco page request. Because `UmbracoTestContext` writes to a process-wide static field it **must always be disposed** and test classes that use it **must not run in parallel** with each other. See [Avoiding flaky tests](#avoiding-flaky-tests) for details.
 
-### One context per test
+### Create and dispose a context in each test (xUnit)
 
 Use `using var` so the context is disposed automatically at the end of the test. You can customise the context mocks with no side-effects.
 
@@ -30,7 +30,7 @@ public void My_test()
 }
 ```
 
-### One context per test, with setup (xUnit)
+### Create and dispose the test class (xUnit)
 
 If all tests in the class need the same setup (for example a `SetupContentType` call), implement `IDisposable` and create the context in the constructor. xUnit creates a new instance of the test class per test, so `Dispose` is called after each test:
 
@@ -54,7 +54,7 @@ public class ExampleTests : IDisposable
 }
 ```
 
-### One context per test, with setup (NUnit)
+### Create and dispose the context using [SetUp] and [TearDown] (NUnit)
 
 If all tests in the class need the same setup (for example a `SetupContentType` call), use `[SetUp]` and `[TearDown]`. NUnit calls these before and after each individual test:
 
@@ -76,48 +76,6 @@ public class ExampleTests
     {
         var element = UmbracoContentFactory.CreateContent<IPublishedElement>("myContentTypeAlias");
     }
-}
-```
-
-### One context per class (xUnit)
-
-Implement `IClassFixture<UmbracoTestContext>`. xUnit creates one instance for the class and disposes it after all tests have run:
-
-```csharp
-public class ExampleTests(UmbracoTestContext _testContext) : IClassFixture<UmbracoTestContext>
-{
-    [Fact]
-    public void My_test()
-    {
-        var controller = new ExampleController(
-            Mock.Of<ILogger<ExampleController>>(),
-            _testContext.CompositeViewEngine.Object,
-            _testContext.UmbracoContextAccessor.Object,
-            _testContext.VariationContextAccessor.Object,
-            _testContext.ServiceContext)
-        {
-            ControllerContext = _testContext.ControllerContext
-        };
-    }
-}
-```
-
-### One context per class (NUnit)
-
-Use `[OneTimeSetUp]` and `[OneTimeTearDown]`:
-
-```csharp
-[TestFixture]
-[NonParallelizable]
-public class ExampleTests
-{
-    private UmbracoTestContext _testContext;
-
-    [OneTimeSetUp]
-    public void SetUp() => _testContext = new UmbracoTestContext();
-
-    [OneTimeTearDown]
-    public void TearDown() => _testContext.Dispose();
 }
 ```
 


### PR DESCRIPTION
There isn't really a use case for one `UmbracoTestContext` per class, so remove that from the documentation for v17.

 [AB#269110](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/269110)