### PR TITLE
Property value converters were caching content across multiple requests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.1.2</Version>
+    <Version>10.1.3</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockGridPropertyValueConverterTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockGridPropertyValueConverterTests.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.Extensions.Options;
+using Moq;
+using ThePensionsRegulator.Umbraco.Core.Blocks;
+using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
+using ThePensionsRegulator.Umbraco.Testing;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+namespace ThePensionsRegulator.Umbraco.Core.Tests.Blocks
+{
+    public class OverridableBlockGridPropertyValueConverterTests
+    {
+        [Fact]
+        public void Sets_PropertyValueFormatters()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var propertyType = UmbracoPropertyFactory.CreateBlockGridProperty("myAlias", "contentTypeAlias", []).PropertyType;
+
+            var initialValue = """{"contentData":[{"contentTypeKey":"90600a82-4925-4287-bb81-45247a91a514","key":"df3f71a6-de00-49a6-820a-ef247e6b675c","values":[{"alias":"linkText","culture":null,"editorAlias":null,"segment":null,"value":"Lorem ipsum dolor sit amet"},{"alias":"linkUrl","culture":null,"editorAlias":null,"segment":null,"value":"[{\u0022url\u0022:\u0022/success\u0022}]"}]},{"contentTypeKey":"90600a82-4925-4287-bb81-45247a91a514","key":"bccca89b-e21b-4beb-b2a7-710a5a5a5214","values":[{"alias":"linkText","culture":null,"editorAlias":null,"segment":null,"value":"Lorem ipsum dolor"},{"alias":"linkUrl","culture":null,"editorAlias":null,"segment":null,"value":"[{\u0022url\u0022:\u0022/success\u0022}]"}]}],"settingsData":[],"expose":[{"contentKey":"df3f71a6-de00-49a6-820a-ef247e6b675c","culture":null,"segment":null},{"contentKey":"bccca89b-e21b-4beb-b2a7-710a5a5a5214","culture":null,"segment":null}],"Layout":{"Umbraco.BlockList":[{"contentKey":"df3f71a6-de00-49a6-820a-ef247e6b675c","contentUdi":null,"settingsKey":null,"settingsUdi":null},{"contentKey":"bccca89b-e21b-4beb-b2a7-710a5a5a5214","contentUdi":null,"settingsKey":null,"settingsUdi":null}]}}""";
+
+            var formatter = new Mock<IPropertyValueFormatter>();
+            var valueConverter = CreateValueConverter(testContext, [formatter.Object]);
+
+            // Act
+            var result = valueConverter.ConvertIntermediateToObject(
+                UmbracoContentFactory.CreateContent<IPublishedElement>().Object,
+                propertyType, PropertyCacheLevel.Element, initialValue, false);
+
+            // Assert
+            Assert.Equal(formatter.Object, ((OverridableBlockGridModel?)result)?.PropertyValueFormatters?.SingleOrDefault());
+        }
+
+
+        [Fact]
+        public void GetPropertyCacheLevel_Returns_None()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var valueConverter = CreateValueConverter(testContext);
+            var propertyType = UmbracoPropertyFactory.CreateBlockGridProperty("myAlias", "contentTypeAlias", []).PropertyType;
+
+            // Act
+            var result = valueConverter.GetPropertyCacheLevel(propertyType);
+
+            // Assert
+            Assert.Equal(PropertyCacheLevel.None, result);
+        }
+
+        private static OverridableBlockGridPropertyValueConverter CreateValueConverter(UmbracoTestContext testContext, IEnumerable<IPropertyValueFormatter>? propertyValueFormatters = null)
+        {
+            var contentSettings = new Mock<IOptionsMonitor<ContentSettings>>();
+            contentSettings.Setup(x => x.CurrentValue).Returns(new ContentSettings { ResolveUrlsFromTextString = false });
+
+            var blockEditorVarianceHandler = new BlockEditorVarianceHandler(testContext.LanguageService.Object, testContext.ContentTypeService.Object);
+
+            return new OverridableBlockGridPropertyValueConverter(
+                testContext.ProfilingLogger.Object,
+                new BlockEditorConverter(testContext.PublishedContentTypeCache.Object, testContext.CacheManager.Object, testContext.PublishedModelFactory.Object, testContext.VariationContextAccessor.Object, blockEditorVarianceHandler),
+                testContext.JsonSerializer,
+                propertyValueFormatters ?? new List<IPropertyValueFormatter>(),
+                testContext.ApiElementBuilder.Object,
+                testContext.BlockGridPropertyValueConstructorCache.Object,
+                testContext.VariationContextAccessor.Object,
+                blockEditorVarianceHandler,
+                testContext.PublishedValueFallback.Object,
+                testContext.LanguageService.Object,
+                testContext.PropertyRenderingContextAccessor.Object
+                );
+        }
+    }
+}

