### PR TITLE
#264550 - Move table CSV download text to meta tag

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.0.3</Version>
+    <Version>10.0.4</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/GovUk.Frontend.ExampleApp/Views/Table/Index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/Table/Index.cshtml
@@ -17,8 +17,7 @@
     <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
             A CSV download button is automatically added below each <code>.govuk-table</code> element on the page.
-            The button text can be customised using a <code>data-tpr-table-csv-download-text</code> attribute on
-            the <code>&lt;body&gt;</code> element.
+            The button text can be customised by passing it to the <code>TPR/BodyClosing</code> partial.
         </p>
 
         <table class="govuk-table govuk-table--tpr-default">

--- a/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml
@@ -58,7 +58,7 @@
     @RenderSection("head", required: false)
 </head>
 
-<body class="govuk-template__body" data-tpr-table-csv-download-text="@(Umbraco.GetDictionaryValue("Table CSV Download Button Text"))">
+<body class="govuk-template__body">
     <partial name="GOVUK/BodyOpen" />
     <partial name="TPR/TPRHeaderLockup" model="headerLockup" />
     <div class="tpr-main-wrapper">
@@ -96,7 +96,7 @@
     {
         <partial name="TPR/TPRFooterLockup" model="footerLockup" />
     }
-    <partial name="TPR/BodyClosing" />
+    <partial name="TPR/BodyClosing" model="@(Umbraco.GetDictionaryValue("Table CSV Download Button Text"))" />
     @RenderSection("scripts", required: false)
 </body>
 </html>

--- a/ThePensionsRegulator.Frontend/TprFrontendOptions.cs
+++ b/ThePensionsRegulator.Frontend/TprFrontendOptions.cs
@@ -6,8 +6,8 @@
 
         /// <summary>
         /// Enable a CSV download button below each .govuk-table element on the page.
-        /// The button text defaults to "Download table data (CSV)" but can be customised by adding
-        /// a data-tpr-table-csv-download-text attribute to the &lt;body&gt; element.
+        /// The button text defaults to "Download table data (CSV)" but can be customised by passing
+        /// a custom text string to the TPR/BodyClosing partial.
         /// Tables with merged cells (colspan or rowspan) are skipped.
         /// </summary>
         public bool EnableTableCsvDownload { get; set; }

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml
@@ -2,9 +2,16 @@
 @using Microsoft.Extensions.Options
 @inject IOptions<TprFrontendOptions> tprOptions
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    var tableCSVDownloadText = Model as string;
+}
 <partial name="GOVUK/BodyClosing" />
 <script src="/ThePensionsRegulator.Frontend/js/tpr-back-to-top.min.js" type="module" asp-append-version="true"></script>
 @if (tprOptions.Value.EnableTableCsvDownload)
 {
+    @if (!string.IsNullOrEmpty(tableCSVDownloadText))
+    {
+        <meta name="tpr-table-csv-download-text" content="@tableCSVDownloadText" />
+    }
     <script src="/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.min.js" type="module" asp-append-version="true"></script>
 }

