### PR TITLE
Upgrade umbraco to v17.5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.0.3</Version>
+    <Version>10.1.0</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/GovUk.Frontend.ExampleApp/GovUk.Frontend.ExampleApp.csproj
+++ b/GovUk.Frontend.ExampleApp/GovUk.Frontend.ExampleApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ButtonController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -10,8 +11,11 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class ButtonController : RenderController
     {
-        public ButtonController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+
+        public ButtonController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(ButtonViewModel))]
@@ -19,7 +23,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
         {
             var viewModel = new ButtonViewModel
             {
-                Page = new Button(CurrentPage, null)
+                Page = new Button(CurrentPage, _publishedValueFallback)
             };
             return CurrentTemplate(viewModel);
         }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/CheckboxesController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/CheckboxesController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -10,8 +11,10 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class CheckboxesController : RenderController
     {
-        public CheckboxesController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public CheckboxesController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(CheckboxesViewModel))]
@@ -19,7 +22,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
         {
             var viewModel = new CheckboxesViewModel
             {
-                Page = new Checkboxes(CurrentPage, null)
+                Page = new Checkboxes(CurrentPage, _publishedValueFallback)
             };
             return CurrentTemplate(viewModel);
         }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/DateInputController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/DateInputController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -10,8 +11,10 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class DateInputController : RenderController
     {
-        public DateInputController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public DateInputController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(DateInputViewModel))]
@@ -19,7 +22,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
         {
             var viewModel = new DateInputViewModel
             {
-                Page = new DateInput(CurrentPage, null)
+                Page = new DateInput(CurrentPage, _publishedValueFallback)
             };
             return CurrentTemplate(viewModel);
         }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ErrorMessageController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/ErrorMessageController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -10,8 +11,10 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class ErrorMessageController : RenderController
     {
-        public ErrorMessageController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public ErrorMessageController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(ErrorMessageViewModel))]
@@ -19,7 +22,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
         {
             var viewModel = new ErrorMessageViewModel
             {
-                Page = new ErrorMessage(CurrentPage, null)
+                Page = new ErrorMessage(CurrentPage, _publishedValueFallback)
             };
             return CurrentTemplate(viewModel);
         }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/PaginationController.cs
@@ -9,6 +9,7 @@ using ThePensionsRegulator.GovUk.Frontend.Umbraco.Validation;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
 using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Core.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -18,13 +19,15 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
     public class PaginationController : RenderController
     {
         private readonly IUmbracoPaginationFactory _paginationFactory;
-
+        private readonly IPublishedValueFallback _publishedValueFallback;
         public PaginationController(ILogger<RenderController> logger,
             ICompositeViewEngine compositeViewEngine,
             IUmbracoContextAccessor umbracoContextAccessor,
-            IUmbracoPaginationFactory paginationFactory) : base(logger, compositeViewEngine, umbracoContextAccessor)
+            IUmbracoPaginationFactory paginationFactory,
+            IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
             _paginationFactory = paginationFactory ?? throw new ArgumentNullException(nameof(paginationFactory));
+            _publishedValueFallback = publishedValueFallback ?? throw new ArgumentNullException(nameof(publishedValueFallback));
         }
 
         [ModelType(typeof(PaginationViewModel))]
