### PR TITLE
Fix CSV download 403 and support merged cells

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.1.1</Version>
+    <Version>10.1.2</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ThePensionsRegulator.Frontend.Tests/Services/TableCsvServiceTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/Services/TableCsvServiceTests.cs
@@ -89,5 +89,38 @@ namespace ThePensionsRegulator.Frontend.Tests.Services
 
             Assert.Equal("\"'=A,B\"" + Environment.NewLine, csv);
         }
+
+        // Merged cells (colspan/rowspan) are expanded into a rectangular grid so the CSV stays
+        // aligned. The value goes in the top-left cell of a span; the remaining spanned positions
+        // are emitted as empty fields. Mirrors the client-side tableToCsv test cases.
+        [Fact]
+        public void Expands_colspan_into_empty_trailing_fields()
+        {
+            var html = "<table><tr><td colspan=\"2\">Merged</td></tr><tr><td>A</td><td>B</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("Merged," + Environment.NewLine + "A,B" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Expands_rowspan_by_carrying_empty_field_into_following_rows()
+        {
+            var html = "<table><tr><td rowspan=\"2\">R</td><td>B1</td></tr><tr><td>B2</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("R,B1" + Environment.NewLine + ",B2" + Environment.NewLine, csv);
+        }
+
+        [Fact]
+        public void Expands_rowspan_in_last_column()
+        {
+            var html = "<table><tr><td>A1</td><td rowspan=\"2\">B</td></tr><tr><td>A2</td></tr></table>";
+
+            var csv = DecodeCsv(_service.ConvertHtmlTableToCsv(html));
+
+            Assert.Equal("A1,B" + Environment.NewLine + "A2," + Environment.NewLine, csv);
+        }
     }
 }

--- a/ThePensionsRegulator.Frontend/Controllers/TableDownloadController.cs
+++ b/ThePensionsRegulator.Frontend/Controllers/TableDownloadController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using HtmlAgilityPack;
 using System.Text;
@@ -10,7 +11,15 @@ namespace ThePensionsRegulator.Frontend.Controllers;
 /// Handles CSV download requests for HTML tables.
 /// Provides both server-side fallback for no-JS scenarios and client-side form interception.
 /// </summary>
+/// <remarks>
+/// The CSV download is an anonymous, public-data feature that must work on the no-JS
+/// server-side path even on sites that enforce a global or fallback authorization policy.
+/// Without <see cref="AllowAnonymousAttribute"/> such a policy blocks the POST and users are
+/// sent to a 401/403 after clicking the download button. The endpoint accepts only table HTML,
+/// validates the anti-forgery token and returns a CSV file, so it does not expose protected data.
+/// </remarks>
 [ApiController]