--- a/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockListPropertyValueConverterTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/Blocks/OverridableBlockListPropertyValueConverterTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Extensions.Options;
+using Moq;
+using ThePensionsRegulator.Umbraco.Core.Blocks;
+using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
+using ThePensionsRegulator.Umbraco.Testing;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+namespace ThePensionsRegulator.Umbraco.Core.Tests.Blocks
+{
+    public class OverridableBlockListPropertyValueConverterTests
+    {
+        [Fact]
+        public void Sets_PropertyValueFormatters()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var propertyType = UmbracoPropertyFactory.CreateBlockListProperty("myAlias", "contentTypeAlias", []).PropertyType;
+
+            var initialValue = """{"contentData":[{"contentTypeKey":"90600a82-4925-4287-bb81-45247a91a514","key":"df3f71a6-de00-49a6-820a-ef247e6b675c","values":[{"alias":"linkText","culture":null,"editorAlias":null,"segment":null,"value":"Lorem ipsum dolor sit amet"},{"alias":"linkUrl","culture":null,"editorAlias":null,"segment":null,"value":"[{\u0022url\u0022:\u0022/success\u0022}]"}]},{"contentTypeKey":"90600a82-4925-4287-bb81-45247a91a514","key":"bccca89b-e21b-4beb-b2a7-710a5a5a5214","values":[{"alias":"linkText","culture":null,"editorAlias":null,"segment":null,"value":"Lorem ipsum dolor"},{"alias":"linkUrl","culture":null,"editorAlias":null,"segment":null,"value":"[{\u0022url\u0022:\u0022/success\u0022}]"}]}],"settingsData":[],"expose":[{"contentKey":"df3f71a6-de00-49a6-820a-ef247e6b675c","culture":null,"segment":null},{"contentKey":"bccca89b-e21b-4beb-b2a7-710a5a5a5214","culture":null,"segment":null}],"Layout":{"Umbraco.BlockList":[{"contentKey":"df3f71a6-de00-49a6-820a-ef247e6b675c","contentUdi":null,"settingsKey":null,"settingsUdi":null},{"contentKey":"bccca89b-e21b-4beb-b2a7-710a5a5a5214","contentUdi":null,"settingsKey":null,"settingsUdi":null}]}}""";
+
+            var formatter = new Mock<IPropertyValueFormatter>();
+            var valueConverter = CreateValueConverter(testContext, [formatter.Object]);
+
+            // Act
+            var result = valueConverter.ConvertIntermediateToObject(
+                UmbracoContentFactory.CreateContent<IPublishedElement>().Object,
+                propertyType, PropertyCacheLevel.Element, initialValue, false);
+
+            // Assert
+            Assert.Equal(formatter.Object, ((OverridableBlockListModel?)result)?.PropertyValueFormatters?.SingleOrDefault());
+        }
+
+
+        [Fact]
+        public void GetPropertyCacheLevel_Returns_None()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var valueConverter = CreateValueConverter(testContext);
+            var propertyType = UmbracoPropertyFactory.CreateBlockListProperty("myAlias", "contentTypeAlias", []).PropertyType;
+
+            // Act
+            var result = valueConverter.GetPropertyCacheLevel(propertyType);
+
+            // Assert
+            Assert.Equal(PropertyCacheLevel.None, result);
+        }
+
+        private static OverridableBlockListPropertyValueConverter CreateValueConverter(UmbracoTestContext testContext, IEnumerable<IPropertyValueFormatter>? propertyValueFormatters = null)
+        {
+            var contentSettings = new Mock<IOptionsMonitor<ContentSettings>>();
+            contentSettings.Setup(x => x.CurrentValue).Returns(new ContentSettings { ResolveUrlsFromTextString = false });
+
+            var blockEditorVarianceHandler = new BlockEditorVarianceHandler(testContext.LanguageService.Object, testContext.ContentTypeService.Object);
+
+            return new OverridableBlockListPropertyValueConverter(
+                testContext.ProfilingLogger.Object,
+                new BlockEditorConverter(testContext.PublishedContentTypeCache.Object, testContext.CacheManager.Object, testContext.PublishedModelFactory.Object, testContext.VariationContextAccessor.Object, blockEditorVarianceHandler),
+                testContext.ContentTypeService.Object,
+                testContext.ApiElementBuilder.Object,
+                testContext.JsonSerializer,
+                testContext.BlockListPropertyValueConstructorCache.Object,
+                testContext.VariationContextAccessor.Object,
+                blockEditorVarianceHandler,
+                testContext.PublishedValueFallback.Object,
+                testContext.LanguageService.Object,
+                testContext.PropertyRenderingContextAccessor.Object,
+                propertyValueFormatters ?? new List<IPropertyValueFormatter>()
+                );
+        }
+    }
+}

