### PR TITLE
Side nav collapse functionality using escape key - adjustments (v17)

### DIFF
--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -3075,9 +3075,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -3203,14 +3203,14 @@
       "peer": true
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.8",
         "marked": "14.0.0"
       }
     },

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-side-navigation.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-side-navigation.js
@@ -124,43 +124,12 @@
             }
         }
 
-        function collapseAll() {
-            // collapse mobile first-level nav if expanded
-            var mobileToggleBtn = sideNav.querySelector(".tpr-side-nav__mobile-expand-toggle[aria-expanded='true']");
-            if (mobileToggleBtn) {
-                var firstLevelNav = sideNav.querySelector("ul");
-                if (firstLevelNav) {
-                    firstLevelNav.classList.remove("tpr-side-nav__list--expanded");
-                }
-                mobileToggleBtn.setAttribute("aria-expanded", "false");
-                var img = mobileToggleBtn.querySelector("img");
-                if (img) {
-                    img.classList.remove("tpr-side-nav__list-item-arrow--up");
-                    img.setAttribute("alt", expandText.replace("{0}", ""));
-                }
-            }
-
-            // collapse all expanded list-item toggles
-            var expandedToggles = sideNav.querySelectorAll(".tpr-side-nav__list-item__expand-toggle[aria-expanded='true']");
-            for (var j = 0; j < expandedToggles.length; j++) {
-                collapseListItem(expandedToggles[j]);
-            }
-
-            // ensure top-level list items also lose the expanded class
-            var expandedNodes = sideNav.querySelectorAll(".tpr-side-nav__list-item--expanded");
-            for (var k = 0; k < expandedNodes.length; k++) {
-                var node = expandedNodes[k];
-                node.classList.remove("tpr-side-nav__list-item--expanded");
-                var nodeArrow = node.querySelector(".tpr-side-nav__list-item-arrow");
-                if (nodeArrow) {
-                    nodeArrow.classList.remove("tpr-side-nav__list-item-arrow--up");
-                }
-                var toggle = node.querySelector(".tpr-side-nav__list-item__expand-toggle");
-                if (toggle) {
-                    toggle.setAttribute("aria-expanded", "false");
-                }
+        function collapseAll(expandedToggles) {
+            for (var i= expandedToggles.length - 1; i >= 0; i--) {
+                expandedToggles[i].click();
             }
         }
+          
 
         // Robust Escape handler
         function onEscapeKey(e) {
@@ -169,22 +138,29 @@
                 return;
             }
 
-            var active = document.activeElement;
-            if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA" || active.tagName === "SELECT" || active.isContentEditable)) {
-                return;
+            var expandedToggles = sideNav.querySelectorAll(".tpr-side-nav__list--expanded, .tpr-side-nav__list-item--expanded, .tpr-side-nav__list-item__expand-toggle[aria-expanded='true']");
+
+            if (!expandedToggles.length) return;
+
+            var mobileToggle = sideNav.querySelector(".tpr-side-nav__mobile-expand-toggle");
+            var focusTarget = mobileToggle;
+
+            var mobileNavIsExpanded = mobileToggle && mobileToggle.getAttribute("aria-expanded") === "true";
+
+            if (!mobileNavIsExpanded) {
+                var active = document.activeElement;
+                var topLevelItem = active && active.closest ? active.closest("ul[data-level='1']") : null;
+
+                if (topLevelItem && sideNav.contains(topLevelItem)) {
+                    focusTarget = topLevelItem.querySelector(".tpr-side-nav__list-item__expand-toggle[aria-expanded='true']") || mobileToggle;
+                }
             }
 
-            var focusedInSideNav = sideNav.contains(active);
-            var hasExpanded = !!sideNav.querySelector(".tpr-side-nav__list--expanded, .tpr-side-nav__list-item--expanded, .tpr-side-nav__list-item__expand-toggle[aria-expanded='true']");
-            if (focusedInSideNav || hasExpanded) {
-                try {
-                    e.preventDefault();
-                    e.stopPropagation();
-                } catch (err) {
-                    // ignore if preventDefault isn't supported in some contexts
-                }
-                collapseAll();
-            }
+            e.preventDefault();
+            e.stopPropagation();
+
+            collapseAll(expandedToggles);
+            if (focusTarget) focusTarget.focus();   
         }
 
         // Attach Escape handlers

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-side-navigation.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-side-navigation.js
@@ -138,7 +138,7 @@
                 return;
             }
 
-            var expandedToggles = sideNav.querySelectorAll(".tpr-side-nav__list--expanded, .tpr-side-nav__list-item--expanded, .tpr-side-nav__list-item__expand-toggle[aria-expanded='true']");
+            var expandedToggles = sideNav.querySelectorAll(".tpr-side-nav__list--expanded, .tpr-side-nav__list-item--expanded, .tpr-side-nav__list-item__expand-toggle[aria-expanded='true'], .tpr-side-nav__mobile-expand-toggle[aria-expanded='true']");
 
             if (!expandedToggles.length) return;
 
@@ -152,7 +152,7 @@
                 var topLevelItem = active && active.closest ? active.closest("ul[data-level='1']") : null;
 
                 if (topLevelItem && sideNav.contains(topLevelItem)) {
-                    focusTarget = topLevelItem.querySelector(".tpr-side-nav__list-item__expand-toggle[aria-expanded='true']") || mobileToggle;
+                    focusTarget = topLevelItem.querySelector("ul[data-level='1'] > " + ".tpr-side-nav__list-item--expanded " + ".tpr-side-nav__list-item__expand-toggle");
                 }
             }
 

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-side-navigation.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-side-navigation.js
@@ -134,10 +134,9 @@
         // Robust Escape handler
         function onEscapeKey(e) {
             var key = e.key || (e.keyCode === 27 ? "Escape" : null);
-            if (key !== "Escape" && key !== "Esc") {
-                return;
-            }
 
+            if (key !== "Escape" && key !== "Esc") return;
+            
             var expandedToggles = sideNav.querySelectorAll(".tpr-side-nav__list--expanded, .tpr-side-nav__list-item--expanded, .tpr-side-nav__list-item__expand-toggle[aria-expanded='true'], .tpr-side-nav__mobile-expand-toggle[aria-expanded='true']");
 
             if (!expandedToggles.length) return;
@@ -160,11 +159,11 @@
             e.stopPropagation();
 
             collapseAll(expandedToggles);
+
             if (focusTarget) focusTarget.focus();   
         }
 
-        // Attach Escape handlers
-        document.addEventListener("keydown", onEscapeKey, false);
+        // Attach Escape handler
         sideNav.addEventListener("keydown", onEscapeKey, false);
 
         // Close other expanded branches at the same top-level

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -3075,9 +3075,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -3203,14 +3203,14 @@
       "peer": true
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.8",
         "marked": "14.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1902,9 +1902,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3742,9 +3742,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Why:

During the PR review process, two outstanding issues were identified within the side navigation component.

In this PR:

- Refactored collapseAll() to remove duplicated collapse logic and reuse the existing functionality.
- Improved onEscapeKey behaviour:
  - Ensured focus remains visible when closing menus with Esc, providing a clearer and more accessible keyboard navigation experience.

Closes #730  

`Question:`  I've removed the event listener from document, leaving only the listener on the side navigation. My thinking is that this will prevent the menu from unexpectedly closing when users interact elsewhere on the page. It also means we no longer need to guard against scenarios where the side nav might be closed while focus is within editable elements.

However, if keeping the document-level listener is preferred, I can add the relevant guards back into onEscapeKey.