@@ -32,7 +35,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
         {
             var viewModel = new PaginationViewModel
             {
-                Page = new Pagination(CurrentPage, null),
+                Page = new Pagination(CurrentPage, _publishedValueFallback),
             };
 
             var block = viewModel.Page.Blocks?.FindBlockByContentTypeAlias(GovukPagination.ModelTypeAlias);

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/RadiosController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/RadiosController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -10,8 +11,10 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class RadiosController : RenderController
     {
-        public RadiosController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public RadiosController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(RadiosViewModel))]
@@ -19,7 +22,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
         {
             var viewModel = new RadiosViewModel
             {
-                Page = new Radios(CurrentPage, null)
+                Page = new Radios(CurrentPage, _publishedValueFallback)
             };
             return CurrentTemplate(viewModel);
         }

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryCardController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryCardController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -10,14 +11,16 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class SummaryCardController : RenderController
     {
-        public SummaryCardController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public SummaryCardController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(SummaryCard))]
         public override IActionResult Index()
         {
-            var viewModel = new SummaryCard(CurrentPage, null);
+            var viewModel = new SummaryCard(CurrentPage, _publishedValueFallback);
 
             // Override content in the block list
             viewModel.Blocks!.FindBlockByClass("full-name")?.Content.OverrideValue(nameof(GovukSummaryListItem.ItemValue), "Sarah Smith");

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/SummaryListController.cs
@@ -17,22 +17,24 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
     {
         private readonly IPublishedContentTypeCache _publishedContentTypeCache;
         private readonly IVariationContextAccessor _variationContextAccessor;
-
+        private readonly IPublishedValueFallback _publishedValueFallback;
         public SummaryListController(ILogger<RenderController> logger,
             ICompositeViewEngine compositeViewEngine,
             IUmbracoContextAccessor umbracoContextAccessor,
             IPublishedContentTypeCache publishedContentTypeCache,
-            IVariationContextAccessor variationContextAccessor)
+            IVariationContextAccessor variationContextAccessor,
+            IPublishedValueFallback publishedValueFallback)
             : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
             _publishedContentTypeCache = publishedContentTypeCache ?? throw new ArgumentNullException(nameof(publishedContentTypeCache));
             _variationContextAccessor = variationContextAccessor ?? throw new ArgumentNullException(nameof(variationContextAccessor));
+            _publishedValueFallback = publishedValueFallback ?? throw new ArgumentNullException(nameof(publishedValueFallback));
         }
 
         [ModelType(typeof(SummaryList))]
         public override IActionResult Index()
         {
-            var viewModel = new SummaryList(CurrentPage, null);
+            var viewModel = new SummaryList(CurrentPage, _publishedValueFallback);
 
             // Override content in a summary list
             var summaryListToOverride = viewModel.Blocks!.FindBlockByClass("override-this");

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TaskListController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Blocks;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -11,14 +12,16 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class TaskListController : RenderController
     {
-        public TaskListController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public TaskListController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(TaskList))]
         public override IActionResult Index()
         {
-            var viewModel = new TaskList(CurrentPage, null);
+            var viewModel = new TaskList(CurrentPage, _publishedValueFallback);
 
             // Override content in the block list
             var target = viewModel.Blocks!.FindBlockByClass("yet-another-thing");

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TextInputController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TextInputController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Umbraco.Validation;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -12,8 +13,10 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class TextInputController : RenderController
     {
-        public TextInputController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public TextInputController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(TextInputViewModel))]
@@ -32,7 +35,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 
             var viewModel = new TextInputViewModel
             {
-                Page = new TextInput(CurrentPage, null)
+                Page = new TextInput(CurrentPage, _publishedValueFallback)
             };
 
             ModelState.SetInitialValue(nameof(TextInputViewModel.Field7), "Hidden field value");

--- a/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TextareaController.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Controllers/TextareaController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using ThePensionsRegulator.GovUk.Frontend.Validation;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.PublishedModels;
@@ -10,8 +11,10 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
 {
     public class TextareaController : RenderController
     {
-        public TextareaController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+        private readonly IPublishedValueFallback _publishedValueFallback;
+        public TextareaController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor, IPublishedValueFallback publishedValueFallback) : base(logger, compositeViewEngine, umbracoContextAccessor)
         {
+            _publishedValueFallback = publishedValueFallback;
         }
 
         [ModelType(typeof(TextareaViewModel))]
@@ -19,7 +22,7 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Controllers
         {
             var viewModel = new TextareaViewModel
             {
-                Page = new Textarea(CurrentPage, null)
+                Page = new Textarea(CurrentPage, _publishedValueFallback)
             };
             return CurrentTemplate(viewModel);
         }

--- a/GovUk.Frontend.Umbraco.ExampleApp/GovUk.Frontend.Umbraco.ExampleApp.csproj
+++ b/GovUk.Frontend.Umbraco.ExampleApp/GovUk.Frontend.Umbraco.ExampleApp.csproj
@@ -13,14 +13,17 @@
   </ItemGroup>
 
     <ItemGroup>
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
         <!-- Pin MessagePack to a patched version to resolve transitive high-severity advisory GHSA-hv8m-jj95-wg3x (CVE-2026-48109) pulled in by Umbraco.Cms. -->
         <PackageReference Include="MessagePack" Version="3.1.7" />
-        <PackageReference Include="Umbraco.Cms" Version="17.2.2" />
+        <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+        <PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
+        <PackageReference Include="Umbraco.Cms" Version="17.5.0" />
     <!-- Force Windows to use ICU. Otherwise Windows 10 2019H1+ will do it, but older Windows 10 and most, if not all, Windows Server editions will run NLS -->
       <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-      <PackageReference Include="uSync" Version="17.0.4" />
+      <PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
+      <PackageReference Include="uSync" Version="17.3.5" />
       <ProjectReference Include="..\ThePensionsRegulator.GovUk.Frontend\ThePensionsRegulator.GovUk.Frontend.csproj" />
       <ProjectReference Include="..\ThePensionsRegulator.Frontend.Umbraco\ThePensionsRegulator.Frontend.Umbraco.csproj" />
       <ProjectReference Include="..\ThePensionsRegulator.GovUk.Frontend.Umbraco\ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj" />

--- a/GovUk.Frontend.Umbraco.ExampleApp/GovUk.Frontend.Umbraco.ExampleApp.csproj
+++ b/GovUk.Frontend.Umbraco.ExampleApp/GovUk.Frontend.Umbraco.ExampleApp.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+		<PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
         <!-- Pin MessagePack to a patched version to resolve transitive high-severity advisory GHSA-hv8m-jj95-wg3x (CVE-2026-48109) pulled in by Umbraco.Cms. -->
         <PackageReference Include="MessagePack" Version="3.1.7" />

--- a/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprYouTubeVideoSettings.generated.cs
+++ b/GovUk.Frontend.Umbraco.ExampleApp/Models/ModelsBuilder/TprYouTubeVideoSettings.generated.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		public virtual string HeadingClass => this.Value<string>(_publishedValueFallback, "headingClass");
 
 		///<summary>
-		/// Heading level: Set the heading level for your text. Defaults to H2 if left blank.
+		/// Heading level: Set the heading level for your text. Defaults to 'Heading 2' if left blank.
 		///</summary>
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "")]
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]