--- a/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/MultiUrlPickerPropertyValueConverterTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/MultiUrlPickerPropertyValueConverterTests.cs
@@ -1,0 +1,68 @@
+﻿using Moq;
+using ThePensionsRegulator.Umbraco.Core.PropertyEditors;
+using ThePensionsRegulator.Umbraco.Core.PropertyEditors.ValueConverters;
+using ThePensionsRegulator.Umbraco.Testing;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace ThePensionsRegulator.Umbraco.Core.Tests.PropertyEditors.ValueConverters
+{
+    public class MultiUrlPickerPropertyValueConverterTests
+    {
+        [Fact]
+        public void Applies_PropertyValueFormatters()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var propertyType = UmbracoPropertyFactory.CreateMultiUrlPickerProperty("myAlias", "contentTypeAlias", new Link()).PropertyType;
+
+            var initialValue = """[{"name":"Home","target":null,"unique":null,"type":null,"udi":"umb://document/5e682cbeb867491a955f3382446d5663","url":null,"queryString":null}]""";
+            var expectedValue = new List<Link> { new Link { Name = "Expected" } };
+
+            var formatter = new Mock<IPropertyValueFormatter>();
+            formatter.Setup(x => x.IsFormatter(propertyType)).Returns(true);
+            formatter.Setup(x => x.FormatValue(It.IsAny<List<Link>>())).Returns<List<Link>>(x => expectedValue);
+
+            var valueConverter = CreateValueConverter(testContext, [formatter.Object]);
+
+            // Act
+            var result = valueConverter.ConvertIntermediateToObject(
+                UmbracoContentFactory.CreateContent<IPublishedElement>().Object,
+                propertyType, PropertyCacheLevel.Element, initialValue, false);
+
+            // Assert
+            Assert.Equal(expectedValue[0].Name, ((List<Link>?)result)?[0].Name);
+        }
+
+        [Fact]
+        public void GetPropertyCacheLevel_Returns_None()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var valueConverter = CreateValueConverter(testContext);
+            var propertyType = UmbracoPropertyFactory.CreateMultiUrlPickerProperty("myAlias", "contentTypeAlias", new Link()).PropertyType;
+
+            // Act
+            var result = valueConverter.GetPropertyCacheLevel(propertyType);
+
+            // Assert
+            Assert.Equal(PropertyCacheLevel.None, result);
+        }
+
+        private static MultiUrlPickerPropertyValueConverter CreateValueConverter(UmbracoTestContext testContext, IEnumerable<IPropertyValueFormatter>? propertyValueFormatters = null)
+        {
+            return new MultiUrlPickerPropertyValueConverter(
+                testContext.ProfilingLogger.Object,
+                testContext.JsonSerializer,
+                testContext.PublishedUrlProvider.Object,
+                propertyValueFormatters ?? new List<IPropertyValueFormatter>(),
+                testContext.ApiContentNameProvider.Object,
+                testContext.ApiMediaUrlProvider.Object,
+                testContext.ApiContentRouteBuilder.Object,
+                testContext.PublishedContentCache.Object,
+                testContext.PublishedMediaCache.Object
+                );
+        }
+    }
+}

--- a/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverterTests.cs
+++ b/ThePensionsRegulator.Umbraco.Core.Tests/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverterTests.cs
@@ -24,7 +24,6 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.PropertyEditors.ValueConverter
             // Arrange
             using var testContext = new UmbracoTestContext();
             var propertyType = UmbracoPropertyFactory.CreateRichTextProperty("myAlias", "contentTypeAlias", new HtmlEncodedString(string.Empty)).PropertyType;
