### PR TITLE
Security fixes to align server-side protection with client-side for CSV table downloads

### DIFF
--- a/ThePensionsRegulator.Frontend.Tests/Services/TableCsvServiceTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Services/TableCsvServiceTests.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using ThePensionsRegulator.Frontend.Services;
+
+namespace ThePensionsRegulator.Frontend.Tests.Services
+{
+    public class TableCsvServiceTests
+    {
+        private readonly TableCsvService _service = new();
+
+        private static string DecodeCsv(byte[] csvBytes)
+        {
+            var preamble = Encoding.UTF8.GetPreamble();
+            var content = csvBytes[preamble.Length..];
+            return Encoding.UTF8.GetString(content);
+        }
+
+        [Fact]
+        public void Converts_simple_table_to_csv()
+        {
+            var html = "<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("Name,Age" + Environment.NewLine + "Alice,30" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Returns_only_bom_when_no_table_present()
+        {
+            var csvBytes = _service.ConvertHtmlTableToCsv("<div>no table here</div>");
+
+            Assert.Equal(Encoding.UTF8.GetPreamble(), csvBytes);
+        }
+
+        [Fact]
+        public void Does_not_alter_ordinary_cell_values()
+        {
+            var html = "<table><tr><td>hello</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("hello" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Quotes_cell_value_containing_comma()
+        {
+            var html = "<table><tr><td>hello,world</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("\"hello,world\"" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Quotes_cell_value_containing_double_quote_and_escapes_it()
+        {
+            var html = "<table><tr><td>say \"hello\"</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("\"say \"\"hello\"\"\"" + Environment.NewLine, csv);
+        }
+
+        // CSV injection (formula injection, CWE-1236): table HTML/cell content is untrusted
+        // input supplied directly by the client, so values that spreadsheet applications
+        // interpret as the start of a formula must be neutralised. Mirrors the equivalent
+        // client-side test cases for escapeCsvValue in tpr-table-csv-download.tests.js.
+        [Theory]
+        [InlineData("=SUM(A1)", "'=SUM(A1)")]
+        [InlineData("+44 123", "'+44 123")]
+        [InlineData("-1", "'-1")]
+        [InlineData("@mention", "'@mention")]
+        public void Prefixes_formula_triggering_cell_values_to_prevent_csv_injection(string cellValue, string expected)
+        {
+            var html = $"<table><tr><td>{cellValue}</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal(expected + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Prefixes_and_quotes_formula_triggering_value_that_also_contains_a_comma()
+        {
+            var html = "<table><tr><td>=A,B</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("\"'=A,B\"" + Environment.NewLine, csv);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco.Tests/Controllers/TableDownloadControllerTests.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco.Tests/Controllers/TableDownloadControllerTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text;
+using ThePensionsRegulator.Frontend.Services;
+using ThePensionsRegulator.Frontend.Umbraco.Controllers;
+
+namespace ThePensionsRegulator.Frontend.Umbraco.Tests.Controllers
+{
+    public class TableDownloadControllerTests
+    {
+        private sealed class StubTableCsvService : ITableCsvService
+        {
+            public byte[] ConvertHtmlTableToCsv(string tableHtml) => Encoding.UTF8.GetBytes("stub-csv-content");
+        }
+
+        private static TableDownloadController CreateController() => new(new StubTableCsvService());
+
+        [Fact]
+        public void Missing_table_html_returns_bad_request()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv(string.Empty, "report");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public void Response_uses_csv_content_type_and_content_from_service()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", "report");
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("text/csv", fileResult.ContentType);
+            Assert.Equal(Encoding.UTF8.GetBytes("stub-csv-content"), fileResult.FileContents);
+        }
+
+        [Fact]
+        public void Missing_file_name_defaults_to_table_data()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", null);
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("table-data.csv", fileResult.FileDownloadName);
+        }
+
+        [Fact]
+        public void File_name_is_sanitized()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", "My Report!!");
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("my-report.csv", fileResult.FileDownloadName);
+        }
+
+        [Fact]
+        public void File_name_defaults_to_table_data_when_sanitizing_removes_everything()
+        {
+            var controller = CreateController();
+
+            var result = controller.DownloadCsv("<table></table>", "###");
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("table-data.csv", fileResult.FileDownloadName);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Umbraco/Controllers/TableDownloadController.cs
+++ b/ThePensionsRegulator.Frontend.Umbraco/Controllers/TableDownloadController.cs
@@ -50,7 +50,12 @@ public class TableDownloadController : ControllerBase
 
         var sanitized = Regex.Replace(fileName.Trim(), @"[^\w\s\-]", "");
         sanitized = Regex.Replace(sanitized, @"\s+", "-").ToLowerInvariant();
-        
+
+        if (string.IsNullOrEmpty(sanitized))
+        {
+            return null;
+        }
+
         return sanitized.Length > 50 ? sanitized[..50] : sanitized;
     }
 }

--- a/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
+++ b/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
@@ -54,6 +54,17 @@ public class TableCsvService : ITableCsvService
             return string.Empty;
         }
 
+        // CSV injection (formula injection) mitigation: if the value starts with a character
+        // that spreadsheet applications (Excel, Google Sheets, LibreOffice) interpret as the
+        // start of a formula, prefix it with a single quote so it is opened as literal text
+        // instead of being executed. This mirrors the client-side escapeCsvValue in
+        // tpr-table-csv-download.js, since tableHtml/cell content here is untrusted input
+        // supplied directly by the client.
+        if (value[0] is '=' or '+' or '-' or '@' or '\t' or '\r')
+        {
+            value = "'" + value;
+        }
+
         if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
         {
             return $"\"{value.Replace("\"", "\"\"")}\"";


### PR DESCRIPTION
CoPilot review when asked about the security of posting filename and HTML data to an API:

## Finding 1 (Critical): CSV/Formula Injection — CWE-1236

`POST /api/table/download-csv` treats `tableHtml` as fully trusted, but it is client-supplied form data, not something the server can verify actually matches page content. `TableCsvService.EscapeCsvValue` only quoted cells containing ,, ", or newlines — it did nothing to neutralize values starting with =, +, -, @, tab, or CR. Those characters are interpreted by Excel/Google Sheets/LibreOffice as the start of a formula. An attacker who can get a victim to submit (or directly POST) a cell value like `=HYPERLINK("http://evil/",...) `or a legacy `=cmd|'/c calc'!A1` DDE payload gets it written verbatim into the downloaded CSV. Opening that file later executes the formula in the victim's spreadsheet app — a real code-execution/data-exfiltration vector.

Notably, the client-side `escapeCsvValue` in `tpr-table-csv-download.js` already implements exactly this mitigation (prefixing with '), with dedicated unit tests. The server-side no-JS fallback path had silently regressed/never had parity with it — this is the concrete gap your hint about "untrusted client-side data" was pointing at. The anti-forgery token only mitigates CSRF; it does not validate or neutralize the content being converted.

Fix applied `(TableCsvService.cs): EscapeCsvValue` now prefixes values starting with =, +, -, @, tab, or \r with a single quote before applying RFC 4180 quoting — matching the JS implementation exactly.

## Finding 2 (Low): Filename sanitization could produce an empty name

`TableDownloadController.SanitizeFileName` stripped disallowed characters but, unlike its JS twin (`sanitizeFileName` in the same JS file, which explicitly falls back to "table-data" when nothing survives sanitization), it returned an empty string (not null) when the input was all punctuation (e.g. `"###"`). Since the controller only falls back via `?? "table-data"`, this produced a bare .csv download instead of the safe default.

Fix applied `(TableDownloadController.cs): SanitizeFileName` now returns null when sanitization leaves nothing, so the existing `?? "table-data"` fallback engages correctly.

[AB#269788](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/269788)