### PR TITLE
#270932- YouTube video unable to copy the link to clipboard via the thumbnail (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprYouTubeVideo.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprYouTubeVideo.cs
@@ -73,7 +73,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
 
             iFrame.Attributes.Add("src", src);
             iFrame.Attributes.Add("title", video.IframeTitle);
-            iFrame.Attributes.Add("allow", "accelerometer; autoplay;  encrypted-media; gyroscope; picture-in-picture; web-share");
+            iFrame.Attributes.Add("allow", "accelerometer; autoplay;  encrypted-media; gyroscope; picture-in-picture; web-share; clipboard-write");
             iFrame.Attributes.Add("referrerpolicy", "strict-origin-when-cross-origin");
             iFrame.Attributes.Add("allowfullscreen", null);
             iFrame.Attributes.Add("credentialless", null);


### PR DESCRIPTION
Why:

Raised in [#AB270932](https://dev.azure.com/thepensionsregulator/TPR/_boards/board/t/Web%20Platform%20Team/Stories?workitem=270932)

- Currently users are unable to copy the video URL from the embedded video thumbnail "link" button. 

In this PR:

- Include clipboard-write in an iframe’s allow attribute to enable copying to clipboard functionality.