-            var urlProvider = testContext.PublishedUrlProvider.Object;
 
             const string INITIAL_VALUE = "<p>Some html</p>";
             const string EXPECTED_VALUE = "<p>Expected</p>";
@@ -33,16 +32,76 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.PropertyEditors.ValueConverter
             formatter.Setup(x => x.IsFormatter(propertyType)).Returns(true);
             formatter.Setup(x => x.FormatValue(It.Is<HtmlEncodedString>(x => x.ToHtmlString() == INITIAL_VALUE))).Returns<HtmlEncodedString>(x => new HtmlEncodedString(EXPECTED_VALUE));
 
+            var valueConverter = CreateValueConverter(testContext, [formatter.Object]);
+
+            // Act
+            var result = valueConverter.ConvertIntermediateToObject(
+                UmbracoContentFactory.CreateContent<IPublishedElement>().Object,
+                propertyType, PropertyCacheLevel.Element, new FakeRichTextIntermediateValue { Markup = INITIAL_VALUE }, false);
+
+            // Assert
+            Assert.Equal(EXPECTED_VALUE, ((IHtmlEncodedString?)result)?.ToHtmlString());
+        }
+
+        [Fact]
+        public void IsConverter_Returns_True_For_RichTextEditor_Alias()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var valueConverter = CreateValueConverter(testContext);
+            var propertyType = UmbracoPropertyFactory.CreateRichTextProperty("myAlias", "contentTypeAlias", new HtmlEncodedString(string.Empty)).PropertyType;
+
+            // Act
+            var result = valueConverter.IsConverter(propertyType);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsConverter_Returns_False_For_Other_Editor_Alias()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var valueConverter = CreateValueConverter(testContext);
+            var propertyType = UmbracoPropertyFactory.CreateTextboxProperty("myAlias", "contentTypeAlias", string.Empty).PropertyType;
+
+            // Act
+            var result = valueConverter.IsConverter(propertyType);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void GetPropertyCacheLevel_Returns_None()
+        {
+            // Arrange
+            using var testContext = new UmbracoTestContext();
+            var valueConverter = CreateValueConverter(testContext);
+            var propertyType = UmbracoPropertyFactory.CreateRichTextProperty("myAlias", "contentTypeAlias", new HtmlEncodedString(string.Empty)).PropertyType;
+
+            // Act
+            var result = valueConverter.GetPropertyCacheLevel(propertyType);
+
+            // Assert
+            Assert.Equal(PropertyCacheLevel.None, result);
+        }
+
+        private static RichTextEditorPropertyValueConverter CreateValueConverter(UmbracoTestContext testContext, IEnumerable<IPropertyValueFormatter>? propertyValueFormatters = null)
+        {
+            var urlProvider = testContext.PublishedUrlProvider.Object;
+
             var contentSettings = new Mock<IOptionsMonitor<ContentSettings>>();
             contentSettings.Setup(x => x.CurrentValue).Returns(new ContentSettings { ResolveUrlsFromTextString = false });
 
-            var blockEditorVarianceHandler =  new BlockEditorVarianceHandler(testContext.LanguageService.Object, testContext.ContentTypeService.Object);
+            var blockEditorVarianceHandler = new BlockEditorVarianceHandler(testContext.LanguageService.Object, testContext.ContentTypeService.Object);
 
-            var valueConverter = new RichTextEditorPropertyValueConverter(
+            return new RichTextEditorPropertyValueConverter(
                 new HtmlLocalLinkParser(urlProvider),
                 new HtmlUrlParser(contentSettings.Object, Mock.Of<ILogger<HtmlUrlParser>>(), Mock.Of<IProfilingLogger>(), Mock.Of<IIOHelper>()),
                 new HtmlImageSourceParser(urlProvider),
-                new List<IPropertyValueFormatter> { formatter.Object },
+                propertyValueFormatters ?? new List<IPropertyValueFormatter>(),
                 testContext.ApiRichTextElementParser.Object,
                 testContext.ApiRichTextMarkupParser.Object,
                 testContext.PartialViewBlockEngine.Object,
@@ -53,16 +112,10 @@ namespace ThePensionsRegulator.Umbraco.Core.Tests.PropertyEditors.ValueConverter
                 Mock.Of<ILogger<RteBlockRenderingValueConverter>>(),
                 blockEditorVarianceHandler,
                 testContext.VariationContextAccessor.Object,
-                Mock.Of<IOptionsMonitor<DeliveryApiSettings>>()
+                Mock.Of<IOptionsMonitor<DeliveryApiSettings>>(),
+                testContext.LanguageService.Object,
+                testContext.PropertyRenderingContextAccessor.Object
                 );
-
-            // Act
-            var result = valueConverter.ConvertIntermediateToObject(
-                UmbracoContentFactory.CreateContent<IPublishedElement>().Object,
-                propertyType, PropertyCacheLevel.Element, new FakeRichTextIntermediateValue { Markup = INITIAL_VALUE }, false);
-
-            // Assert
-            Assert.Equal(EXPECTED_VALUE, ((IHtmlEncodedString?)result)?.ToHtmlString());
         }
 
         private class FakeRichTextIntermediateValue : IRichTextEditorIntermediateValue

--- a/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockGridPropertyValueConverter.cs
+++ b/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockGridPropertyValueConverter.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
 
 namespace ThePensionsRegulator.Umbraco.Core.Blocks
 {
@@ -20,9 +21,11 @@ namespace ThePensionsRegulator.Umbraco.Core.Blocks
             BlockGridPropertyValueConstructorCache _constructorCache,
             IVariationContextAccessor _variationContextAccessor,
             BlockEditorVarianceHandler _blockEditorVarianceHandler,
-            IPublishedValueFallback _publishedValueFallback
+            IPublishedValueFallback _publishedValueFallback,
+            ILanguageService _languageService,
+            IPropertyRenderingContextAccessor _propertyRenderingContextAccessor
         )
-        : BlockGridPropertyValueConverter(_proflog, _blockConverter, _jsonSerializer, _apiElementBuilder, _constructorCache, _variationContextAccessor, _blockEditorVarianceHandler)
+        : BlockGridPropertyValueConverter(_proflog, _blockConverter, _jsonSerializer, _apiElementBuilder, _constructorCache, _variationContextAccessor, _blockEditorVarianceHandler, _languageService, _propertyRenderingContextAccessor)
     {
         /// <inheritdoc />
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
@@ -39,6 +42,6 @@ namespace ThePensionsRegulator.Umbraco.Core.Blocks
         }
 
         /// <inheritdoc />
-        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.None;
     }
 }

