### PR TITLE
Support additional localizable attributes on documents component (v17)

### DIFF
--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/pages.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/pages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Dictionary Key="a997298e-3b70-44b6-b9d0-b67daf1f1e48" Alias="Pages" Level="0">
+  <Info />
+  <Translations>
+    <Translation Language="cy">tudalen(nau)</Translation>
+    <Translation Language="en-GB">page(s)</Translation>
+  </Translations>
+</Dictionary>

--- a/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/published.config
+++ b/GovUk.Frontend.Umbraco.ExampleApp/uSync/v17/Dictionary/published.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Dictionary Key="d7b92c69-d92f-4733-8ba0-79da92faf173" Alias="Published" Level="0">
+  <Info />
+  <Translations>
+    <Translation Language="cy">Cyhoeddwyd</Translation>
+    <Translation Language="en-GB">Published </Translation>
+  </Translations>
+</Dictionary>

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
@@ -6,7 +6,6 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
 {
     public class TprDocumentTitleTagHelperTests
     {
-
         [Theory]
         [InlineData("/media/test.pdf", "pdf", "PDF", "120KB, 4 page(s)")]
         [InlineData("/media/test.doc", "doc", "Word", "120KB, 4 page(s)")]
@@ -17,37 +16,13 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
         [InlineData("/media/test.odt", "misc", "ODT", "120KB, 4 page(s)")]
         [InlineData("/media/test.xlsx", "excel", "Excel", "120KB")]
         [InlineData("/media/test.xlst", "excel", "XLST", "120KB")]
-        [InlineData("/media/test.csv", "excel", "CSV", "120KB")]
+        [InlineData("/media/test.csv", "excel", "CSV", "120KB")]    
         public async Task TprDocumentTitleTagHelper_Should_RenderExpected_DocumentMetadata(string href, string expectedIconClass, string expectedFileLabel, string expectedMetaDataText)
         {
-
-            //Arrange
-            var documentContext = new TprDocumentContext
-            {
-                Href = href,
-                KbSize = "120",
-                Pages = "4"
-            };
-
-            var attributes = new TagHelperAttributeList();
-
-            var context = new TagHelperContext(attributes, new Dictionary<object, object> { { typeof(TprDocumentsTagHelper), documentContext } }, Guid.NewGuid().ToString());
-
-            var output = new TagHelperOutput(TprDocumentTitleTagHelper.TagName, attributes, (useCachedResult, encoder) =>
-            {
-                var tagHelperContent = new DefaultTagHelperContent();
-                return Task.FromResult<TagHelperContent>(tagHelperContent);
-            });
-
-            var tagHelper = new TprDocumentTitleTagHelper();
-
             //Act
-            await tagHelper.ProcessAsync(context, output);
+            var output = await GenerateTagHelper(href, "4");
 
-            using var result = new StringWriter();
-            output.WriteTo(result, HtmlEncoder.Create());
-
-            var html = result.ToString();
+            var html = RenderHtml(output);
 
             //Assert
             Assert.Contains("<dt>", html);
@@ -55,39 +30,17 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
             Assert.Contains($"href=\"{href}\"", html);
             Assert.Contains($"<span class=\"{expectedIconClass} fileicon\">{expectedFileLabel}</span>", html);
             Assert.Contains(expectedMetaDataText, html);
+            Assert.Contains("download", html);
             Assert.Contains("</dt>", html);
         }
 
         [Fact]
         public async Task Document_WithZeroPages_DoesNotRender_PageCount()
-        {
-            //Arrange
-            var documentContext = new TprDocumentContext
-            {
-                Href = "/media/test.pdf",
-                KbSize = "120",
-                Pages = "0"
-            };
-
-            var attributes = new TagHelperAttributeList();
-
-            var context = new TagHelperContext(attributes, new Dictionary<object, object> { { typeof(TprDocumentsTagHelper), documentContext } }, Guid.NewGuid().ToString());
-
-            var output = new TagHelperOutput(TprDocumentTitleTagHelper.TagName, attributes, (useCachedResult, encoder) =>
-            {
-                var tagHelperContent = new DefaultTagHelperContent();
-                return Task.FromResult<TagHelperContent>(tagHelperContent);
-            });
-
-            var tagHelper = new TprDocumentTitleTagHelper();
-
+        { 
             //Act
-            await tagHelper.ProcessAsync(context, output);
+            var output = await GenerateTagHelper("/media/test.pdf", "0");
 
-            using var result = new StringWriter();
-            output.WriteTo(result, HtmlEncoder.Create());
-
-            var html = result.ToString();
+            var html = RenderHtml(output);
 
             //Assert
             Assert.Contains("PDF", html);
@@ -98,11 +51,17 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
         [Fact]
         public async Task ProcessAsync_WhenHrefIsNull_ThrowsArgumentNullException()
         {
+            //Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => GenerateTagHelper(null, "4"));
+        }
+
+        private static async Task<TagHelperOutput> GenerateTagHelper(string href, string pages)
+        {
             var documentContext = new TprDocumentContext
             {
-                Href = null,
+                Href = href,
                 KbSize = "120",
-                Pages = "1"
+                Pages = pages
             };
 
             var attributes = new TagHelperAttributeList();
@@ -117,17 +76,17 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
 
             var tagHelper = new TprDocumentTitleTagHelper();
 
-            await Assert.ThrowsAsync<ArgumentNullException>(
-                () => tagHelper.ProcessAsync(context, output));
+
+            await tagHelper.ProcessAsync(context, output);
+
+            return output;
         }
 
-        [Theory]
-        [InlineData("/media/test.pdf")]
-        [InlineData("/media/test.docx")]
-        [InlineData("/media/test.xlsx")]
-        public async Task MediaFiles_Should_RenderDowloadAttribute(string href)
+        private static string RenderHtml(TagHelperOutput output)
         {
-
+            using var result = new StringWriter();
+            output.WriteTo(result, HtmlEncoder.Create());
+            return result.ToString();
         }
     }
 }

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
@@ -15,6 +15,7 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
         [InlineData("/media/test.rtf", "misc", "RTF", "120KB, 4 page(s)")]
         [InlineData("/media/test.odt", "misc", "ODT", "120KB, 4 page(s)")]
         [InlineData("/media/test.xlsx", "excel", "Excel", "120KB")]
+        [InlineData("/media/test.xlst", "excel", "XLST", "120KB")]
         [InlineData("/media/test.csv", "excel", "CSV", "120KB")]
         public async Task TprDocumentTitleTagHelper_Should_RenderExpected_DocumentMetadata(string href, string expectedIconClass, string expectedFileLabel, string expectedMetaDataText)
         {

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using ThePensionsRegulator.Frontend.TagHelpers;
+
+namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
+{
+    public class TprDocumentTitleTagHelperTests
+    {
+
+        [Theory]
+        [InlineData("/media/test.pdf", "pdf", "PDF", "120KB, 4 page(s)")]
+        [InlineData("/media/test.doc", "doc", "Word", "120KB, 4 page(s)")]
+        [InlineData("/media/test.docx", "doc", "Word", "120KB, 4 page(s)")]
+        [InlineData("/media/test.pptx", "powerpoint", "PPTX", "120KB, 4 page(s)")]
+        [InlineData("/media/test.rtf", "misc", "RTF", "120KB, 4 page(s)")]
+        [InlineData("/media/test.odt", "misc", "ODT", "120KB, 4 page(s)")]
+        [InlineData("/media/test.xlsx", "excel", "Excel", "120KB")]
+        [InlineData("/media/test.csv", "excel", "CSV", "120KB")]
+        public async Task TprDocumentTitleTagHelper_Should_RenderExpected_DocumentMetadata(string href, string expectedIconClass, string expectedFileLabel, string expectedMetaDataText)
+        {
+
+            //Arrange
+            var documentContext = new TprDocumentContext
+            {
+                Href = href,
+                KbSize = "120",
+                Pages = "4"
+            };
+
+            var attributes = new TagHelperAttributeList();
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object> { { typeof(TprDocumentsTagHelper), documentContext } }, Guid.NewGuid().ToString());
+
+            var output = new TagHelperOutput(TprDocumentTitleTagHelper.TagName, attributes, (useCachedResult, encoder) =>
+            {
+                var tagHelperContent = new DefaultTagHelperContent();
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+            var tagHelper = new TprDocumentTitleTagHelper();
+
+            //Act
+            await tagHelper.ProcessAsync(context, output);
+
+            using var result = new StringWriter();
+            output.WriteTo(result, HtmlEncoder.Create());
+
+            var html = result.ToString();
+
+            //Assert
+            Assert.Contains("<dt>", html);
+            Assert.Contains($"<span class=\"{expectedIconClass} fileicon\">{expectedFileLabel}</span>", html);
+            Assert.Contains(expectedMetaDataText, html);
+            Assert.Contains("</dt>", html);
+        }
+
+        [Fact]
+        public async Task Document_WithZeroPages_DoesNotRender_PageCount()
+        {
+            //Arrange
+            var documentContext = new TprDocumentContext
+            {
+                Href = "/media/test.pdf",
+                KbSize = "120",
+                Pages = "0"
+            };
+
+            var attributes = new TagHelperAttributeList();
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object> { { typeof(TprDocumentsTagHelper), documentContext } }, Guid.NewGuid().ToString());
+
+            var output = new TagHelperOutput(TprDocumentTitleTagHelper.TagName, attributes, (useCachedResult, encoder) =>
+            {
+                var tagHelperContent = new DefaultTagHelperContent();
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+            var tagHelper = new TprDocumentTitleTagHelper();
+
+            //Act
+            await tagHelper.ProcessAsync(context, output);
+
+            using var result = new StringWriter();
+            output.WriteTo(result, HtmlEncoder.Create());
+
+            var html = result.ToString();
+
+            //Assert
+            Assert.Contains("PDF", html);
+            Assert.Contains("120KB", html);
+            Assert.DoesNotContain("pages(s)", html);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
@@ -11,6 +11,7 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
         [InlineData("/media/test.pdf", "pdf", "PDF", "120KB, 4 page(s)")]
         [InlineData("/media/test.doc", "doc", "Word", "120KB, 4 page(s)")]
         [InlineData("/media/test.docx", "doc", "Word", "120KB, 4 page(s)")]
+        [InlineData("/media/test.dotx", "doc", "DOTX", "120KB")]
         [InlineData("/media/test.pptx", "powerpoint", "PPTX", "120KB, 4 page(s)")]
         [InlineData("/media/test.rtf", "misc", "RTF", "120KB, 4 page(s)")]
         [InlineData("/media/test.odt", "misc", "ODT", "120KB, 4 page(s)")]
@@ -50,6 +51,8 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
 
             //Assert
             Assert.Contains("<dt>", html);
+            Assert.Contains("govuk-link", html);
+            Assert.Contains($"href=\"{href}\"", html);
             Assert.Contains($"<span class=\"{expectedIconClass} fileicon\">{expectedFileLabel}</span>", html);
             Assert.Contains(expectedMetaDataText, html);
             Assert.Contains("</dt>", html);
@@ -89,7 +92,42 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
             //Assert
             Assert.Contains("PDF", html);
             Assert.Contains("120KB", html);
-            Assert.DoesNotContain("pages(s)", html);
+            Assert.DoesNotContain("page(s)", html);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_WhenHrefIsNull_ThrowsArgumentNullException()
+        {
+            var documentContext = new TprDocumentContext
+            {
+                Href = null,
+                KbSize = "120",
+                Pages = "1"
+            };
+
+            var attributes = new TagHelperAttributeList();
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object> { { typeof(TprDocumentsTagHelper), documentContext } }, Guid.NewGuid().ToString());
+
+            var output = new TagHelperOutput(TprDocumentTitleTagHelper.TagName, attributes, (useCachedResult, encoder) =>
+            {
+                var tagHelperContent = new DefaultTagHelperContent();
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+            var tagHelper = new TprDocumentTitleTagHelper();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => tagHelper.ProcessAsync(context, output));
+        }
+
+        [Theory]
+        [InlineData("/media/test.pdf")]
+        [InlineData("/media/test.docx")]
+        [InlineData("/media/test.xlsx")]
+        public async Task MediaFiles_Should_RenderDowloadAttribute(string href)
+        {
+
         }
     }
 }

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprDocumentTitleTagHelperTests.cs
@@ -76,7 +76,6 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
 
             var tagHelper = new TprDocumentTitleTagHelper();
 
-
             await tagHelper.ProcessAsync(context, output);
 
             return output;

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
@@ -28,6 +28,7 @@
             var docLinkType = documentLink.Type;
             var docPages = document.Content.Value<string>(TprPropertyAliases.DocumentNumberOfPages);
             var dteValue = document.Content.Value<DateTime>(TprPropertyAliases.DocumentDatePublished);
+            var docPublishedLabel = Umbraco.GetDictionaryValueOrDefault("Published", "Published");
             var docDatePublished = dteValue > DateTime.MinValue ? dteValue.ToString("MMMM yyyy") : null;
             var docDescription = document.Content.Value<string>(TprPropertyAliases.DocumentDescription);
 
@@ -54,14 +55,14 @@
                         : mediaLinkDocName;
                 }
 
-                <tpr-document href="@docHref" kbsize="@docKB" pages="@docPages" datepublished="@docDatePublished" innercss="@innerCssClasses">
+                <tpr-document href="@docHref" kbsize="@docKB" pages="@docPages" published-label="@docPublishedLabel" datepublished="@docDatePublished" innercss="@innerCssClasses">
                     <tpr-document-title>@docTitle</tpr-document-title>
                     <tpr-document-description>@docDescription</tpr-document-description>
                 </tpr-document>
             }
             else
             {
-                <tpr-document href="@docHref" pages="@docPages" datepublished="@docDatePublished" innercss="@innerCssClasses">
+                <tpr-document href="@docHref" pages="@docPages" published-label="@docPublishedLabel" datepublished="@docDatePublished" innercss="@innerCssClasses">
                     <tpr-document-title>@documentLink.Name</tpr-document-title>
                     <tpr-document-description>@docDescription</tpr-document-description>
                 </tpr-document>

--- a/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
+++ b/ThePensionsRegulator.Frontend.Umbraco/Views/Shared/TPR/TPRDocuments.cshtml
@@ -28,6 +28,7 @@
             var docLinkType = documentLink.Type;
             var docPages = document.Content.Value<string>(TprPropertyAliases.DocumentNumberOfPages);
             var dteValue = document.Content.Value<DateTime>(TprPropertyAliases.DocumentDatePublished);
+			var docPagesLabel = Umbraco.GetDictionaryValueOrDefault("Pages", "page(s)");
             var docPublishedLabel = Umbraco.GetDictionaryValueOrDefault("Published", "Published");
             var docDatePublished = dteValue > DateTime.MinValue ? dteValue.ToString("MMMM yyyy") : null;
             var docDescription = document.Content.Value<string>(TprPropertyAliases.DocumentDescription);
@@ -55,14 +56,14 @@
                         : mediaLinkDocName;
                 }
 
-                <tpr-document href="@docHref" kbsize="@docKB" pages="@docPages" published-label="@docPublishedLabel" datepublished="@docDatePublished" innercss="@innerCssClasses">
+                <tpr-document href="@docHref" kbsize="@docKB" pages="@docPages" pages-label="@docPagesLabel" published-label="@docPublishedLabel" datepublished="@docDatePublished" innercss="@innerCssClasses">
                     <tpr-document-title>@docTitle</tpr-document-title>
                     <tpr-document-description>@docDescription</tpr-document-description>
                 </tpr-document>
             }
             else
             {
-                <tpr-document href="@docHref" pages="@docPages" published-label="@docPublishedLabel" datepublished="@docDatePublished" innercss="@innerCssClasses">
+                <tpr-document href="@docHref" pages="@docPages" pages-label="@docPagesLabel" published-label="@docPublishedLabel" datepublished="@docDatePublished" innercss="@innerCssClasses">
                     <tpr-document-title>@documentLink.Name</tpr-document-title>
                     <tpr-document-description>@docDescription</tpr-document-description>
                 </tpr-document>

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentContext.cs
@@ -10,6 +10,8 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
 
         public string? Pages { get; set; }
 
+        public string? PublishedLabel { get; set; } 
+
         public string? DatePublished { get; set; }
 
         public IHtmlContent? Document { get; set; }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentContext.cs
@@ -10,6 +10,8 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
 
         public string? Pages { get; set; }
 
+        public string? PagesLabel { get; set; }
+
         public string? PublishedLabel { get; set; } 
 
         public string? DatePublished { get; set; }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentDescriptionTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentDescriptionTagHelper.cs
@@ -13,10 +13,11 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             var documentContext = (TprDocumentContext)context.Items[typeof(TprDocumentsTagHelper)];
             var innerText = await output.GetChildContentAsync();
             documentContext.DocumentDescription = innerText;
+            var publishedLabel = documentContext.PublishedLabel ?? "Published";
 
             if (!string.IsNullOrEmpty(documentContext.DatePublished))
             {
-                output.PreElement.SetHtmlContent($"<dd>Published: {documentContext.DatePublished}</dd>");
+                output.PreElement.SetHtmlContent($"<dd>{publishedLabel}: {documentContext.DatePublished}</dd>");
             }
 
             output.TagName = innerText.IsEmptyOrWhiteSpace ? "" : "dd";

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
@@ -19,6 +19,9 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         [HtmlAttributeName("pages")]
         public string? Pages { get; set; }
 
+        [HtmlAttributeName("published-label")]
+        public string? PublishedLabel { get; set; }
+
         [HtmlAttributeName("datepublished")]
         public string? DatePublished { get; set; }
 
@@ -33,6 +36,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             documentContext.Href = Href;
             documentContext.KbSize = KbSize;
             documentContext.Pages = Pages;
+            documentContext.PublishedLabel = PublishedLabel;
             documentContext.DatePublished = DatePublished;
             documentContext.Document = await output.GetChildContentAsync();
 

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTagHelper.cs
@@ -19,6 +19,9 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         [HtmlAttributeName("pages")]
         public string? Pages { get; set; }
 
+        [HtmlAttributeName("pages-label")]
+        public string? PagesLabel { get; set; }
+
         [HtmlAttributeName("published-label")]
         public string? PublishedLabel { get; set; }
 
@@ -36,6 +39,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             documentContext.Href = Href;
             documentContext.KbSize = KbSize;
             documentContext.Pages = Pages;
+            documentContext.PagesLabel = PagesLabel;
             documentContext.PublishedLabel = PublishedLabel;
             documentContext.DatePublished = DatePublished;
             documentContext.Document = await output.GetChildContentAsync();

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
@@ -33,7 +33,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                     case ".docx":
                         output.PostContent.SetHtmlContent(GenerateFileInfoHtml("doc", "Word", documentContext, includePages: true));
                         break;
-                    case "dotx":
+                    case ".dotx":
                         output.PostContent.SetHtmlContent(GenerateFileInfoHtml("doc", "DOTX", documentContext, includePages: true));
                         break;
                     case ".pptx":

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
@@ -71,10 +71,12 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         private static string GenerateFileInfoHtml(string cssClass, string fileType, TprDocumentContext context, bool includePages = false)
         {
             var html = $"<br /><span class=\"{cssClass} fileicon\">{fileType}</span> {context.KbSize}KB";
+            var pageLabel = context.PagesLabel ?? "page(s)";
+
 
             if(includePages && context.Pages != "0")
             {
-                html = html + $", {context.Pages} page(s)";
+                html = html + $", {context.Pages} {pageLabel}";
             }
 
             return html;

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
 {
@@ -73,8 +70,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             var html = $"<br /><span class=\"{cssClass} fileicon\">{fileType}</span> {context.KbSize}KB";
             var pageLabel = context.PagesLabel ?? "page(s)";
 
-
-            if(includePages && context.Pages != "0")
+            if (includePages && context.Pages != "0")
             {
                 html = html + $", {context.Pages} {pageLabel}";
             }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprDocumentTitleTagHelper.cs
@@ -27,93 +27,57 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
 
                 if (isMediaLink) { output.TagName += "download"; }
 
-                if (documentContext.Href.EndsWith(".pdf"))
+                switch (fileExtension)
                 {
-                    if (documentContext.Pages == "0")
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"pdf fileicon\">PDF</span> {documentContext.KbSize}KB </dt>");
-                    }
-                    else
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"pdf fileicon\">PDF</span> {documentContext.KbSize}KB, {documentContext.Pages} page(s) </dt>");
-                    }
+                    case ".pdf":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("pdf", "PDF", documentContext, includePages: true));
+                        break;
+                    case ".doc":
+                    case ".docx":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("doc", "Word", documentContext, includePages: true));
+                        break;
+                    case "dotx":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("doc", "DOTX", documentContext, includePages: true));
+                        break;
+                    case ".pptx":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("powerpoint", "PPTX", documentContext, includePages: true));
+                        break;
+                    case ".rtf":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("misc", "RTF", documentContext, includePages: true));
+                        break;
+                    case ".odt":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("misc", "ODT", documentContext, includePages: true));
+                        break;
+                    case ".xlsx":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("excel", "Excel", documentContext));
+                        break;
+                    case ".xlst":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("excel", "XLST", documentContext));
+                        break;
+                    case ".csv":
+                        output.PostContent.SetHtmlContent(GenerateFileInfoHtml("excel", "CSV", documentContext));
+                        break;
+                    default:
+                        break;
                 }