--- a/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Tests/ThePensionsRegulator.Frontend.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
     <PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/ThePensionsRegulator.Frontend.Umbraco.Tests.csproj
@@ -9,11 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
+    <PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -56,9 +56,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
-		<PackageReference Include="MailKit" Version="4.16.0" />
-		<PackageReference Include="uSync.BackOffice" Version="17.0.4" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.101.0" />
+		<PackageReference Include="MailKit" Version="4.17.0" />
+		<PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
+		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
+		<PackageReference Include="uSync.BackOffice" Version="17.3.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.Frontend.Umbraco/ThePensionsRegulator.Frontend.Umbraco.csproj
@@ -58,6 +58,7 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.SassCompiler" Version="1.101.0" />
 		<PackageReference Include="MailKit" Version="4.17.0" />
+		<PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
 		<PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
 		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
 		<PackageReference Include="uSync.BackOffice" Version="17.3.5" />

--- a/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
+++ b/ThePensionsRegulator.Frontend/ThePensionsRegulator.Frontend.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.101.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />

--- a/ThePensionsRegulator.GovUk.Frontend.ConformanceTests/ThePensionsRegulator.GovUk.Frontend.ConformanceTests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.ConformanceTests/ThePensionsRegulator.GovUk.Frontend.ConformanceTests.csproj
@@ -12,13 +12,13 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
@@ -9,12 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
+    <PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
@@ -61,14 +61,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
-		<PackageReference Include="MailKit" Version="4.16.0" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.101.0" />
+		<PackageReference Include="MailKit" Version="4.17.0" />
 		<!-- Pin MessagePack to a patched version to resolve transitive high-severity advisory GHSA-hv8m-jj95-wg3x (CVE-2026-48109) pulled in by Umbraco.Cms. -->
 		<PackageReference Include="MessagePack" Version="3.1.7" />
-		<PackageReference Include="TinyMCE.Umbraco" Version="17.2.0" />
-		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.2.2" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="17.2.2" />
-		<PackageReference Include="uSync.BackOffice" Version="17.0.4" />
+		<PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
+		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="17.5.0" />
+		<PackageReference Include="uSync.BackOffice" Version="17.3.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ThePensionsRegulator.GovUk.Frontend.Umbraco.csproj
@@ -65,6 +65,7 @@
 		<PackageReference Include="MailKit" Version="4.17.0" />
 		<!-- Pin MessagePack to a patched version to resolve transitive high-severity advisory GHSA-hv8m-jj95-wg3x (CVE-2026-48109) pulled in by Umbraco.Cms. -->
 		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
 		<PackageReference Include="TinyMCE.Umbraco" Version="17.5.0" />
 		<PackageReference Include="Umbraco.Cms.Api.Management" Version="17.5.0" />
 		<PackageReference Include="Umbraco.Cms.Web.Website" Version="17.5.0" />

--- a/ThePensionsRegulator.GovUk.Frontend.UnitTests/ThePensionsRegulator.GovUk.Frontend.UnitTests.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend.UnitTests/ThePensionsRegulator.GovUk.Frontend.UnitTests.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="FakeLocalTimeZone" Version="0.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
+++ b/ThePensionsRegulator.GovUk.Frontend/ThePensionsRegulator.GovUk.Frontend.csproj
@@ -39,9 +39,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" />
+		<PackageReference Include="AspNetCore.SassCompiler" Version="1.101.0" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-		<PackageReference Include="FileSignatures" Version="7.0.0" />
+		<PackageReference Include="FileSignatures" Version="7.2.1" />
 		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 		<PackageReference Include="OpenMcdf" Version="3.1.4" />