--- a/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockListPropertyValueConverter.cs
+++ b/ThePensionsRegulator.Umbraco.Core/Blocks/OverridableBlockListPropertyValueConverter.cs
@@ -23,9 +23,11 @@ namespace ThePensionsRegulator.Umbraco.Core.Blocks
         IVariationContextAccessor _variationContextAccessor,
         BlockEditorVarianceHandler _blockEditorVarianceHandler,
         IPublishedValueFallback _publishedValueFallback,
+        ILanguageService _languageService,
+        IPropertyRenderingContextAccessor _propertyRenderingContextAccessor,
         IEnumerable<IPropertyValueFormatter> _propertyValueFormatters
         )
-        : BlockListPropertyValueConverter(_proflog, _blockConverter, _contentTypeService, _apiElementBuilder, _jsonSerializer, _constructorCache, _variationContextAccessor, _blockEditorVarianceHandler)
+        : BlockListPropertyValueConverter(_proflog, _blockConverter, _contentTypeService, _apiElementBuilder, _jsonSerializer, _constructorCache, _variationContextAccessor, _blockEditorVarianceHandler, _languageService, _propertyRenderingContextAccessor)
     {
         /// <inheritdoc />
         public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
@@ -42,6 +44,6 @@ namespace ThePensionsRegulator.Umbraco.Core.Blocks
         }
 
         /// <inheritdoc />
-        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.None;
     }
 }

--- a/ThePensionsRegulator.Umbraco.Core/PropertyEditors/ValueConverters/MultiUrlPickerPropertyValueConverter.cs
+++ b/ThePensionsRegulator.Umbraco.Core/PropertyEditors/ValueConverters/MultiUrlPickerPropertyValueConverter.cs
@@ -47,5 +47,8 @@ namespace ThePensionsRegulator.Umbraco.Core.PropertyEditors.ValueConverters
 
             return value is null ? null : _propertyValueFormatters.ApplyFormatters(propertyType, value);
         }
+
+        /// <inheritdoc />
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.None;
     }
 }