-                else if (documentContext.Href.EndsWith(".docx") || documentContext.Href.EndsWith(".doc"))
-                {
-                    if (documentContext.Pages == "0")
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"doc fileicon\">Word</span> {documentContext.KbSize}KB </dt>");
-                    }
-                    else
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"doc fileicon\">Word</span> {documentContext.KbSize}KB, {documentContext.Pages} page(s) </dt>");
-                    }
-                }
-                else if (documentContext.Href.EndsWith(".dotx"))
-                {
-                    if (documentContext.Pages == "0")
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"doc fileicon\">DOTX</span> {documentContext.KbSize}KB </dt>");
-                    }
-                    else
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"doc fileicon\">DOTX</span> {documentContext.KbSize}KB, {documentContext.Pages} page(s) </dt>");
-                    }
-                }
-                else if (documentContext.Href.EndsWith(".pptx"))
-                {
-                    if (documentContext.Pages == "0")
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"powerpoint fileicon\">PPTX</span> {documentContext.KbSize}KB </dt>");
-                    }
-                    else
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"powerpoint fileicon\">PPTX</span> {documentContext.KbSize}KB, {documentContext.Pages} page(s) </dt>");
-                    }
-                }
-                else if (documentContext.Href.EndsWith(".rtf"))
-                {
-                    if (documentContext.Pages == "0")
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"misc fileicon\">RTF</span> {documentContext.KbSize}KB </dt>");
-                    }
-                    else
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"misc fileicon\">RTF</span> {documentContext.KbSize}KB, {documentContext.Pages} page(s) </dt>");
-                    }
-                }
-                else if (documentContext.Href.EndsWith(".odt"))
-                {
-                    if (documentContext.Pages == "0")
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"misc fileicon\">ODT</span> {documentContext.KbSize}KB </dt>");
-                    }
-                    else
-                    {
-                        output.PostContent.SetHtmlContent($"<br /><span class=\"misc fileicon\">ODT</span> {documentContext.KbSize}KB, {documentContext.Pages} page(s) </dt>");
-                    }
-                }
-                else if (documentContext.Href.EndsWith(".xlsx"))
-                {
-                    output.PostContent.SetHtmlContent($"<br /><span class=\"excel fileicon\">Excel</span> {documentContext.KbSize}KB </dt>");
-                }
-                else if (documentContext.Href.EndsWith(".xlst"))
-                {
-                    output.PostContent.SetHtmlContent($"<br /><span class=\"excel fileicon\">XLST</span> {documentContext.KbSize}KB </dt>");
-                }
-                else if (documentContext.Href.EndsWith(".csv"))
-                {
-                    output.PostContent.SetHtmlContent($"<br /><span class=\"excel fileicon\">CSV</span> {documentContext.KbSize}KB </dt>");
-                }
-                else
-                {
-                    output.PostElement.SetHtmlContent("</dt>");
-                }
+                output.PostContent.AppendHtml("</dt>");
             }
             else
             {
                 throw new ArgumentNullException(nameof(documentContext.Href), "Document href cannot be null");
             }