--- a/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
@@ -4,21 +4,35 @@ import { getButtonText, sanitizeFileName, getCellText, escapeCsvValue, hasMerged
 
 beforeEach(() => {
     document.body.innerHTML = "";
-    document.body.removeAttribute("data-tpr-table-csv-download-text");
+    document.head.innerHTML = "";
 });
 
+function setTableCsvDownloadText(text) {
+    let meta = document.querySelector('meta[name="tpr-table-csv-download-text"]');
+    if (!meta) {
+        meta = document.createElement('meta');
+        meta.setAttribute('name', 'tpr-table-csv-download-text');
+        document.head.appendChild(meta);
+    }
+    if (text) {
+        meta.setAttribute('content', text);
+    } else {
+        meta.setAttribute('content', '');
+    }
+}
+
 describe("getButtonText", () => {
-    test("returns default text when no data attribute is set", () => {
+    test("returns default text when no meta tag is set", () => {
         expect(getButtonText()).toBe("Download table data (CSV)");
     });
 
-    test("returns custom text from body data attribute", () => {
-        document.body.setAttribute("data-tpr-table-csv-download-text", "Custom download");
+    test("returns custom text from meta tag", () => {
+        setTableCsvDownloadText("Custom download");
         expect(getButtonText()).toBe("Custom download");
     });
 
-    test("returns default text when data attribute is empty", () => {
-        document.body.setAttribute("data-tpr-table-csv-download-text", "");
+    test("returns default text when meta tag is empty", () => {
+        setTableCsvDownloadText("");
         expect(getButtonText()).toBe("Download table data (CSV)");
     });
 });
@@ -292,20 +306,19 @@ describe("initTableCsvDownload", () => {
         expect(document.querySelector('button[data-tpr-table-csv-button="true"]')).toBeInTheDocument();
     });
 
-    test("uses custom button text from body data attribute", () => {
-        document.body.setAttribute("data-tpr-table-csv-download-text", "Lawrlwytho data tabl (CSV)");
+    test("uses custom button text from meta tag", () => {
+        setTableCsvDownloadText("Lawrlwytho data tabl (CSV)");
         document.body.innerHTML = `
             <table class="govuk-table">
                 <tr><td>Data</td></tr>
             </table>`;
-        // Re-set the attribute after innerHTML clears it
-        document.body.setAttribute("data-tpr-table-csv-download-text", "Lawrlwytho data tabl (CSV)");
         initTableCsvDownload();
         const button = document.querySelector("button");
         expect(button).toHaveTextContent("Lawrlwytho data tabl (CSV)");
     });
 
     test("uses caption text for file name attribute", () => {
+        setTableCsvDownloadText("");
         document.body.innerHTML = `
             <div>
                 <table class="govuk-table">

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
@@ -3,11 +3,12 @@
 const DEFAULT_BUTTON_TEXT = "Download table data (CSV)";
 
 /**
- * Gets the button text from the body's data attribute, falling back to default.
+ * Gets the button text from a meta tag, falling back to default.
  * @returns {string}
  */
 export function getButtonText() {
-    const customText = document.body.getAttribute("data-tpr-table-csv-download-text");
+    const metaTag = document.querySelector('meta[name="tpr-table-csv-download-text"]');
+    const customText = metaTag ? metaTag.getAttribute("content") : null;
     return customText || DEFAULT_BUTTON_TEXT;
 }
 

--- a/docs/components/tpr-table-csv-download.md
+++ b/docs/components/tpr-table-csv-download.md
@@ -38,13 +38,19 @@ The downloaded file name is derived from the table's `<caption>` element. If the
 
 ## Customising button text
 
-The default button text is **"Download table data (CSV)"**. To customise it (e.g. for Welsh language support), add a `data-tpr-table-csv-download-text` attribute to the `<body>` element:
+The default button text is **"Download table data (CSV)"**. To customise it (e.g. for Welsh language support), pass the custom text to the `TPR/BodyClosing` partial:
 
+**Regular ASP.NET Core app (Example):**
 ```html
-<body data-tpr-table-csv-download-text="Lawrlwytho data tabl (CSV)">
+<partial name="TPR/BodyClosing" model="@customDownloadText" />
 ```
 
-In Umbraco, a dictionary item `Table CSV Download Button Text` can be used to provide translations. The layout page should render the body attribute using the dictionary value.
+**Umbraco app:**
+```html
+<partial name="TPR/BodyClosing" model="@(Umbraco.GetDictionaryValue("Table CSV Download Button Text"))" />
+```
+
+The custom text is rendered as a `<meta name="tpr-table-csv-download-text" content="...">` tag in the document when the feature is enabled.
 
 ## Merged cells
 


### PR DESCRIPTION
This pull request updates how the CSV download button text is customized for tables, moving from a `data-` attribute on the `<body>` tag to using a `<meta>` tag injected via the `TPR/BodyClosing` partial. This change improves flexibility, especially for integration with Umbraco and localization support. Documentation, code, and tests have all been updated to reflect this new approach.

**Customization Mechanism Update:**

* The button text for table CSV downloads is now set by passing a string to the `TPR/BodyClosing` partial, which renders a `<meta name="tpr-table-csv-download-text" ...>` tag, instead of setting a `data-tpr-table-csv-download-text` attribute on `<body>`. (`GovUk.Frontend.ExampleApp/Views/Table/Index.cshtml` [[1]](diffhunk://#diff-15431dbafff0108e28a73f010c2a58ee9ddc6bcf084867f8a30e4acc2683ed3dL20-R20) `GovUk.Frontend.Umbraco.ExampleApp/Views/Shared/_Layout.cshtml` [[2]](diffhunk://#diff-90222bb085ede99892b6c296914b9c15d7ba2de6fe1195527d2b51cf5b376502L61-R61) [[3]](diffhunk://#diff-90222bb085ede99892b6c296914b9c15d7ba2de6fe1195527d2b51cf5b376502L99-R99) `ThePensionsRegulator.Frontend/Views/Shared/TPR/BodyClosing.cshtml` [[4]](diffhunk://#diff-872417264a0d0964266023f358e8cb2fb917daabf133da7aca0e247f4cf94f5cR5-R15) `ThePensionsRegulator.Frontend/TprFrontendOptions.cs` [[5]](diffhunk://#diff-c5801efd243b25a0d14f8ef58337d85f2513c0341a7d222369066e451abbb10cL9-R10)

* The JavaScript function `getButtonText` now reads the custom text from the new `<meta>` tag rather than the body attribute. (`ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js` [ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.jsL6-R11](diffhunk://#diff-2a21a5d5c9d75b44c81d58f578df9c2a558e3ef41f8f446dd2450f36beac0369L6-R11))

**Test and Documentation Updates:**

* All relevant tests have been updated to use and verify the `<meta>` tag approach for customizing button text. (`ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js` [[1]](diffhunk://#diff-2688b8d80e8400fb1442ebf73eb06af03eb9212dabbf5dc989314f9f45866710L7-R35) [[2]](diffhunk://#diff-2688b8d80e8400fb1442ebf73eb06af03eb9212dabbf5dc989314f9f45866710L295-R321)

* Documentation has been revised to describe the new customization method, with examples for both regular ASP.NET Core and Umbraco apps. (`docs/components/tpr-table-csv-download.md` [docs/components/tpr-table-csv-download.mdL41-R53](diffhunk://#diff-f4cfe158aa47b1465b0fac1568e39911a9ad9087eb7f408824dc0323c74365d6L41-R53))

**How to Use**

Umbraco:
```
<partial name="TPR/BodyClosing" model="@(Umbraco.GetDictionaryValue("Table CSV Download Button Text"))" />
```
Regular ASP.NET Core:
```
<partial name="TPR/BodyClosing" model="@downloadButtonText" />
```