--- a/ThePensionsRegulator.Umbraco.Core.Tests/ThePensionsRegulator.Umbraco.Core.Tests.csproj
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/ThePensionsRegulator.Umbraco.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,11 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
+++ b/ThePensionsRegulator.Umbraco.Core/ThePensionsRegulator.Umbraco.Core.csproj
@@ -34,11 +34,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <!-- Pin MessagePack to a patched version to resolve transitive high-severity advisory GHSA-hv8m-jj95-wg3x (CVE-2026-48109) pulled in by Umbraco.Cms. -->
     <PackageReference Include="MessagePack" Version="3.1.7" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
-    <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.2.2" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.5.0" />
   </ItemGroup>
 
 </Project>

--- a/ThePensionsRegulator.Umbraco.Testing.Tests/ThePensionsRegulator.Umbraco.Testing.Tests.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing.Tests/ThePensionsRegulator.Umbraco.Testing.Tests.csproj
@@ -9,11 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
+++ b/ThePensionsRegulator.Umbraco.Testing/ThePensionsRegulator.Umbraco.Testing.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoPublishedContentExtensions.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoPublishedContentExtensions.cs
@@ -28,6 +28,11 @@ namespace ThePensionsRegulator.Umbraco.Testing
                     It.IsAny<string?>()))
                 .Returns(parent is null ? [] : [parent]);
 
+            filteringService
+                .Setup(x => x.Unfiltered(
+                    It.Is<IEnumerable<Guid>>(keys => parent == null ? !keys.Any() : keys.Count() == 1 && keys.First() == parentKey)))
+                .Returns(parent is null ? new List<IPublishedContent>() : new List<IPublishedContent> { parent });
+
             return content;
         }
 
@@ -52,6 +57,9 @@ namespace ThePensionsRegulator.Umbraco.Testing
             queryService
                 .Setup(x => x.TryGetAncestorsKeys(child.Object.Key, out ancestorKeys))
                 .Returns(true);
+            queryService
+                .Setup(x => x.TryGetAncestorsKeysOfType(child.Object.Key, child.Object.ContentType.Alias, out ancestorKeys))
+                .Returns(true);
 
             filteringService
                 .Setup(x => x.FilterAvailable(
@@ -59,6 +67,9 @@ namespace ThePensionsRegulator.Umbraco.Testing
                     It.IsAny<string?>()))
                 .Returns(ancestors.ToList());
 
+            filteringService
+                .Setup(x => x.Unfiltered(It.Is<IEnumerable<Guid>>(keys => keys == ancestorKeys)))
+                .Returns(ancestors.ToList());
             return child;
         }
 
@@ -79,6 +90,9 @@ namespace ThePensionsRegulator.Umbraco.Testing
             var childrenKeys = children.Select(c => c.Key);
             queryService
                 .Setup(x => x.TryGetChildrenKeys(parent.Object.Key, out childrenKeys))
+                .Returns(true);
+            queryService
+                .Setup(x => x.TryGetChildrenKeysOfType(parent.Object.Key, parent.Object.ContentType.Alias, out childrenKeys))
                 .Returns(true);
 
             filteringService

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
@@ -467,6 +467,11 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// </summary>
         public Mock<IApiRichTextMarkupParser> ApiRichTextMarkupParser { get; private init; } = new();
 
+        /// <summary>
+        /// Provides access to the property rendering context.
+        /// </summary>
+        public Mock<IPropertyRenderingContextAccessor> PropertyRenderingContextAccessor { get; private init; } = new();
+
         // Disable 'Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.'
         // so that we can use the CurrentPrincipal setter to assign _currentPrincipal.
 #pragma warning disable CS8618
@@ -591,6 +596,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
             SetupService(NotificationService.Object);
             SetupService(PackagingService.Object);
             SetupService(PartialViewBlockEngine.Object);
+            SetupService(PropertyRenderingContextAccessor.Object);
             SetupService(PublicAccessService.Object);
             SetupService(PublishedContentCache.Object);
             SetupService(PublishedMediaCache.Object);


### PR DESCRIPTION
This PR includes:

- Upgrade umbraco to v17.5.0 to deal with vulnerable dependencies
- Upgrade auxiliary  .net core dependencies
- Fix breaking changes for controller based components using null IPublishedValueFallback dependency
- Fixed mock setup extensions to cater for umbraco 17.5.0 updates affecting PublishedContentExtensions