+        }
+
+        private static string GenerateFileInfoHtml(string cssClass, string fileType, TprDocumentContext context, bool includePages = false)
+        {
+            var html = $"<br /><span class=\"{cssClass} fileicon\">{fileType}</span> {context.KbSize}KB";
+
+            if(includePages && context.Pages != "0")
+            {
+                html = html + $", {context.Pages} page(s)";
+            }
+
+            return html;
         }
     }
 }

--- a/docs/components/tpr-documents.md
+++ b/docs/components/tpr-documents.md
@@ -2,7 +2,65 @@
 
 The 'TPR Documents' component can be used to display a list of documents.
 
-## Umbraco example
+## Example
+
+```cshtml
+<tpr-documents outercss="custom-documents">
+
+    <tpr-document href="/documents/annual-report-2025.pdf" kbsize="20" pages="1" datepublished="March 2025" innercss="custom-document">
+        
+      <tpr-document-title>
+            Annual Report 2025
+      </tpr-document-title>
+
+      <tpr-document-description>
+            Annual report covering scheme performance and regulatory updates.
+      </tpr-document-description>
+
+    </tpr-document>
+
+</tpr-documents>
+```
+
+---
+
+## `<tpr-documents>`
+
+Container component required to group one or more document entries.
+
+## Attributes
+
+| Attribute | Required | Description |
+|------------|----------|-------------|
+| `outercss` | No | Additional CSS classes applied to the document list container. |
+
+
+## `<tpr-document>`
+
+Represents an individual document within a document list.
+
+## Attributes
+
+| Attribute | Required | Description |
+|------------|----------|-------------|
+| `href` | Yes | URL the document title links to. |
+| `kbsize` | No | File size in kilobytes (KB). Typically used for downloadable files such as PDFs or Word documents etc. |
+| `pages` | No | Number of pages in the document. |
+| `pages-label` | No | Label displayed alongside the page count. Useful for localisation. If attribute is not provided on tag, will default to "page(s)". |
+| `published-label` | No | Label displayed before the publication date. Useful for localisation. Will only display if `datepublished` value is also provided. If attribute is not provided on tag, will default to "Published:" |
+| `datepublished` | No | Publication date displayed underneath document title. |
+| `innercss` | No | Additional CSS classes applied to the document item. |
+
+
+## `<tpr-document-title>`
+
+The document title displayed as the primary link text.
+
+## `<tpr-document-description>`
+
+Optional supporting content displayed beneath the document title.
+
+# Umbraco example
 
 The 'Documents' block is supported on the 'TPR Block Grid' and 'TPR Block List' data types in Umbraco. The block should look like this:
 
