### PR TITLE
Add support for building a breadcrumb trail using async code (v13)

### DIFF
--- a/GovUk.Frontend.Umbraco/Components/GovUkBreadcrumbComponent.cs
+++ b/GovUk.Frontend.Umbraco/Components/GovUkBreadcrumbComponent.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using System;
-using GovUk.Frontend.Umbraco.Models;
+﻿using GovUk.Frontend.Umbraco.Models;
 using GovUk.Frontend.Umbraco.Services;
+using Microsoft.AspNetCore.Mvc;
 using ThePensionsRegulator.Umbraco;
 
 namespace GovUk.Frontend.Umbraco.Components
@@ -9,28 +8,42 @@ namespace GovUk.Frontend.Umbraco.Components
     [ViewComponent(Name = "GovUkBreadcrumb")]
     public class GovUkBreadcrumbComponent : ViewComponent
     {
-        private BreadcrumbViewModel ViewModel;
+        private BreadcrumbViewModel? ViewModel;
+        private readonly IGovUkAsyncBreadcrumbLinksService? _asyncBreadcrumbLinksService;
+        private readonly IGovUkBreadcrumbLinksService? _breadcrumbLinksService;
+        private readonly IUmbracoPublishedContentAccessor _publishedContext;
 
-        public GovUkBreadcrumbComponent(IGovUkBreadcrumbLinksService breadcrumbLinksService, IUmbracoPublishedContentAccessor publishedContext)
+        public GovUkBreadcrumbComponent(
+            IUmbracoPublishedContentAccessor publishedContext,
+            IGovUkAsyncBreadcrumbLinksService? asyncBreadcrumbLinksService = null,
+            IGovUkBreadcrumbLinksService? breadcrumbLinksService = null)
         {
-            if (breadcrumbLinksService is not null && publishedContext is not null)
+            if (publishedContext is null)
             {
-                ViewModel = breadcrumbLinksService.GetLinks(publishedContext.PublishedContent);
+                throw new ArgumentNullException(nameof(publishedContext), "Published context is not initialised.");
             }
-            else if (breadcrumbLinksService is null)
+
+            if (asyncBreadcrumbLinksService is null && breadcrumbLinksService is null)
             {
-                ViewModel.Error = "Breadcrumb links service is not initialised.";
-                throw new ArgumentNullException(nameof(breadcrumbLinksService), ViewModel.Error);
+                throw new ArgumentException("At least one breadcrumb links service must be provided.");
             }
-            else
-            {
-                ViewModel.Error = "Published context is not initialised.";
-                throw new ArgumentNullException(nameof(publishedContext), ViewModel.Error);
-            }
+
+            _asyncBreadcrumbLinksService = asyncBreadcrumbLinksService;
+            _breadcrumbLinksService = breadcrumbLinksService;
+            _publishedContext = publishedContext;
         }
 
-        public IViewComponentResult Invoke()
+        public async Task<IViewComponentResult> InvokeAsync()
         {
+            if (_asyncBreadcrumbLinksService is not null)
+            {
+                ViewModel = await _asyncBreadcrumbLinksService.GetLinks(_publishedContext.PublishedContent);
+            }
+            else if (_breadcrumbLinksService is not null)
+            {
+                ViewModel = _breadcrumbLinksService.GetLinks(_publishedContext.PublishedContent);
+            }
+
             return View("Breadcrumb", ViewModel);
         }
     }

--- a/GovUk.Frontend.Umbraco/Services/IGovUkAsyncBreadcrumbLinksService.cs
+++ b/GovUk.Frontend.Umbraco/Services/IGovUkAsyncBreadcrumbLinksService.cs
@@ -1,0 +1,10 @@
+﻿using GovUk.Frontend.Umbraco.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace GovUk.Frontend.Umbraco.Services
+{
+    public interface IGovUkAsyncBreadcrumbLinksService
+    {
+        public Task<BreadcrumbViewModel> GetLinks(IPublishedContent page);
+    }
+}

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -4,19 +4,27 @@ The breadcrumbs component helps users to understand where they are within a webs
 
 ## How it's implemented
 
-The `govuk-frontend-aspnetcore-extensions` project supplies you with a service interface named `IGovUkBreadcrumbLinksService` in namespace `GovUk.Frontend.Umbraco.Services`, located inside the `ThePensionsRegulator.Govuk.Frontend.Umbraco` package. 
+The `govuk-frontend-aspnetcore-extensions` project supplies you with service interfaces for breadcrumb management in namespace `GovUk.Frontend.Umbraco.Services`, located inside the `ThePensionsRegulator.Govuk.Frontend.Umbraco` package:
 
