### PR TITLE
ReTest - Menu links do not always show the current section 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>10.1.2</Version>
+    <Version>10.1.3</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.Frontend.Umbraco/Backoffice/package-lock.json
@@ -3229,9 +3229,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3368,9 +3368,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3388,7 +3388,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
+++ b/ThePensionsRegulator.Frontend/Styles/_tpr-header-menu.scss
@@ -42,22 +42,22 @@
     }
 }
 
-.tpr-header-menu__button--hidden{
-    display :none;
+.tpr-header-menu__button--hidden {
+    display: none;
 }
 
 .tpr-mobile-menu__no-js-link {
     display: flex;
     align-items: flex-end;
     gap: 0.5rem;
-    
-    &:hover{
+
+    &:hover {
         color: $tpr-colour-white;
     }
 }
 
-.tpr-mobile-menu__no-js-link--hidden{
-    display:none;
+.tpr-mobile-menu__no-js-link--hidden {
+    display: none;
 }
 
 .tpr-mobile-menu__icon-no-js {
@@ -93,16 +93,16 @@
     cursor: pointer;
 }
 
-    .tpr-header-menu__button-inner:focus {
-        color: $tpr-colour-black;
-        background-color: $tpr-colour-tangerine-yellow;
-        box-shadow: 0 -2px $tpr-colour-tangerine-yellow, 0 4px $tpr-colour-black;
-        text-decoration: none;
-    }
+.tpr-header-menu__button-inner:focus {
+    color: $tpr-colour-black;
+    background-color: $tpr-colour-tangerine-yellow;
+    box-shadow: 0 -2px $tpr-colour-tangerine-yellow, 0 4px $tpr-colour-black;
+    text-decoration: none;
+}
 
-    .tpr-header-menu__button:focus-visible {
-        outline: transparent;
-    }
+.tpr-header-menu__button:focus-visible {
+    outline: transparent;
+}
 
 .tpr-header-menu__button-inner--opened {
     color: $tpr-colour-royal-blue;
@@ -117,14 +117,14 @@
     padding-left: 0.3rem;
 }
 
-    .tpr-header-menu__button--open::before {
-        content: "x";
-        font-size: 1.5rem;
-        font-weight: 700;
-        font-family: $govuk-font-family;
-        color: $tpr-colour-royal-blue;
-        margin-left: 0.5rem;
-    }
+.tpr-header-menu__button--open::before {
+    content: "x";
+    font-size: 1.5rem;
+    font-weight: 700;
+    font-family: $govuk-font-family;
+    color: $tpr-colour-royal-blue;
+    margin-left: 0.5rem;
+}
 
 .tpr-mobile-menu__svg {
     width: 1.5rem;
@@ -290,6 +290,11 @@
         border-width: 0 3px 3px 0;
     }
 
+    .tpr-header-menu__nav-menu-item--active-mobile {
+        background: $tpr-colour-violet;
+        color: $tpr-colour-white;
+    }
+
     .tpr-header-menu__nav-menu-item-link:focus + .tpr-header-menu__arrow-container .tpr-header-menu__arrow, .tpr-header-menu__arrow:focus {
         border: solid $tpr-colour-black;
         border-width: 0 3px 3px 0;
@@ -301,7 +306,7 @@
         display: none;
     }
 
-    .tpr-mobile-menu__container-inner{
+    .tpr-mobile-menu__container-inner {
         display: none;
     }
 
@@ -477,7 +482,7 @@
     }
 
     .tpr-header-menu__nav-menu-item:has(.tpr-header-menu__nav-sub-menu:focus-within) {
-         background: $tpr-colour-white;    
+        background: $tpr-colour-white;
     }
 
     .tpr-header-menu__nav-menu-item:has(.tpr-header-menu__nav-sub-menu:focus-within) > a {
@@ -512,9 +517,18 @@
     }
 }
 
-.tpr-header-menu__nav-menu-item--active {
-    background: $tpr-colour-violet;
-    color: $tpr-colour-white;
+a.tpr-header-menu__nav-menu-item--active-desktop {
+    text-decoration: underline;
+    text-decoration-thickness: 8px;
+    text-underline-offset: 10px;
+
+    &:focus {
+        text-decoration-thickness: 8px;
+    }
+
+    &:hover {
+        text-decoration-thickness: 8px;
+    }
 }
 
 @media(max-width: 350px) {

--- a/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
+++ b/ThePensionsRegulator.Frontend/wwwroot/ThePensionsRegulator.Frontend/js/headermenu.js
@@ -1,9 +1,6 @@
 ﻿document.addEventListener("DOMContentLoaded", function () {
 
-
-    highlightCurrentSection();
     const mediaQuery = window.matchMedia("(max-width: 993px)");
-
     function SelectNavOption(e) {
 
         const mobileMenuInnerContainers = document.querySelectorAll(".tpr-mobile-menu__container-inner");
@@ -17,6 +14,7 @@
 
         const isMobile = e.matches;
 
+        highlightCurrentSection(isMobile);
 
         if (isMobile) {
 
@@ -81,7 +79,7 @@
     mediaQuery.addEventListener("change", SelectNavOption);
 });
 
-function highlightCurrentSection() {
+function highlightCurrentSection(isMobile) {
 
     let url = window.location.pathname;
 
@@ -110,9 +108,16 @@ function highlightCurrentSection() {
         const arrow = item.querySelector(".tpr-header-menu__arrow")
 
         if (anchorText.includes(section.toLowerCase())) {
-            anchor.classList.toggle("tpr-header-menu__nav-menu-item--active")
-            item.classList.toggle("tpr-header-menu__nav-menu-item--active")
-            arrow.classList.toggle("tpr-header-menu_arrow--active")
+
+            if (isMobile) {
+                anchor.classList.remove("tpr-header-menu__nav-menu-item--active-desktop")
+                anchor.classList.add("tpr-header-menu__nav-menu-item--active-mobile")
+                arrow.classList.add("tpr-header-menu_arrow--active")
+            } else {
+                anchor.classList.remove("tpr-header-menu__nav-menu-item--active-mobile")
+                arrow.classList.remove("tpr-header-menu_arrow--active")
+                anchor.classList.add("tpr-header-menu__nav-menu-item--active-desktop")
+            }
         }
     });
 }

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/Backoffice/package-lock.json
@@ -3229,9 +3229,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3368,9 +3368,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3388,7 +3388,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1902,15 +1902,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
Why:

There is an accessibility contrast issue between the interactive element and the background in the desktop header menu. I discussed potential solutions with the design team and suggested aligning more closely with GOV.UK patterns by using an active marker beneath the link text rather than relying solely on a colour change.

[#AB260868](https://dev.azure.com/thepensionsregulator/TPR/_boards/board/t/Web%20Platform%20Team/Stories?workitem=260868)

GOVUK implementation:

<img width="1443" height="183" alt="GovUK banner" src="https://github.com/user-attachments/assets/d7798f75-0020-4a05-bc20-dbd478ded6a1" />

TPR version to accommodate the white active bar on a white page background. A small amount of the dark header background is retained to create clearer separation between the active indicator and the page content.

<img width="1798" height="75" alt="tpr banner" src="https://github.com/user-attachments/assets/d9359700-c36c-4bf7-a34b-771e2679bdb8" />

In this PR:

- Split desktop and mobile active-state styling into separate classes.
- Moved highlightCurrentSection inside selectNavOptions to support the correct styling based on screen size.
- Created a new active marker for the desktop header menu.

Solution Implementation: 

<img width="1837" height="167" alt="Header Menu" src="https://github.com/user-attachments/assets/ce94c69a-4209-4e2d-8a86-7d16b31d3c7b" />

