### PR TITLE
Touch targets do not have sufficient size or spacing (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -331,6 +331,7 @@
             padding-right: 0.3rem;
             padding-left: 0.3rem;
             padding-bottom: 1.2rem;
+            margin-right: 0.1rem
         }
     }
 
@@ -445,7 +446,8 @@
     }
 
     .tpr-header-menu__nav-inner-container {
-        width: 100%
+        width: 100%;
+        margin: -1rem;
     }
 
     .tpr-mobile-menu__header-search-container {
@@ -501,6 +503,8 @@
 
     .tpr-header-menu__nav-menu-item {
         margin-right: 0.5rem;
+        padding-top: 1rem;
+        padding-bottom: 1rem;
     }
 }
 

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -330,7 +330,7 @@
             padding: 1rem;
             padding-right: 0.3rem;
             padding-left: 0.3rem;
-            padding-bottom: 1.2rem;
+            padding-bottom: 1.1rem;
             margin-right: 0.1rem
         }
     }
@@ -474,6 +474,10 @@
 
     .tpr-header-menu__arrow-container:has(.tpr-header-menu__arrow:hover) {
         background: $tpr-colour-white;
+    }
+
+    .tpr-header-menu__nav-menu-item:has(.tpr-header-menu__nav-sub-menu:focus-within) {
+         background: $tpr-colour-white;    
     }
 
     .tpr-header-menu__nav-menu-item:has(.tpr-header-menu__nav-sub-menu:focus-within) > a {

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -517,10 +517,6 @@
     color: $tpr-colour-white;
 }
 
-.tpr-header-menu_arrow-container--active {
-    background: $tpr-colour-violet;
-}
-
 @media(max-width: 350px) {
 
     .tpr-mobile-menu__container {

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
@@ -110,9 +110,12 @@ function highlightCurrentSection() {
         const arrowContainer = item.querySelector(".tpr-header-menu__arrow-container")
         const arrow = item.querySelector(".tpr-header-menu__arrow")
 
+        const menuItem = document.querySelector(".tpr-header-menu__nav-menu-item");
+
         if (anchorText.includes(section.toLowerCase())) {
             anchor.classList.toggle("tpr-header-menu__nav-menu-item--active")
-            arrowContainer.classList.toggle("tpr-header-menu_arrow-container--active")
+            menuItem.classList.toggle("tpr-header-menu__nav-menu-item--active")
+          /*  arrowContainer.classList.toggle("tpr-header-menu_arrow-container--active")*/
             arrow.classList.toggle("tpr-header-menu_arrow--active")
         }
     });

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
@@ -107,15 +107,11 @@ function highlightCurrentSection() {
         const anchor = item.querySelector('a');
         let anchorText = anchor.innerHTML.toLowerCase();
 
-        const arrowContainer = item.querySelector(".tpr-header-menu__arrow-container")
         const arrow = item.querySelector(".tpr-header-menu__arrow")
-
-        const menuItem = document.querySelector(".tpr-header-menu__nav-menu-item");
 
         if (anchorText.includes(section.toLowerCase())) {
             anchor.classList.toggle("tpr-header-menu__nav-menu-item--active")
-            menuItem.classList.toggle("tpr-header-menu__nav-menu-item--active")
-          /*  arrowContainer.classList.toggle("tpr-header-menu_arrow-container--active")*/
+            item.classList.toggle("tpr-header-menu__nav-menu-item--active")
             arrow.classList.toggle("tpr-header-menu_arrow--active")
         }
     });


### PR DESCRIPTION
Why: 

- Raised in [#AB269108](https://dev.azure.com/thepensionsregulator/TPR/_boards/board/t/Web%20Platform%20Team/Stories?workitem=269108) that menu items were failing lighthouse accessibility test due to proximity of clickable targets. 

In this PR:

- Added spacing between menu item link and sub menu toggle
- Moved active styling to entire menu item to ensure no gap is visible when menu item is in active state on desktop.