-Create your own implementation of the `IGovUkBreadcrumbLinksService` interface by inheriting from it in your own custom service class e.g `public class BreadcrumbLinksServiceForExampleApp : IGovUkBreadcrumbLinksService`. This allows you to provide your own links to the GovUkBreadcrumb component. You can then have full control over the breadcrumb links in your project. You may benefit by:
+### Synchronous Implementation
+
+Create your own implementation of the `IGovUkBreadcrumbLinksService` interface by inheriting from it in your own custom service class, e.g. `public class BreadcrumbLinksServiceForExampleApp : IGovUkBreadcrumbLinksService`. You simply need to implement the `public BreadcrumbViewModel GetLinks(IPublishedContent Page)` method.
+
+### Asynchronous Implementation
+
+For asynchronous operations (eg database calls, external API calls), create a class that implements `IGovUkAsyncBreadcrumbLinksService` by implementing the `public async Task<BreadcrumbViewModel> GetLinks(IPublishedContent Page)` method.
+
+### Benefits
+
+You can provide your own links to the GovUkBreadcrumb component and have full control over the breadcrumb links in your project:
 -  Having different logic for generating breadcrumb links based on the page type.
--  Implementing custom logic for how to populate the link text of each link. 
+-  Implementing custom logic for how to populate the link text of each link.
+-  Using async operations to fetch breadcrumb data from external sources without blocking the request.
 
-You simply need to implement the `public BreadcrumbViewModel GetLinks(IPublishedContent Page)` method in your custom service class and return a populated `GovUk.Frontend.Umbraco.Models.BreadcrumbViewModel` object. 
+## Create your IGovUkBreadcrumbLinksService implementation (Synchronous)
 
+Here is an example of a synchronous implementation from within the `GovUk.Frontend.Umbraco.ExampleApp`:
 
-
-## Create your IGovUkBreadcrumbLinksService implementation
-
-Here is an example of this implementation from within the `GovUk.Frontend.Umbraco.ExampleApp`:
 ```csharp
 using System.Linq;
 using GovUk.Frontend.Umbraco.Models;
@@ -44,12 +52,58 @@ namespace GovUk.Frontend.Umbraco.ExampleApp.Services
 }
 
 ```
+
+## Create your IGovUkAsyncBreadcrumbLinksService implementation (Asynchronous)
+
+```csharp
+using System.Linq;
+using GovUk.Frontend.Umbraco.Models;
+using GovUk.Frontend.Umbraco.Services;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace GovUk.Frontend.Umbraco.ExampleApp.Services
+{
+    public class AsyncBreadcrumbLinksServiceForExampleApp(IExternalBreadcrumbDataService externalService) : IGovUkAsyncBreadcrumbLinksService
+    {
+        public async Task<BreadcrumbViewModel> GetLinksAsync(IPublishedContent page)
+        {
+            BreadcrumbViewModel breadcrumbViewModel = new();
+
+            foreach (var ancestor in page.Ancestors().OrderBy(x => x.Level)) 
+            {
+                // Example: fetch additional data from external service asynchronously
+                var additionalData = await _externalService.GetLinkDataAsync(ancestor.Id);
+                breadcrumbViewModel.Links.Add(new BreadcrumbLink 
+                { 
+                    Name = additionalData.DisplayName ?? ancestor.Name, 
+                    Url = ancestor.Url() 
+                }); 
+            }
+
+            breadcrumbViewModel.Links.Add(new BreadcrumbLink { Name = page.Name }); 
+            breadcrumbViewModel.CurrentPage = page;
+            return breadcrumbViewModel;
+        }
+    }
+}
+
+```
 ## Register your service
+
 You should register your service class within your Program/Startup file (or wherever you keep your services declarations) with code such as the following:
 
+**For synchronous implementation:**
 ```csharp
 services.AddTransient<IGovUkBreadcrumbLinksService, BreadcrumbLinksServiceForExampleApp>();
 ```
+
+**For asynchronous implementation:**
+```csharp
+services.AddTransient<IGovUkAsyncBreadcrumbLinksService, AsyncBreadcrumbLinksServiceForExampleApp>();
+```
+
+If both are registered, the asynchronous implementation will be used.
 
 ## Render the breadcrumb
 


### PR DESCRIPTION
This PR updates the `GovUkBreadcrumbComponent` view component for Umbraco v13 to accept either async or synchronous implementations of the service that provides the breadcrumb links. Only the synchronous service was supported before.

Adding the extra option enables async code to be called within the service without inefficient use of `.Result`. The async implementation is preferred but will fall back gracefully to the synchronous implementation if not provided.

This is a non-breaking change because the change to the constructor will be handled by DI.

A similar PR will follow for v17 so that this does not become a regression.

[AB#271232](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/271232)