--- a/ThePensionsRegulator.Umbraco.Core/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverter.cs
+++ b/ThePensionsRegulator.Umbraco.Core/PropertyEditors/ValueConverters/RichTextEditorPropertyValueConverter.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Templates;
 
@@ -22,38 +23,41 @@ namespace ThePensionsRegulator.Umbraco.Core.PropertyEditors.ValueConverters
         private readonly IEnumerable<IPropertyValueFormatter> _propertyValueFormatters;
 
         public RichTextEditorPropertyValueConverter(
-            HtmlLocalLinkParser linkParser,
-            HtmlUrlParser urlParser,
-            HtmlImageSourceParser imageSourceParser,
-            IEnumerable<IPropertyValueFormatter> propertyValueFormatters,
-            IApiRichTextElementParser apiRichTextElementParser,
-            IApiRichTextMarkupParser apiRichTextMarkupParser,
-            IPartialViewBlockEngine partialViewBlockEngine,
-            BlockEditorConverter blockEditorConverter,
-            IJsonSerializer jsonSerializer,
-            IApiElementBuilder apiElementBuilder,
-            RichTextBlockPropertyValueConstructorCache richTextBlockConstructorCache,
-            ILogger<RteBlockRenderingValueConverter> logger,
-            BlockEditorVarianceHandler blockEditorVarianceHandler,
-            IVariationContextAccessor variationContextAccessor,
-
-            IOptionsMonitor<DeliveryApiSettings> deliveryApiSettings) :
-            base(linkParser,
-                urlParser,
-                imageSourceParser,
-                apiRichTextElementParser,
-                apiRichTextMarkupParser,
-                partialViewBlockEngine,
-                blockEditorConverter,
-                jsonSerializer,
-                apiElementBuilder,
-                richTextBlockConstructorCache,
-                logger,
-                variationContextAccessor,
-                blockEditorVarianceHandler,
-                deliveryApiSettings)
+            HtmlLocalLinkParser _linkParser,
+            HtmlUrlParser _urlParser,
+            HtmlImageSourceParser _imageSourceParser,
+            IEnumerable<IPropertyValueFormatter> _propertyValueFormatters,
+            IApiRichTextElementParser _apiRichTextElementParser,
+            IApiRichTextMarkupParser _apiRichTextMarkupParser,
+            IPartialViewBlockEngine _partialViewBlockEngine,
+            BlockEditorConverter _blockEditorConverter,
+            IJsonSerializer _jsonSerializer,
+            IApiElementBuilder _apiElementBuilder,
+            RichTextBlockPropertyValueConstructorCache _richTextBlockConstructorCache,
+            ILogger<RteBlockRenderingValueConverter> _logger,
+            BlockEditorVarianceHandler _blockEditorVarianceHandler,
+            IVariationContextAccessor _variationContextAccessor,
+            IOptionsMonitor<DeliveryApiSettings> _deliveryApiSettings,
+            ILanguageService _languageService,
+            IPropertyRenderingContextAccessor _propertyRenderingContextAccessor) :
+            base(_linkParser,
+                _urlParser,
+                _imageSourceParser,
+                _apiRichTextElementParser,
+                _apiRichTextMarkupParser,
+                _partialViewBlockEngine,
+                _blockEditorConverter,
+                _jsonSerializer,
+                _apiElementBuilder,
+                _richTextBlockConstructorCache,
+                _logger,
+                _variationContextAccessor,
+                _blockEditorVarianceHandler,
+                _deliveryApiSettings,
+                _languageService,
+                _propertyRenderingContextAccessor)
         {
-            _propertyValueFormatters = propertyValueFormatters ?? throw new ArgumentNullException(nameof(propertyValueFormatters));
+            this._propertyValueFormatters = _propertyValueFormatters ?? throw new ArgumentNullException(nameof(_propertyValueFormatters));
         }
 
         /// <inheritdoc />
@@ -70,6 +74,9 @@ namespace ThePensionsRegulator.Umbraco.Core.PropertyEditors.ValueConverters
         {
             return propertyType.EditorAlias == Constants.PropertyEditors.Aliases.RichText;
         }
+
+        /// <inheritdoc />
+        public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.None;
     }
 
 

