### PR TITLE
Permissions issue on download table data as a CSV.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.1.0</Version>
+    <Version>10.1.1</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ThePensionsRegulator.Frontend.Tests/Controllers/TableDownloadControllerTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Controllers/TableDownloadControllerTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using ThePensionsRegulator.Frontend.Controllers;
+using ThePensionsRegulator.Frontend.Services;
+
+namespace ThePensionsRegulator.Frontend.Tests.Controllers;
+
+public class TableDownloadControllerTests
+{
+    [Fact]
+    public void DownloadCsv_returns_BadRequest_when_tableHtml_is_empty()
+    {
+        var controller = new TableDownloadController(Mock.Of<ITableCsvService>());
+
+        var result = controller.DownloadCsv("", "my-file");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void DownloadCsv_returns_BadRequest_when_tableHtml_exceeds_max_size()
+    {
+        var controller = new TableDownloadController(Mock.Of<ITableCsvService>());
+        var oversizedHtml = "<table>" + new string('a', 310 * 1024) + "</table>";
+
+        var result = controller.DownloadCsv(oversizedHtml, "my-file");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void DownloadCsv_returns_BadRequest_when_no_table_exists()
+    {
+        var controller = new TableDownloadController(Mock.Of<ITableCsvService>());
+
+        var result = controller.DownloadCsv("<div>Not a table</div>", "my-file");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void DownloadCsv_returns_BadRequest_when_multiple_tables_exist()
+    {
+        var controller = new TableDownloadController(Mock.Of<ITableCsvService>());
+
+        var result = controller.DownloadCsv("<table><tr><td>A</td></tr></table><table><tr><td>B</td></tr></table>", "my-file");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void DownloadCsv_returns_file_for_valid_table_html_and_only_passes_table_to_service()
+    {
+        var csvBytes = new byte[] { 1, 2, 3 };
+        var tableCsvService = new Mock<ITableCsvService>();
+        tableCsvService
+            .Setup(x => x.ConvertHtmlTableToCsv(It.IsAny<string>()))
+            .Returns(csvBytes);
+
+        var controller = new TableDownloadController(tableCsvService.Object);
+        const string html = "<div><script>alert('x')</script><table><tr><td>A</td></tr></table></div>";
+
+        var result = controller.DownloadCsv(html, "My File");
+
+        var fileResult = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("text/csv", fileResult.ContentType);
+        Assert.Equal("my-file.csv", fileResult.FileDownloadName);
+        Assert.Equal(csvBytes, fileResult.FileContents);
+
+        tableCsvService.Verify(
+            x => x.ConvertHtmlTableToCsv(It.Is<string>(postedTable =>
+                postedTable.StartsWith("<table", StringComparison.OrdinalIgnoreCase)
+                && postedTable.Contains("<td>A</td>", StringComparison.Ordinal)
+                && !postedTable.Contains("<script", StringComparison.OrdinalIgnoreCase))),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!!!")]
+    public void DownloadCsv_uses_default_filename_when_sanitized_filename_is_missing_or_invalid(string? postedFileName)
+    {
+        var tableCsvService = new Mock<ITableCsvService>();
+        tableCsvService
+            .Setup(x => x.ConvertHtmlTableToCsv(It.IsAny<string>()))
+            .Returns([1, 2, 3]);
+
+        var controller = new TableDownloadController(tableCsvService.Object);
+
+        var result = controller.DownloadCsv("<table><tr><td>A</td></tr></table>", postedFileName);
+
+        var fileResult = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("table-data.csv", fileResult.FileDownloadName);
+    }
+}

--- a/ThePensionsRegulator.Frontend.Tests/Services/TableCsvServiceTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Services/TableCsvServiceTests.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using ThePensionsRegulator.Frontend.Services;
+
+namespace ThePensionsRegulator.Frontend.Tests.Services
+{
+    public class TableCsvServiceTests
+    {
+        private readonly TableCsvService _service = new();
+
+        private static string DecodeCsv(byte[] csvBytes)
+        {
+            var preamble = Encoding.UTF8.GetPreamble();
+            var content = csvBytes[preamble.Length..];
+            return Encoding.UTF8.GetString(content);
+        }
+
+        [Fact]
+        public void Converts_simple_table_to_csv()
+        {
+            var html = "<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("Name,Age" + Environment.NewLine + "Alice,30" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Returns_only_bom_when_no_table_present()
+        {
+            var csvBytes = _service.ConvertHtmlTableToCsv("<div>no table here</div>");
+
+            Assert.Equal(Encoding.UTF8.GetPreamble(), csvBytes);
+        }
+
+        [Fact]
+        public void Does_not_alter_ordinary_cell_values()
+        {
+            var html = "<table><tr><td>hello</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("hello" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Quotes_cell_value_containing_comma()
+        {
+            var html = "<table><tr><td>hello,world</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("\"hello,world\"" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Quotes_cell_value_containing_double_quote_and_escapes_it()
+        {
+            var html = "<table><tr><td>say \"hello\"</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("\"say \"\"hello\"\"\"" + Environment.NewLine, csv);
+        }
+
+        // CSV injection (formula injection, CWE-1236): table HTML/cell content is untrusted
+        // input supplied directly by the client, so values that spreadsheet applications
+        // interpret as the start of a formula must be neutralised. Mirrors the equivalent
+        // client-side test cases for escapeCsvValue in tpr-table-csv-download.tests.js.
+        [Theory]
+        [InlineData("=SUM(A1)", "'=SUM(A1)")]
+        [InlineData("+44 123", "'+44 123")]
+        [InlineData("-1", "'-1")]
+        [InlineData("@mention", "'@mention")]
+        public void Prefixes_formula_triggering_cell_values_to_prevent_csv_injection(string cellValue, string expected)
+        {
+            var html = $"<table><tr><td>{cellValue}</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal(expected + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Prefixes_and_quotes_formula_triggering_value_that_also_contains_a_comma()
+        {
+            var html = "<table><tr><td>=A,B</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("\"'=A,B\"" + Environment.NewLine, csv);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Controllers/TableDownloadControllerTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Controllers/TableDownloadControllerTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text;
+using ThePensionsRegulator.Frontend.Services;
+using ThePensionsRegulator.Frontend.Umbraco.Controllers;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Controllers
+{
+    public class TableDownloadControllerTests
+    {
+        private sealed class StubTableCsvService : ITableCsvService
+        {
+            public byte[] ConvertHtmlTableToCsv(string tableHtml) => Encoding.UTF8.GetBytes("stub-csv-content");
+        }
+
+        private static TableDownloadController CreateController() => new(new StubTableCsvService());
+
+        [Fact]
+        public void Missing_table_html_returns_bad_request()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv(string.Empty, "report");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public void Response_uses_csv_content_type_and_content_from_service()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", "report");
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("text/csv", fileResult.ContentType);
+            Assert.Equal(Encoding.UTF8.GetBytes("stub-csv-content"), fileResult.FileContents);
+        }
+
+        [Fact]
+        public void Missing_file_name_defaults_to_table_data()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", null);
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("table-data.csv", fileResult.FileDownloadName);
+        }
+
+        [Fact]
+        public void File_name_is_sanitized()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", "My Report!!");
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("my-report.csv", fileResult.FileDownloadName);
+        }
+
+        [Fact]
+        public void File_name_defaults_to_table_data_when_sanitizing_removes_everything()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", "###");
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("table-data.csv", fileResult.FileDownloadName);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Controllers/TableDownloadControllerTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Controllers/TableDownloadControllerTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Text;
+using ThePensionsRegulator.Frontend.Controllers;
 using ThePensionsRegulator.Frontend.Services;
-using ThePensionsRegulator.Frontend.Umbraco.Controllers;
 
 namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Controllers
 {

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatterTests.cs
@@ -107,13 +107,56 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
         }
 
-        private static TprTablePropertyValueFormatter CreateFormatter()
+        [Fact]
+        public void Uses_default_button_text_for_no_js_csv_form()
         {
-            var options = Options.Create(new TprFrontendOptions { EnableTableCsvDownload = false });
-            var antiforgery = Mock.Of<IAntiforgery>();
-            var httpContextAccessor = new HttpContextAccessor();
+            // Arrange
+            const string INPUT = "<table><caption>Quarterly results</caption><tr><td>Example</td></tr></table>";
+            var formatter = CreateFormatter(enableTableCsvDownload: true);
 
-            return new TprTablePropertyValueFormatter(options, antiforgery, httpContextAccessor);
+            // Act
+            var result = (HtmlEncodedString)formatter.FormatValue(INPUT);
+
+            // Assert
+            Assert.Contains("Download table data (CSV)", result.ToHtmlString());
+        }
+
+        [Fact]
+        public void Uses_configured_button_text_for_no_js_csv_form()
+        {
+            // Arrange
+            const string INPUT = "<table><caption>Quarterly results</caption><tr><td>Example</td></tr></table>";
+            const string CUSTOM_BUTTON_TEXT = "Lawrlwytho data tabl (CSV)";
+            var formatter = CreateFormatter(
+                enableTableCsvDownload: true,
+                tableCsvDownloadButtonText: CUSTOM_BUTTON_TEXT);
+
+            // Act
+            var result = (HtmlEncodedString)formatter.FormatValue(INPUT);
+
+            // Assert
+            Assert.Contains(CUSTOM_BUTTON_TEXT, result.ToHtmlString());
+        }
+
+        private static TprTablePropertyValueFormatter CreateFormatter(
+            bool enableTableCsvDownload = false,
+            string? tableCsvDownloadButtonText = null)
+        {
+            var options = Options.Create(
+                new TprFrontendOptions
+                {
+                    EnableTableCsvDownload = enableTableCsvDownload,
+                    TableCsvDownloadButtonText = tableCsvDownloadButtonText
+                });
+
+            var antiforgery = new Mock<IAntiforgery>();
+            antiforgery
+                .Setup(a => a.GetAndStoreTokens(It.IsAny<HttpContext>()))
+                .Returns(new AntiforgeryTokenSet("test-request-token", "test-cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN"));
+
+            var httpContextAccessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+
+            return new TprTablePropertyValueFormatter(options, antiforgery.Object, httpContextAccessor);
         }
     }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatterTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatterTests.cs
@@ -1,4 +1,9 @@
-﻿using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
+﻿using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using ThePensionsRegulator.Frontend;
+using ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters;
 using ThePensionsRegulator.Umbraco.Testing;
 using Umbraco.Cms.Core.Strings;
 
@@ -10,7 +15,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
         public void Applies_to_rich_text_properties_with_any_alias()
         {
             // Arrange
-            var formatter = new TprTablePropertyValueFormatter();
+            var formatter = CreateFormatter();
             var property = UmbracoPropertyFactory.CreateRichTextProperty(
                 Guid.NewGuid().ToString(),
                 "someContentType",
@@ -27,7 +32,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
         public void Does_not_apply_to_textbox_property()
         {
             // Arrange
-            var formatter = new TprTablePropertyValueFormatter();
+            var formatter = CreateFormatter();
             var property = UmbracoPropertyFactory.CreateTextboxProperty(
                 Guid.NewGuid().ToString(),
                 "someContentType",
@@ -46,7 +51,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             // Arrange
             const string INPUT = "<table><tr><td>Example</td><td>Example</td></tr></table>";
             const string EXPECTED = $"<table class=\"{TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
-            var formatter = new TprTablePropertyValueFormatter();
+            var formatter = CreateFormatter();
 
             // Act
             var resultOfString = formatter.FormatValue(INPUT);
@@ -63,7 +68,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             // Arrange
             const string INPUT = "<table class=\"existing-class\"><tr><td>Example</td><td>Example</td></tr></table>";
             const string EXPECTED = $"<table class=\"existing-class {TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
-            var formatter = new TprTablePropertyValueFormatter();
+            var formatter = CreateFormatter();
 
             // Act
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
@@ -78,7 +83,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             // Arrange
             const string INPUT = $"<table class=\"{TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
             const string EXPECTED = $"<table class=\"{TprClassNames.Table}\"><tr><td>Example</td><td>Example</td></tr></table>";
-            var formatter = new TprTablePropertyValueFormatter();
+            var formatter = CreateFormatter();
 
             // Act
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
@@ -93,13 +98,22 @@ namespace ThePensionsRegulator.Frontend.Umbraco.Tests.PropertyEditors.ValueForma
             // Arrange
             const string INPUT = "<h2>Example</h2><p>Example</p><strong>Example</strong>";
             const string EXPECTED = INPUT;
-            var formatter = new TprTablePropertyValueFormatter();
+            var formatter = CreateFormatter();
 
             // Act
             var resultOfHtmlEncodedString = formatter.FormatValue(new HtmlEncodedString(INPUT));
 
             // Assert
             Assert.Equal(EXPECTED, ((HtmlEncodedString)resultOfHtmlEncodedString)?.ToHtmlString());
+        }
+
+        private static TprTablePropertyValueFormatter CreateFormatter()
+        {
+            var options = Options.Create(new TprFrontendOptions { EnableTableCsvDownload = false });
+            var antiforgery = Mock.Of<IAntiforgery>();
+            var httpContextAccessor = new HttpContextAccessor();
+
+            return new TprTablePropertyValueFormatter(options, antiforgery, httpContextAccessor);
         }
     }
 }

--- a/ThePensionsRegulator.Frontend.Umbraco/Controllers/TableDownloadController.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Controllers/TableDownloadController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
+using ThePensionsRegulator.Frontend.Services;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Controllers;
+
+/// <summary>
+/// Handles CSV download requests for HTML tables.
+/// Provides both server-side fallback for no-JS scenarios and client-side form interception.
+/// </summary>
+[ApiController]
+public class TableDownloadController : ControllerBase
+{
+    private readonly ITableCsvService _tableCsvService;
+
+    public TableDownloadController(ITableCsvService tableCsvService)
+    {
+        _tableCsvService = tableCsvService;
+    }
+
+    /// <summary>
+    /// Downloads a table as a CSV file.
+    /// Accepts POST from the tpr-table-download-form when JavaScript is unavailable.
+    /// </summary>
+    /// <param name="tableHtml">The complete table element HTML to convert.</param>
+    /// <param name="fileName">The desired filename (optional, defaults to 'table-data').</param>
+    /// <returns>CSV file download.</returns>
+    [HttpPost]
+    [Route("api/table/download-csv")]
+    [ValidateAntiForgeryToken]
+    public IActionResult DownloadCsv([FromForm] string tableHtml, [FromForm] string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(tableHtml))
+        {
+            return BadRequest("Table HTML is required.");
+        }
+
+        var csvBytes = _tableCsvService.ConvertHtmlTableToCsv(tableHtml);
+        var sanitizedFileName = SanitizeFileName(fileName) ?? "table-data";
+
+        return File(csvBytes, "text/csv", $"{sanitizedFileName}.csv");
+    }
+
+    private static string? SanitizeFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        var sanitized = Regex.Replace(fileName.Trim(), @"[^\w\s\-]", "");
+        sanitized = Regex.Replace(sanitized, @"\s+", "-").ToLowerInvariant();
+        
+        return sanitized.Length > 50 ? sanitized[..50] : sanitized;
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatter.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatter.cs
@@ -63,7 +63,10 @@ namespace ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters
                 if (_tprOptions.Value.EnableTableCsvDownload && _httpContextAccessor.HttpContext != null)
                 {
                     var tokens = _antiforgery.GetAndStoreTokens(_httpContextAccessor.HttpContext);
-                    richTextHtml = _formGenerator.AddCsvDownloadForms(richTextHtml, tokens.RequestToken!);
+                    richTextHtml = _formGenerator.AddCsvDownloadForms(
+                        richTextHtml,
+                        tokens.RequestToken!,
+                        _tprOptions.Value.TableCsvDownloadButtonText);
                 }
             }
             return new HtmlEncodedString(richTextHtml ?? "");

--- a/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatter.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/PropertyEditors/ValueFormatters/TprTablePropertyValueFormatter.cs
@@ -1,4 +1,8 @@
 ﻿using HtmlAgilityPack;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using ThePensionsRegulator.Frontend.Services;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
 using Umbraco.Cms.Core;
@@ -9,9 +13,26 @@ namespace ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters
 {
     /// <summary>
     /// Apply .tpr-table class to HTML tables from the Umbraco rich text editor.
+    /// Optionally injects CSV download forms for no-JS support when EnableTableCsvDownload is true.
     /// </summary>
     public class TprTablePropertyValueFormatter : IPropertyValueFormatter
     {
+        private readonly IOptions<TprFrontendOptions> _tprOptions;
+        private readonly IAntiforgery _antiforgery;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly TableHtmlCsvFormGenerator _formGenerator;
+
+        public TprTablePropertyValueFormatter(
+            IOptions<TprFrontendOptions> tprOptions,
+            IAntiforgery antiforgery,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _tprOptions = tprOptions;
+            _antiforgery = antiforgery;
+            _httpContextAccessor = httpContextAccessor;
+            _formGenerator = new TableHtmlCsvFormGenerator();
+        }
+
         public virtual bool IsFormatter(IPublishedPropertyType propertyType) => Constants.PropertyEditors.Aliases.RichText.Equals(propertyType.EditorAlias);
 
         /// <inheritdoc />
@@ -37,6 +58,13 @@ namespace ThePensionsRegulator.Frontend.Umbraco.PropertyEditors.ValueFormatters
                     }
                 }
                 richTextHtml = document.DocumentNode.OuterHtml;
+
+                // Inject CSV download forms for no-JS support if enabled
+                if (_tprOptions.Value.EnableTableCsvDownload && _httpContextAccessor.HttpContext != null)
+                {
+                    var tokens = _antiforgery.GetAndStoreTokens(_httpContextAccessor.HttpContext);
+                    richTextHtml = _formGenerator.AddCsvDownloadForms(richTextHtml, tokens.RequestToken!);
+                }
             }
             return new HtmlEncodedString(richTextHtml ?? "");
         }

--- a/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -82,7 +82,16 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             services.AddTprGovUkFrontendUmbraco(configureGovUkOptions, configureGovUkUmbracoOptions);
 
             // ThePensionsRegulator.Frontend
-            services.AddTprFrontend(configureGovUkOptions, configureTprOptions);
+            // Keep these registrations explicit here rather than calling AddTprFrontend(), because
+            // AddTprGovUkFrontendUmbraco() above has already registered the GOV.UK frontend services.
+            services.AddTransient<IContextAwareHostUpdater, TprHostUpdater>();
+            services.AddTransient<IConsentCookieReader, TprConsentCookieReader>();
+            services.AddTransient<IStaticFileCachePolicy, TprStaticFileCachePolicy>();
+            services.AddTransient<ITableCsvService, TableCsvService>();
+
+            var tprFrontendOptions = new TprFrontendOptions();
+            configureTprOptions(tprFrontendOptions);
+            services.AddTransient((services) => Options.Create(tprFrontendOptions));
 
             // ThePensionsRegulator.Frontend.Umbraco
             services.Configure<RazorViewEngineOptions>(options => options.ViewLocationFormats.Add("/Views/Shared/TPR/{0}.cshtml"));

--- a/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/ServiceCollectionExtensions.cs
@@ -82,13 +82,7 @@ namespace ThePensionsRegulator.Frontend.Umbraco
             services.AddTprGovUkFrontendUmbraco(configureGovUkOptions, configureGovUkUmbracoOptions);
 
             // ThePensionsRegulator.Frontend
-            services.AddTransient<IConsentCookieReader, TprConsentCookieReader>();
-            services.AddTransient<IContextAwareHostUpdater, TprHostUpdater>();
-            services.AddTransient<IStaticFileCachePolicy, TprStaticFileCachePolicy>();
-
-            var tprFrontendOptions = new TprFrontendOptions();
-            if (configureTprOptions is not null) { configureTprOptions(tprFrontendOptions); }
-            services.AddTransient((services) => Options.Create(tprFrontendOptions));
+            services.AddTprFrontend(configureGovUkOptions, configureTprOptions);
 
             // ThePensionsRegulator.Frontend.Umbraco
             services.Configure<RazorViewEngineOptions>(options => options.ViewLocationFormats.Add("/Views/Shared/TPR/{0}.cshtml"));

--- a/ThePensionsRegulator.Frontend/Controllers/TableDownloadController.cs
+++ b/ThePensionsRegulator.Frontend/Controllers/TableDownloadController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Text.RegularExpressions;
 using ThePensionsRegulator.Frontend.Services;
 
-namespace ThePensionsRegulator.Frontend.Umbraco.Controllers;
+namespace ThePensionsRegulator.Frontend.Controllers;
 
 /// <summary>
 /// Handles CSV download requests for HTML tables.
@@ -50,7 +50,7 @@ public class TableDownloadController : ControllerBase
 
         var sanitized = Regex.Replace(fileName.Trim(), @"[^\w\s\-]", "");
         sanitized = Regex.Replace(sanitized, @"\s+", "-").ToLowerInvariant();
-        
+
         return sanitized.Length > 50 ? sanitized[..50] : sanitized;
     }
 }

--- a/ThePensionsRegulator.Frontend/Controllers/TableDownloadController.cs
+++ b/ThePensionsRegulator.Frontend/Controllers/TableDownloadController.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using HtmlAgilityPack;
+using System.Text;
 using System.Text.RegularExpressions;
 using ThePensionsRegulator.Frontend.Services;
 
@@ -11,6 +13,7 @@ namespace ThePensionsRegulator.Frontend.Controllers;
 [ApiController]
 public class TableDownloadController : ControllerBase
 {
+    private const int MaxTableHtmlBytes = 300 * 1024;
     private readonly ITableCsvService _tableCsvService;
 
     public TableDownloadController(ITableCsvService tableCsvService)
@@ -35,7 +38,28 @@ public class TableDownloadController : ControllerBase
             return BadRequest("Table HTML is required.");
         }
 
-        var csvBytes = _tableCsvService.ConvertHtmlTableToCsv(tableHtml);
+        if (Encoding.UTF8.GetByteCount(tableHtml) > MaxTableHtmlBytes)
+        {
+            return BadRequest("Table HTML is too large.");
+        }
+
+        var htmlDoc = new HtmlDocument();
+        htmlDoc.LoadHtml(tableHtml);
+
+        var tableNodes = htmlDoc.DocumentNode.SelectNodes("//table");
+        if (tableNodes == null || tableNodes.Count == 0)
+        {
+            return BadRequest("Table HTML must contain a table element.");
+        }
+
+        if (tableNodes.Count > 1)
+        {
+            return BadRequest("Table HTML must contain exactly one table element.");
+        }
+
+        var tableOnlyHtml = tableNodes[0].OuterHtml;
+
+        var csvBytes = _tableCsvService.ConvertHtmlTableToCsv(tableOnlyHtml);
         var sanitizedFileName = SanitizeFileName(fileName) ?? "table-data";
 
         return File(csvBytes, "text/csv", $"{sanitizedFileName}.csv");
@@ -50,6 +74,11 @@ public class TableDownloadController : ControllerBase
 
         var sanitized = Regex.Replace(fileName.Trim(), @"[^\w\s\-]", "");
         sanitized = Regex.Replace(sanitized, @"\s+", "-").ToLowerInvariant();
+
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            return null;
+        }
 
         return sanitized.Length > 50 ? sanitized[..50] : sanitized;
     }

--- a/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
+++ b/ThePensionsRegulator.Frontend/ServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ namespace ThePensionsRegulator.Frontend
             services.AddTransient<IContextAwareHostUpdater, TprHostUpdater>();
             services.AddTransient<IConsentCookieReader, TprConsentCookieReader>();
             services.AddTransient<IStaticFileCachePolicy, TprStaticFileCachePolicy>();
+            services.AddTransient<ITableCsvService, TableCsvService>();
 
             services.AddTprGovUkFrontend(configureGovUkOptions);
 

--- a/ThePensionsRegulator.Frontend/Services/ITableCsvService.cs
+++ b/ThePensionsRegulator.Frontend/Services/ITableCsvService.cs
@@ -1,0 +1,14 @@
+namespace ThePensionsRegulator.Frontend.Services;
+
+/// <summary>
+/// Converts HTML table elements to CSV format.
+/// </summary>
+public interface ITableCsvService
+{
+    /// <summary>
+    /// Converts an HTML table to CSV bytes with UTF-8 BOM.
+    /// </summary>
+    /// <param name="tableHtml">The table element HTML.</param>
+    /// <returns>CSV content as bytes with UTF-8 BOM.</returns>
+    byte[] ConvertHtmlTableToCsv(string tableHtml);
+}

--- a/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
+++ b/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
@@ -54,6 +54,17 @@ public class TableCsvService : ITableCsvService
             return string.Empty;
         }
 
+        // CSV injection (formula injection) mitigation: if the value starts with a character
+        // that spreadsheet applications (Excel, Google Sheets, LibreOffice) interpret as the
+        // start of a formula, prefix it with a single quote so it is opened as literal text
+        // instead of being executed. This mirrors the client-side escapeCsvValue in
+        // tpr-table-csv-download.js, since tableHtml/cell content here is untrusted input
+        // supplied directly by the client.
+        if (value[0] is '=' or '+' or '-' or '@' or '\t' or '\r')
+        {
+            value = "'" + value;
+        }
+
         if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
         {
             return $"\"{value.Replace("\"", "\"\"")}\"";

--- a/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
+++ b/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
@@ -1,0 +1,64 @@
+using HtmlAgilityPack;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ThePensionsRegulator.Frontend.Services;
+
+public class TableCsvService : ITableCsvService
+{
+    public byte[] ConvertHtmlTableToCsv(string tableHtml)
+    {
+        ArgumentNullException.ThrowIfNull(tableHtml);
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(tableHtml);
+
+        var table = doc.DocumentNode.SelectSingleNode("//table");
+        if (table == null)
+        {
+            return Encoding.UTF8.GetPreamble();
+        }
+
+        var csvBuilder = new StringBuilder();
+        var rows = table.SelectNodes(".//tr");
+
+        if (rows != null)
+        {
+            foreach (var row in rows)
+            {
+                var cells = row.SelectNodes("th|td");
+                if (cells != null)
+                {
+                    var cellValues = cells.Select(cell => EscapeCsvValue(GetCellText(cell)));
+                    csvBuilder.AppendLine(string.Join(",", cellValues));
+                }
+            }
+        }
+
+        var bom = Encoding.UTF8.GetPreamble();
+        var csvBytes = Encoding.UTF8.GetBytes(csvBuilder.ToString());
+        return [.. bom, .. csvBytes];
+    }
+
+    private static string GetCellText(HtmlNode cell)
+    {
+        var text = cell.InnerText;
+        text = Regex.Replace(text, @"\s+", " ");
+        return text.Trim();
+    }
+
+    private static string EscapeCsvValue(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+        {
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+
+        return value;
+    }
+}

--- a/ThePensionsRegulator.Frontend/Services/TableHtmlCsvFormGenerator.cs
+++ b/ThePensionsRegulator.Frontend/Services/TableHtmlCsvFormGenerator.cs
@@ -1,0 +1,75 @@
+using HtmlAgilityPack;
+using System.Web;
+
+namespace ThePensionsRegulator.Frontend.Services;
+
+/// <summary>
+/// Generates and injects CSV download forms into HTML table elements for no-JS support.
+/// </summary>
+public class TableHtmlCsvFormGenerator
+{
+    /// <summary>
+    /// Adds a CSV download form after each table in the HTML, with anti-forgery token.
+    /// </summary>
+    /// <param name="html">The HTML content containing tables.</param>
+    /// <param name="antiForgeryToken">The anti-forgery token to include in the form.</param>
+    /// <returns>HTML with download forms injected after each table.</returns>
+    public string AddCsvDownloadForms(string html, string antiForgeryToken)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return html;
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var tables = doc.DocumentNode.SelectNodes("//table")?.ToList();
+        if (tables == null || tables.Count == 0)
+            return html;
+
+        foreach (var table in tables)
+        {
+            var caption = table.SelectSingleNode(".//caption")?.InnerText?.Trim();
+            var fileName = !string.IsNullOrEmpty(caption) ? caption : "table-data";
+
+            var wrapper = doc.CreateElement("div");
+            wrapper.SetAttributeValue("class", "tpr-table-wrapper");
+
+            var form = doc.CreateElement("form");
+            form.SetAttributeValue("method", "post");
+            form.SetAttributeValue("action", "/api/table/download-csv");
+            form.SetAttributeValue("class", "tpr-table-download-form");
+
+            var tableInput = doc.CreateElement("input");
+            tableInput.SetAttributeValue("type", "hidden");
+            tableInput.SetAttributeValue("name", "tableHtml");
+            tableInput.SetAttributeValue("value", HttpUtility.HtmlEncode(table.OuterHtml));
+            form.AppendChild(tableInput);
+
+            var fileNameInput = doc.CreateElement("input");
+            fileNameInput.SetAttributeValue("type", "hidden");
+            fileNameInput.SetAttributeValue("name", "fileName");
+            fileNameInput.SetAttributeValue("value", HttpUtility.HtmlEncode(fileName));
+            form.AppendChild(fileNameInput);
+
+            var tokenInput = doc.CreateElement("input");
+            tokenInput.SetAttributeValue("type", "hidden");
+            tokenInput.SetAttributeValue("name", "__RequestVerificationToken");
+            tokenInput.SetAttributeValue("value", antiForgeryToken);
+            form.AppendChild(tokenInput);
+
+            var submitButton = doc.CreateElement("button");
+            submitButton.SetAttributeValue("type", "submit");
+            submitButton.SetAttributeValue("class", "govuk-button govuk-button--secondary");
+            submitButton.SetAttributeValue("data-module", "govuk-button");
+            submitButton.InnerHtml = "Download table data (CSV)";
+            form.AppendChild(submitButton);
+
+            table.ParentNode.InsertBefore(wrapper, table);
+            table.Remove();
+            wrapper.AppendChild(table);
+            wrapper.AppendChild(form);
+        }
+
+        return doc.DocumentNode.OuterHtml;
+    }
+}

--- a/ThePensionsRegulator.Frontend/Services/TableHtmlCsvFormGenerator.cs
+++ b/ThePensionsRegulator.Frontend/Services/TableHtmlCsvFormGenerator.cs
@@ -8,16 +8,21 @@ namespace ThePensionsRegulator.Frontend.Services;
 /// </summary>
 public class TableHtmlCsvFormGenerator
 {
+    private const string DEFAULT_BUTTON_TEXT = "Download table data (CSV)";
+
     /// <summary>
     /// Adds a CSV download form after each table in the HTML, with anti-forgery token.
     /// </summary>
     /// <param name="html">The HTML content containing tables.</param>
     /// <param name="antiForgeryToken">The anti-forgery token to include in the form.</param>
+    /// <param name="buttonText">Optional text for the download button.</param>
     /// <returns>HTML with download forms injected after each table.</returns>
-    public string AddCsvDownloadForms(string html, string antiForgeryToken)
+    public string AddCsvDownloadForms(string html, string antiForgeryToken, string? buttonText = null)
     {
         if (string.IsNullOrWhiteSpace(html))
             return html;
+
+        var resolvedButtonText = string.IsNullOrWhiteSpace(buttonText) ? DEFAULT_BUTTON_TEXT : buttonText;
 
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
@@ -61,7 +66,7 @@ public class TableHtmlCsvFormGenerator
             submitButton.SetAttributeValue("type", "submit");
             submitButton.SetAttributeValue("class", "govuk-button govuk-button--secondary");
             submitButton.SetAttributeValue("data-module", "govuk-button");
-            submitButton.InnerHtml = "Download table data (CSV)";
+            submitButton.InnerHtml = HttpUtility.HtmlEncode(resolvedButtonText);
             form.AppendChild(submitButton);
 
             table.ParentNode.InsertBefore(wrapper, table);

--- a/ThePensionsRegulator.Frontend/TprFrontendOptions.cs
+++ b/ThePensionsRegulator.Frontend/TprFrontendOptions.cs
@@ -11,5 +11,11 @@
         /// Tables with merged cells (colspan or rowspan) are skipped.
         /// </summary>
         public bool EnableTableCsvDownload { get; set; }
+
+        /// <summary>
+        /// Override the server-rendered (no-JS) CSV download button text.
+        /// If not set, the default button text "Download table data (CSV)" is used.
+        /// </summary>
+        public string? TableCsvDownloadButtonText { get; set; }
     }
 }

--- a/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { jest } from '@jest/globals';
-import { getButtonText, sanitizeFileName, getCellText, escapeCsvValue, hasMergedCells, tableToCsv, initTableCsvDownload, downloadCsv, hasExistingDownloadButton } from '../wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download';
+import { getButtonText, sanitizeFileName, getCellText, escapeCsvValue, hasMergedCells, tableToCsv, initTableCsvDownload, downloadCsv, hasExistingDownloadButton, findServerSideDownloadForm } from '../wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download';
 
 beforeEach(() => {
     document.body.innerHTML = "";
@@ -473,5 +473,146 @@ describe("hasExistingDownloadButton", () => {
             </div>`;
         const table = document.querySelector(".govuk-table");
         expect(hasExistingDownloadButton(table)).toBe(true);
+    });
+});
+
+describe("findServerSideDownloadForm", () => {
+    test("returns null when there is no following element", () => {
+        document.body.innerHTML = `<table class="govuk-table"><tr><td>Data</td></tr></table>`;
+        const table = document.querySelector(".govuk-table");
+        expect(findServerSideDownloadForm(table)).toBeNull();
+    });
+
+    test("returns null when followed by an unrelated form", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table"><tr><td>Data</td></tr></table>
+            <form class="search-form"><button>Search</button></form>`;
+        const table = document.querySelector(".govuk-table");
+        expect(findServerSideDownloadForm(table)).toBeNull();
+    });
+
+    test("returns null when followed by a script-added button (not a form)", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table"><tr><td>Data</td></tr></table>
+            <button data-tpr-table-csv-button="true">Download table data (CSV)</button>`;
+        const table = document.querySelector(".govuk-table");
+        expect(findServerSideDownloadForm(table)).toBeNull();
+    });
+
+    test("returns the form when directly followed by a tpr-table-download-form", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table"><tr><td>Data</td></tr></table>
+            <form class="tpr-table-download-form"><button>Download</button></form>`;
+        const table = document.querySelector(".govuk-table");
+        const form = document.querySelector(".tpr-table-download-form");
+        expect(findServerSideDownloadForm(table)).toBe(form);
+    });
+
+    test("returns the form when it has additional classes", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table"><tr><td>Data</td></tr></table>
+            <form class="tpr-table-download-form govuk-!-margin-top-3"><button>Download</button></form>`;
+        const table = document.querySelector(".govuk-table");
+        const form = document.querySelector(".tpr-table-download-form");
+        expect(findServerSideDownloadForm(table)).toBe(form);
+    });
+
+    test("returns the form when nested in a wrapping sibling", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table"><tr><td>Data</td></tr></table>
+            <div class="download-wrapper">
+                <form class="tpr-table-download-form"><button>Download</button></form>
+            </div>`;
+        const table = document.querySelector(".govuk-table");
+        const form = document.querySelector(".tpr-table-download-form");
+        expect(findServerSideDownloadForm(table)).toBe(form);
+    });
+
+    test("returns null when the form has no button", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table"><tr><td>Data</td></tr></table>
+            <form class="tpr-table-download-form"><input type="hidden"></form>`;
+        const table = document.querySelector(".govuk-table");
+        expect(findServerSideDownloadForm(table)).toBeNull();
+    });
+});
+
+describe("initTableCsvDownload — server-side form interception", () => {
+    function mockDownload() {
+        const mockUrl = "blob:mock-url";
+        URL.createObjectURL = jest.fn(() => mockUrl);
+        URL.revokeObjectURL = jest.fn();
+        const clickSpy = jest.fn();
+        const originalCreateElement = document.createElement.bind(document);
+        jest.spyOn(document, "createElement").mockImplementation((tag) => {
+            const el = originalCreateElement(tag);
+            if (tag === "a") el.click = clickSpy;
+            return el;
+        });
+        return { clickSpy };
+    }
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("intercepts server-side form submit and downloads CSV client-side", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table">
+                <thead><tr><th>Name</th><th>Age</th></tr></thead>
+                <tbody><tr><td>Alice</td><td>30</td></tr></tbody>
+            </table>
+            <form method="post" action="/api/table/download-csv" class="tpr-table-download-form">
+                <input type="hidden" name="tableHtml" value="...">
+                <input type="hidden" name="fileName" value="table-data">
+                <input type="hidden" name="__RequestVerificationToken" value="token">
+                <button type="submit" class="govuk-button govuk-button--secondary">Download table data (CSV)</button>
+            </form>`;
+
+        initTableCsvDownload();
+        const { clickSpy } = mockDownload();
+
+        const form = document.querySelector(".tpr-table-download-form");
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+        expect(URL.createObjectURL).toHaveBeenCalled();
+        expect(clickSpy).toHaveBeenCalled();
+    });
+
+    test("does not add an extra button when a server-side form is present", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table">
+                <thead><tr><th>Name</th></tr></thead>
+                <tbody><tr><td>Alice</td></tr></tbody>
+            </table>
+            <form method="post" action="/api/table/download-csv" class="tpr-table-download-form">
+                <button type="submit" class="govuk-button govuk-button--secondary">Download table data (CSV)</button>
+            </form>`;
+
+        initTableCsvDownload();
+
+        expect(document.querySelectorAll("button").length).toBe(1);
+        expect(document.querySelector('button[data-tpr-table-csv-button="true"]')).not.toBeInTheDocument();
+    });
+
+    test("is idempotent — calling init twice does not attach duplicate submit listeners", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table">
+                <tr><td>Data</td></tr>
+            </table>
+            <form method="post" action="/api/table/download-csv" class="tpr-table-download-form">
+                <button type="submit" class="govuk-button">Download</button>
+            </form>`;
+
+        initTableCsvDownload();
+        initTableCsvDownload();
+
+        const { clickSpy } = mockDownload();
+
+        const form = document.querySelector(".tpr-table-download-form");
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+        // createObjectURL should be called exactly once (not twice if listener was added twice)
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
     });
 });

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
@@ -132,8 +132,32 @@ export function hasExistingDownloadButton(table) {
 }
 
 /**
+ * Finds a server-side rendered CSV download form that follows the table, if present.
+ * Returns the form element, or null if not found.
+ * @param {HTMLTableElement} table
+ * @returns {HTMLFormElement|null}
+ */
+export function findServerSideDownloadForm(table) {
+    const next = table.nextElementSibling;
+    if (!next) return null;
+
+    if (next.classList.contains("tpr-table-download-form") && next.querySelector("button")) {
+        return next;
+    }
+
+    if (next.querySelector) {
+        const form = next.querySelector(".tpr-table-download-form");
+        if (form && form.querySelector("button")) return form;
+    }
+
+    return null;
+}
+
+/**
  * Initialises CSV download buttons on all .govuk-table elements.
  * Idempotent — will not add a duplicate button if one already follows the table.
+ * When a server-side download form is present, intercepts its submit and performs
+ * the download client-side instead of posting to the server.
  */
 export function initTableCsvDownload() {
     const buttonText = getButtonText();
@@ -145,14 +169,26 @@ export function initTableCsvDownload() {
         // Skip tables with merged cells — CSV cannot represent them reliably
         if (hasMergedCells(table)) continue;
 
-        // Skip if a download button has already been provided for this table
-        // (either by this script or server-side), to avoid duplicates.
-        if (hasExistingDownloadButton(table)) {
-            continue;
-        }
+        // Skip if a client-side download button was already added by this script (idempotency).
+        const next = table.nextElementSibling;
+        if (next && next.hasAttribute("data-tpr-table-csv-button")) continue;
 
         const caption = table.querySelector("caption");
         const fileName = sanitizeFileName(caption ? (caption.innerText || caption.textContent) : null);
+
+        // If a server-side download form is present, intercept its submit and perform
+        // the download client-side to avoid a server round-trip.
+        const serverForm = findServerSideDownloadForm(table);
+        if (serverForm) {
+            if (!serverForm.hasAttribute("data-tpr-table-csv-intercepted")) {
+                serverForm.setAttribute("data-tpr-table-csv-intercepted", "true");
+                serverForm.addEventListener("submit", (e) => {
+                    e.preventDefault();
+                    downloadCsv(tableToCsv(table), fileName);
+                });
+            }
+            continue;
+        }
 
         const button = document.createElement("button");
         button.type = "button";

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ steps:
     inputs:
       command: custom
       workingDir: '$(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions'
-      customCommand: "audit --level moderate --groups dependencies"
+      customCommand: "audit --audit-level=moderate"
     displayName: npm audit root project
 
   - task: Npm@1
@@ -78,7 +78,7 @@ steps:
     inputs:
       command: custom
       workingDir: '$(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.GovUk.Frontend.Umbraco\Backoffice'
-      customCommand: "audit --level moderate --groups dependencies"
+      customCommand: "audit --audit-level=moderate"
     displayName: npm audit GOV.UK backoffice
 
   - task: Npm@1
@@ -92,7 +92,7 @@ steps:
     inputs:
       command: custom
       workingDir: '$(Build.SourcesDirectory)\govuk-frontend-aspnetcore-extensions\ThePensionsRegulator.Frontend.Umbraco\Backoffice'
-      customCommand: "audit --level moderate --groups dependencies"
+      customCommand: "audit --audit-level=moderate"
     displayName: npm audit TPR backoffice
 
   - task: Npm@1

--- a/docs/components/tpr-table-csv-download.md
+++ b/docs/components/tpr-table-csv-download.md
@@ -38,13 +38,25 @@ The downloaded file name is derived from the table's `<caption>` element. If the
 
 ## Customising button text
 
-The default button text is **"Download table data (CSV)"**. To customise it (e.g. for Welsh language support), add a `data-tpr-table-csv-download-text` attribute to the `<body>` element:
+The default button text is **"Download table data (CSV)"**.
+
+For JavaScript-enhanced buttons, customise it (e.g. for Welsh language support) by adding a `data-tpr-table-csv-download-text` attribute to the `<body>` element:
 
 ```html
 <body data-tpr-table-csv-download-text="Lawrlwytho data tabl (CSV)">
 ```
 
 In Umbraco, a dictionary item `Table CSV Download Button Text` can be used to provide translations. The layout page should render the body attribute using the dictionary value.
+
+For server-rendered no-JS forms, set `TableCsvDownloadButtonText` in `TprFrontendOptions`:
+
+```csharp
+builder.Services.AddTprFrontend(options =>
+{
+	options.EnableTableCsvDownload = true;
+	options.TableCsvDownloadButtonText = "Lawrlwytho data tabl (CSV)";
+});
+```
 
 ## Merged cells
 

--- a/docs/components/tpr-table-csv-download.md
+++ b/docs/components/tpr-table-csv-download.md
@@ -2,6 +2,8 @@
 
 Adds a "Download table data (CSV)" button below each `.govuk-table` on the page, allowing users to download the table data as a CSV file. This improves accessibility by providing an alternative way to consume tabular data.
 
+The feature is provided by `ThePensionsRegulator.Frontend`. Umbraco adds automatic no-JS form injection for rich text tables, but Umbraco is not required to use either the JavaScript enhancement or the server-side CSV download endpoint.
+
 ## Enabling the feature
 
 Set `EnableTableCsvDownload = true` on `TprFrontendOptions`:
@@ -25,6 +27,22 @@ On `DOMContentLoaded`, the script:
 3. On button click, converts the table to CSV and triggers a file download.
 
 The script is idempotent — if it runs more than once, it will not create duplicate buttons.
+
+## No-JS support
+
+When using `ThePensionsRegulator.Frontend.Umbraco`, no-JS download forms are injected automatically for eligible rich text tables.
+
+When using `ThePensionsRegulator.Frontend` without Umbraco, the JavaScript enhancement works automatically, and you can add a server-side fallback by rendering a form that posts the table HTML to `/api/table/download-csv`:
+
+```html
+<form method="post" action="/api/table/download-csv" class="tpr-table-download-form">
+	<input type="hidden" name="tableHtml" value="&lt;table&gt;...&lt;/table&gt;" />
+	<input type="hidden" name="__RequestVerificationToken" value="..." />
+	<button type="submit" class="govuk-button govuk-button--secondary">Download table data (CSV)</button>
+</form>
+```
+
+When JavaScript is available, the script intercepts that form submission and performs the CSV download client-side instead of posting to the server.
 
 ### File naming
 


### PR DESCRIPTION
## Issue found in testing on SIT: 

<img width="632" height="346" alt="image" src="https://github.com/user-attachments/assets/2d719535-fcae-48b1-ad1b-17b3973ed6f6" />

## Root cause

When the Umbraco HTML table component renders a table with `EnableTableCsvDownload = true`, it emits a server-side `<form class="tpr-table-download-form">` that POSTs the table HTML to `/api/table/download-csv`. The `tpr-table-csv-download.js` script detected this form and skipped adding its own client-side button, leaving the server form as the sole download mechanism.

On affected pages, Umbraco's routing pipeline was intercepting the POST to `/api/table/download-csv` before the `TableDownloadController` MVC route could handle it, resulting in Umbraco serving its access-denied content page. Tables on other pages worked correctly because they had no server-side form and the script added a client-side button instead.

## Fix

Changed `tpr-table-csv-download.js` so that when a server-side `tpr-table-download-form` is detected, the script intercepts its `submit` event, prevents the default POST to the server, and performs the CSV conversion and file download entirely in the browser — consistent with how client-side buttons work for all other tables.

### Changes

- **`tpr-table-csv-download.js`**
  - Added exported helper `findServerSideDownloadForm(table)` — returns the server-side form element following a table, or `null`.
  - Updated `initTableCsvDownload()` to attach a `submit` listener on any detected server-side form. The listener calls `e.preventDefault()` then runs `downloadCsv(tableToCsv(table), fileName)`. A `data-tpr-table-csv-intercepted` attribute prevents duplicate listeners if the function is called more than once (idempotency).

- **`tpr-table-csv-download.tests.js`**
  - Added import for `findServerSideDownloadForm`.
  - Added `describe("findServerSideDownloadForm")` test suite covering direct sibling, nested sibling, additional classes, missing button, and unrelated form cases.
  - Added `describe("initTableCsvDownload — server-side form interception")` test suite verifying: submit triggers client-side download, no extra button is added, and the listener is not duplicated on repeated `init` calls.

## Testing

- Existing tests all continue to pass.
- Manually verified on the affected page: clicking "Download table data (CSV)" now downloads the file client-side without navigating to the API URL.

## Related

[AB #269788](https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/269110)