### PR TITLE
Add support for building a breadcrumb trail using async code (v17)

### DIFF
--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Services/IGovUkAsyncBreadcrumbLinksService.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Services/IGovUkAsyncBreadcrumbLinksService.cs
@@ -1,0 +1,10 @@
+﻿using ThePensionsRegulator.GovUk.Frontend.Umbraco.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Services
+{
+    public interface IGovUkAsyncBreadcrumbLinksService
+    {
+        public Task<BreadcrumbViewModel> GetLinks(IPublishedContent page);
+    }
+}

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkBreadcrumbs.cshtml
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkBreadcrumbs.cshtml
@@ -1,12 +1,24 @@
-﻿@using ThePensionsRegulator.GovUk.Frontend.Umbraco.Services
-@using ThePensionsRegulator.Umbraco
+﻿@using Microsoft.Extensions.DependencyInjection
+@using ThePensionsRegulator.GovUk.Frontend.Umbraco.Models
+@using ThePensionsRegulator.GovUk.Frontend.Umbraco.Services
 @using ThePensionsRegulator.Umbraco.Core
-@using Umbraco.Cms.Core.Routing
 @addTagHelper *, GovUk.Frontend.AspNetCore
-@inject IGovUkBreadcrumbLinksService breadcrumbLinksService
+@inject IServiceProvider serviceProvider
 @inject IUmbracoPublishedContentAccessor publishedContext
 @{
-    var model = breadcrumbLinksService.GetLinks(publishedContext.PublishedContent);
+    BreadcrumbViewModel? model = null;
+
+    var asyncBreadcrumbLinksService = serviceProvider.GetService(typeof(IGovUkAsyncBreadcrumbLinksService)) as IGovUkAsyncBreadcrumbLinksService;
+
+    if (asyncBreadcrumbLinksService is not null)
+    {
+        model = await asyncBreadcrumbLinksService.GetLinks(publishedContext.PublishedContent);
+    }
+    else 
+    {
+        var breadcrumbLinksService = serviceProvider.GetRequiredService(typeof(IGovUkBreadcrumbLinksService)) as IGovUkBreadcrumbLinksService;
+        model = breadcrumbLinksService!.GetLinks(publishedContext.PublishedContent);
+    }
 }
 
 <govuk-breadcrumbs collapse-on-mobile="true">

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkBreadcrumbs.cshtml
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Views/Shared/GOVUK/GovUkBreadcrumbs.cshtml
@@ -19,6 +19,7 @@
         var breadcrumbLinksService = serviceProvider.GetRequiredService(typeof(IGovUkBreadcrumbLinksService)) as IGovUkBreadcrumbLinksService;
         model = breadcrumbLinksService!.GetLinks(publishedContext.PublishedContent);
     }
+    if (model is null) { return; }
 }
 
 <govuk-breadcrumbs collapse-on-mobile="true">

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -12,7 +12,9 @@ In Umbraco applications the Breadcrumbs component is _not_ added to the block gr
 <partial name="GOVUK/GovUkBreadcrumbs" />
 ```
 
-If the default implementation does not meet your needs you can create your own implementation of the `ThePensionsRegulator.GovUk.Frontend.Umbraco.Services.IGovUkBreadcrumbLinksService` interface from the `ThePensionsRegulator.Govuk.Frontend.Umbraco` NuGet package, and replace the default implementation which is registered with dependency injection. This allows you to provide your own links to the `GovUkBreadcrumb` component. You can then have full control over the breadcrumb links in your project. You may benefit by:
+If the default implementation does not meet your needs you can create your own implementation of either the `ThePensionsRegulator.GovUk.Frontend.Umbraco.Services.IGovUkAsyncBreadcrumbLinksService` or `ThePensionsRegulator.GovUk.Frontend.Umbraco.Services.IGovUkBreadcrumbLinksService` interface from the `ThePensionsRegulator.Govuk.Frontend.Umbraco` NuGet package, and replace the default implementation which is registered with dependency injection. This allows you to provide your own links to the `GovUkBreadcrumb` component. You can then have full control over the breadcrumb links in your project. You may benefit by:
 
 - Having different logic for generating breadcrumb links based on the page type.
 - Implementing custom logic for how to populate the link text of each link.
+
+If implementations are registered in DI for both interfaces, the async service will be preferred.


### PR DESCRIPTION
This PR updates the `GovUkBreadcrumbs` partial view for Umbraco v17 to accept either async or synchronous implementations of the service that provides the breadcrumb links. Only the synchronous service was supported before.

Adding the extra option enables async code to be called within the service without inefficient use of `.Result`. The async implementation is preferred but will fall back gracefully to the synchronous implementation if not provided.

This is a non-breaking change because the async service is optional and the view will fall back to the previous behaviour.

[AB#271232](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/271232)