--- a/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
+++ b/ThePensionsRegulator.Umbraco.Testing/UmbracoTestContext.cs
@@ -21,7 +21,9 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Dictionary;
+using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
@@ -181,6 +183,16 @@ namespace ThePensionsRegulator.Umbraco.Testing
         /// Provides access to Umbraco's caches of current published content.
         /// </summary>
         public Mock<ICacheManager> CacheManager { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the service used to cache blocks in block grids.
+        /// </summary>
+        public Mock<BlockGridPropertyValueConstructorCache> BlockGridPropertyValueConstructorCache { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the service used to cache blocks in block lists.
+        /// </summary>
+        public Mock<BlockListPropertyValueConstructorCache> BlockListPropertyValueConstructorCache { get; private init; } = new();
 
         /// <summary>
         /// Gets the service used to cache blocks in rich text editors.
@@ -453,9 +465,29 @@ namespace ThePensionsRegulator.Umbraco.Testing
         public Mock<ITempDataDictionaryFactory> TempDataDictionaryFactory { get; private init; } = new();
 
         /// <summary>
+        /// The logging service used by Umbraco.
+        /// </summary>
+        public Mock<IProfilingLogger> ProfilingLogger { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the service used to provide content names for the Delivery API.
+        /// </summary>
+        public Mock<IApiContentNameProvider> ApiContentNameProvider { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the builder that creates <see cref="IApiContentRoute"/> objects from published content for the Delivery API.
+        /// </summary>
+        public Mock<IApiContentRouteBuilder> ApiContentRouteBuilder { get; private init; } = new();
+
+        /// <summary>
         /// Gets the service used to build API elements for the Delivery API.
         /// </summary>
         public Mock<IApiElementBuilder> ApiElementBuilder { get; private init; } = new();
+
+        /// <summary>
+        /// Gets the service used to retrieve URLs for media items for the Delivery API.
+        /// </summary>
+        public Mock<IApiMediaUrlProvider> ApiMediaUrlProvider { get; private init; } = new();
 
         /// <summary>
         /// Gets the parser used to parse rich text editor elements for the Delivery API.
@@ -558,10 +590,15 @@ namespace ThePensionsRegulator.Umbraco.Testing
         private void SetupServices()
         {
             HttpContext.Setup(x => x.RequestServices).Returns(ServiceProvider.Object);
+            SetupService(ApiContentRouteBuilder.Object);
+            SetupService(ApiContentNameProvider.Object);
+            SetupService(ApiMediaUrlProvider.Object);
             SetupService(ApiElementBuilder.Object);
             SetupService(ApiRichTextElementParser.Object);
             SetupService(ApiRichTextMarkupParser.Object);
             SetupService(AuditService.Object);
+            SetupService(BlockGridPropertyValueConstructorCache.Object);
+            SetupService(BlockListPropertyValueConstructorCache.Object);
             SetupService(CompositeViewEngine.Object);
             SetupService(CacheManager.Object);
             SetupService(ConsentService.Object);
@@ -596,6 +633,7 @@ namespace ThePensionsRegulator.Umbraco.Testing
             SetupService(NotificationService.Object);
             SetupService(PackagingService.Object);
             SetupService(PartialViewBlockEngine.Object);
+            SetupService(ProfilingLogger.Object);
             SetupService(PropertyRenderingContextAccessor.Object);
             SetupService(PublicAccessService.Object);
             SetupService(PublishedContentCache.Object);


### PR DESCRIPTION
In v17 it looks like the page content is shared across requests rather than generated per request. This means that any modified content on a page is persisted across requests and causes an issue if we are looking for a placeholder to update.

For example, if a first request for a page returns content that includes a token for replacement, a subsequent request might return the content with that token already replaced.

This issue was seen in v13, described in https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/pull/210 and fixed in https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/pull/211 by setting the PropertyCacheLevel to Snapshot.

In Umbraco v17 the concept of a snapshot is gone, and during the upgrade [this setting was replaced with Element](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/commit/0b17a8a6aa73c21e0d85fbef7cdd6a29b42ce626#diff-c89a7914b819940ae25873b61d4febadefcc6e276864b20e43b68e299c9171a0) but this was a best guess at the appropriate value, and it was [removed entirely from RichTextEditorPropertyValueConverter](https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/commit/e5a727c02500464172d329c00e579175f9f36009#diff-dd77eb57b8f1e7653931ae1855da991c5c1568ee17290f62e9a66185e72bc53e) . Having reproduced the faulty behaviour, we now know the correct value is None.

This PR also adds some missing tests for property value converters.

Fixes #865.