@@ -12,7 +70,7 @@ Once you have clicked on the block, an inner custom Block List will appear that 
 
 ![TPR Documents custom inner block list](../images/tpr-documents-inner-blocklist.png)
 
-After pressing 'Add Document' the following menu should appear, prompting you to link the document (which can be to either a media item that has already been uploaded to Umbraco, or a URL) as well as fill out any relevant information about the document. The 'Number of pages' field should only be filled out if the document you are linking to is a piece of media such as a .PDF or .DOCX file. A media file that consists of a speadsheet such as an Excel file will not display the 'Number of pages' field.
+After pressing 'Add Document' the following menu should appear, prompting you to link the document (which can be to either a media item that has already been uploaded to Umbraco, or a URL) as well as fill out any relevant information about the document. The 'Number of pages' field should only be filled out if the document you are linking to is a piece of media such as a .PDF or .DOCX file. A media file that consists of a spreadsheet such as an Excel file will not display the 'Number of pages' field.
 
 ![TPR Documents document input form](../images/tpr-documents-input-document-form.png)
 
@@ -47,3 +105,4 @@ This is what the generated HTML should look like, as well as what is displayed o
 ```
 
 ![TPR Documents on screen display](../images/tpr-documents-on-screen-display.png)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1902,9 +1902,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3742,9 +3742,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Why:

Welsh localisation support is currently available for the document component, including the document title and published date. However, additional document metadata such as the "Published" label and page count text are not currently localisable.

In this PR:

- Added Welsh translations to the Umbraco dictionary for document metadata labels.
- Added new Tag Helper attributes to support custom labels for:
    - 'Published:'
    - 'page(s)'
- Refactored TprDocumentTitleTagHelper to simplify the implementation of localisable metadata label.
- Added unit tests covering document metadata rendering across supported file types.
- Added unit test to verify custom page labels where page counts are not displayed.

[#AB259461](https://dev.azure.com/thepensionsregulator/TPR/_boards/board/t/Web%20Platform%20Team/Stories?workitem=259461)