+[AllowAnonymous]
 public class TableDownloadController : ControllerBase
 {
     private const int MaxTableHtmlBytes = 300 * 1024;

--- a/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
+++ b/ThePensionsRegulator.Frontend/Services/TableCsvService.cs
@@ -24,13 +24,59 @@ public class TableCsvService : ITableCsvService
 
         if (rows != null)
         {
+            // Tracks active rowspans keyed by column index: the number of further rows still to fill.
+            var rowspanCarry = new Dictionary<int, int>();
+
             foreach (var row in rows)
             {
-                var cells = row.SelectNodes("th|td");
-                if (cells != null)
+                var cellList = row.SelectNodes("th|td")?.ToList() ?? [];
+                var rowData = new List<string>();
+                var col = 0;
+                var cellIndex = 0;
+
+                // Expand merged cells (colspan/rowspan) into a rectangular grid so the CSV stays
+                // aligned. The value is placed in the top-left cell of a span; the remaining
+                // spanned positions are emitted as empty fields. This mirrors tableToCsv in the
+                // client-side tpr-table-csv-download.js so both paths produce identical output.
+                while (cellIndex < cellList.Count || HasCarryAtOrBeyond(rowspanCarry, col))
                 {
-                    var cellValues = cells.Select(cell => EscapeCsvValue(GetCellText(cell)));
-                    csvBuilder.AppendLine(string.Join(",", cellValues));
+                    if (rowspanCarry.TryGetValue(col, out var remaining) && remaining > 0)
+                    {
+                        SetCell(rowData, col, string.Empty);
+                        rowspanCarry[col] = remaining - 1;
+                        if (rowspanCarry[col] == 0) { rowspanCarry.Remove(col); }
+                        col++;
+                        continue;
+                    }
+
+                    if (cellIndex < cellList.Count)
+                    {
+                        var cell = cellList[cellIndex++];
+                        var colspan = Math.Max(1, ParseSpan(cell, "colspan"));
+                        var rowspan = Math.Max(1, ParseSpan(cell, "rowspan"));
+                        var text = EscapeCsvValue(GetCellText(cell));
+
+                        for (var c = 0; c < colspan; c++)
+                        {
+                            SetCell(rowData, col + c, c == 0 ? text : string.Empty);
+                            if (rowspan > 1)
+                            {
+                                rowspanCarry[col + c] = rowspan - 1;
+                            }
+                        }
+                        col += colspan;
+                        continue;
+                    }
+
+                    // No cell and no carry at this column, but a rowspan carry exists further
+                    // right: fill the gap with an empty field to preserve grid alignment.
+                    SetCell(rowData, col, string.Empty);
+                    col++;
+                }
+
+                if (rowData.Count > 0)
+                {
+                    csvBuilder.AppendLine(string.Join(",", rowData));
                 }
             }
         }
@@ -38,6 +84,33 @@ public class TableCsvService : ITableCsvService
         var bom = Encoding.UTF8.GetPreamble();
         var csvBytes = Encoding.UTF8.GetBytes(csvBuilder.ToString());
         return [.. bom, .. csvBytes];
+    }
+
+    private static bool HasCarryAtOrBeyond(Dictionary<int, int> rowspanCarry, int col)
+    {
+        foreach (var carry in rowspanCarry)
+        {
+            if (carry.Key >= col && carry.Value > 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void SetCell(List<string> row, int index, string value)
+    {
+        while (row.Count <= index)
+        {
+            row.Add(string.Empty);
+        }
+        row[index] = value;
+    }
+
+    private static int ParseSpan(HtmlNode cell, string attributeName)
+    {
+        var raw = cell.GetAttributeValue(attributeName, "1");
+        return int.TryParse(raw, out var value) ? value : 1;
     }
 
     private static string GetCellText(HtmlNode cell)

--- a/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
+++ b/ThePensionsRegulator.Frontend/__tests__/tpr-table-csv-download.tests.js
@@ -148,6 +148,36 @@ describe("tableToCsv", () => {
         const table = document.querySelector("table");
         expect(tableToCsv(table)).toBe('"Hello, World",Normal');
     });
+
+    test("expands a colspan into empty trailing fields", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table">
+                <tr><td colspan="2">Merged</td></tr>
+                <tr><td>A</td><td>B</td></tr>
+            </table>`;
+        const table = document.querySelector("table");
+        expect(tableToCsv(table)).toBe("Merged,\r\nA,B");
+    });
+
+    test("expands a rowspan by carrying an empty field into following rows", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table">
+                <tr><td rowspan="2">R</td><td>B1</td></tr>
+                <tr><td>B2</td></tr>
+            </table>`;
+        const table = document.querySelector("table");
+        expect(tableToCsv(table)).toBe("R,B1\r\n,B2");
+    });
+
+    test("expands a rowspan in the last column", () => {
+        document.body.innerHTML = `
+            <table class="govuk-table">
+                <tr><td>A1</td><td rowspan="2">B</td></tr>
+                <tr><td>A2</td></tr>
+            </table>`;
+        const table = document.querySelector("table");
+        expect(tableToCsv(table)).toBe("A1,B\r\nA2,");
+    });
 });
 
 describe("hasMergedCells", () => {
@@ -318,7 +348,7 @@ describe("initTableCsvDownload", () => {
         expect(button).toHaveAttribute("data-tpr-table-csv-filename", "quarterly-results");
     });
 
-    test("skips tables with merged cells", () => {
+    test("adds a button to tables with merged cells", () => {
         document.body.innerHTML = `
             <div>
                 <table class="govuk-table">
@@ -327,7 +357,7 @@ describe("initTableCsvDownload", () => {
                 </table>
             </div>`;
         initTableCsvDownload();
-        expect(document.querySelector('button[data-tpr-table-csv-button="true"]')).not.toBeInTheDocument();
+        expect(document.querySelector('button[data-tpr-table-csv-button="true"]')).toBeInTheDocument();
     });
 
     test("handles multiple .govuk-table elements", () => {

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/tpr-table-csv-download.js
@@ -55,6 +55,8 @@ export function escapeCsvValue(value) {
 
 /**
  * Returns true if the table has any cells with colspan or rowspan greater than 1.
+ * Merged cells are still exported as CSV — tableToCsv expands them into a rectangular
+ * grid — so this is retained only as a utility for callers that need to detect them.
  * @param {HTMLTableElement} table
  * @returns {boolean}
  */
@@ -71,19 +73,77 @@ export function hasMergedCells(table) {
 }
 
 /**
- * Converts a table to CSV content.
+ * Returns true if any active rowspan carry occupies the given column or a column to its right.
+ * @param {Object.<number, number>} rowspanCarry
+ * @param {number} col
+ * @returns {boolean}
+ */
+function hasCarryAtOrBeyond(rowspanCarry, col) {
+    for (const key in rowspanCarry) {
+        if (parseInt(key, 10) >= col && rowspanCarry[key] > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Converts a table to CSV content, expanding merged cells (colspan/rowspan) into a
+ * rectangular grid so the CSV stays aligned. The value is placed in the top-left cell
+ * of a span; the remaining spanned positions are emitted as empty fields. This mirrors
+ * ConvertHtmlTableToCsv in the server-side TableCsvService so both paths produce
+ * identical output.
  * @param {HTMLTableElement} table
  * @returns {string}
  */
 export function tableToCsv(table) {
     const rows = table.querySelectorAll("tr");
     const csvRows = [];
+    // Active rowspans keyed by column index: the number of further rows still to fill.
+    const rowspanCarry = {};
+
     for (let i = 0; i < rows.length; i++) {
         const cells = rows[i].querySelectorAll("th, td");
         const rowData = [];
-        for (let j = 0; j < cells.length; j++) {
-            rowData.push(escapeCsvValue(getCellText(cells[j])));
+        let col = 0;
+        let cellIndex = 0;
+
+        while (cellIndex < cells.length || hasCarryAtOrBeyond(rowspanCarry, col)) {
+            if (rowspanCarry[col] > 0) {
+                rowData[col] = "";
+                rowspanCarry[col]--;
+                if (rowspanCarry[col] === 0) delete rowspanCarry[col];
+                col++;
+                continue;
+            }
+
+            if (cellIndex < cells.length) {
+                const cell = cells[cellIndex++];
+                const colspan = Math.max(1, parseInt(cell.getAttribute("colspan"), 10) || 1);
+                const rowspan = Math.max(1, parseInt(cell.getAttribute("rowspan"), 10) || 1);
+                const text = escapeCsvValue(getCellText(cell));
+
+                for (let c = 0; c < colspan; c++) {
+                    rowData[col + c] = c === 0 ? text : "";
+                    if (rowspan > 1) {
+                        rowspanCarry[col + c] = rowspan - 1;
+                    }
+                }
+                col += colspan;
+                continue;
+            }
+
+            // No cell and no carry at this column, but a rowspan carry exists further right:
+            // fill the gap with an empty field to preserve grid alignment.
+            rowData[col] = "";
+            col++;
         }
+
+        // Replace any holes left by sparse assignment with empty strings.
+        for (let c = 0; c < rowData.length; c++) {
+            if (rowData[c] === undefined) rowData[c] = "";
+        }
+
         csvRows.push(rowData.join(","));
     }
     return csvRows.join("\r\n");
@@ -165,9 +225,6 @@ export function initTableCsvDownload() {
 
     for (let i = 0; i < tables.length; i++) {
         const table = tables[i];
-
-        // Skip tables with merged cells — CSV cannot represent them reliably
-        if (hasMergedCells(table)) continue;
 
         // Skip if a client-side download button was already added by this script (idempotency).
         const next = table.nextElementSibling;

--- a/docs/components/tpr-table-csv-download.md
+++ b/docs/components/tpr-table-csv-download.md
@@ -44,6 +44,10 @@ When using `ThePensionsRegulator.Frontend` without Umbraco, the JavaScript enhan
 
 When JavaScript is available, the script intercepts that form submission and performs the CSV download client-side instead of posting to the server.
 
+### Authorization
+
+The `/api/table/download-csv` endpoint is decorated with `[AllowAnonymous]`. It only converts posted, public table HTML to CSV and validates the anti-forgery token, so it does not expose protected data. Allowing anonymous access ensures the no-JS server-side download still works on sites that enforce a global or fallback authorization policy — without it, those sites return a 401/403 when the button is clicked.
+
 ### File naming
 
 The downloaded file name is derived from the table's `<caption>` element. If there is no caption, the file is named `table-data.csv`. The name is sanitised to remove special characters and truncated to 50 characters.
@@ -78,4 +82,4 @@ builder.Services.AddTprFrontend(options =>
 
 ## Merged cells
 
-Tables containing cells with `colspan` or `rowspan` greater than 1 are skipped — no download button is added — because merged cells cannot be reliably represented in CSV.
+Tables containing cells with `colspan` or `rowspan` greater than 1 are still exported. Merged cells are expanded into a rectangular grid so the CSV stays aligned: the value is placed in the top-left cell of the span and the remaining spanned positions are written as empty fields. Both the client-side JavaScript and the server-side endpoint use the same expansion, so the download button appears and produces identical output on either path.


### PR DESCRIPTION
Add [AllowAnonymous] to TableDownloadController so the no-JS CSV download POST is not blocked by a global/fallback authorization policy (was returning 401/403 on click). Expand merged cells (colspan/rowspan) into a rectangular grid in both the client-side tableToCsv and server-side TableCsvService so the download button appears on those tables and both paths produce identical CSV. Update tests and docs.

[AB#269788](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/269788)