### PR TITLE
274812 change to return error message in front end when 29th February entered in day and month date controls

### DIFF
--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -467,6 +467,8 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
         [InlineData(DateInputItemTypes.DayMonthAndYear, "31", "January", "2020", false, DateInputParseErrors.InvalidMonth)]
         [InlineData(DateInputItemTypes.DayMonthAndYear, "29", "February", "2023", true, DateInputParseErrors.InvalidDay)]
         [InlineData(DateInputItemTypes.DayAndMonth, "29", "February", null, true, DateInputParseErrors.InvalidDay)]
+        [InlineData(DateInputItemTypes.DayAndMonth, "32", "March", null, true, DateInputParseErrors.InvalidDay)]
+        [InlineData(DateInputItemTypes.DayAndMonth, "0", "March", null, true, DateInputParseErrors.InvalidDay)]
         public void Parse_InvalidDate_ComputesExpectedParseErrors(DateInputItemTypes itemTypes,
             string? day, string? month, string? year, bool acceptMonthNames, DateInputParseErrors expectedParseErrors)
         {

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -13,6 +13,7 @@ using ThePensionsRegulator.Umbraco.Core;
 using ThePensionsRegulator.Umbraco.Testing;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Web.Common;
+using static Umbraco.Cms.Infrastructure.ModelsBuilder.Building.TypeModel;
 
 namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
 {
@@ -442,37 +443,37 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
         }
 
         [Theory]
-        [InlineData("", "4", "2020", false, DateInputParseErrors.MissingDay)]
-        [InlineData(null, "4", "2020", false, DateInputParseErrors.MissingDay)]
-        [InlineData("1", "", "2020", false, DateInputParseErrors.MissingMonth)]
-        [InlineData("1", null, "2020", false, DateInputParseErrors.MissingMonth)]
-        [InlineData("1", "4", null, false, DateInputParseErrors.MissingYear)]
-        [InlineData("1", "4", "", false, DateInputParseErrors.MissingYear)]
-        [InlineData("0", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [InlineData("-1", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [InlineData("32", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [InlineData("x", "4", "2020", false, DateInputParseErrors.InvalidDay)]
-        [InlineData("1", "0", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [InlineData("1", "-1", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [InlineData("1", "13", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [InlineData("1", "x", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [InlineData("1", "4", "15", false, DateInputParseErrors.InvalidYear)]
-        [InlineData("1", "4", "0", false, DateInputParseErrors.InvalidYear)]
-        [InlineData("1", "4", "-1", false, DateInputParseErrors.InvalidYear)]
-        [InlineData("1", "4", "10000", false, DateInputParseErrors.InvalidYear)]
-        [InlineData("1", "4", "x", false, DateInputParseErrors.InvalidYear)]
-        [InlineData("1", "x", "2020", true, DateInputParseErrors.InvalidMonth)]
-        [InlineData("1", "dec", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [InlineData("31", "January", "2020", false, DateInputParseErrors.InvalidMonth)]
-        [InlineData("29", "February", "2023", true, DateInputParseErrors.InvalidDay)]
-        [InlineData("29", "February", "1900", true, DateInputParseErrors.InvalidDay)]
-        public void Parse_InvalidDate_ComputesExpectedParseErrors(
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "", "4", "2020", false, DateInputParseErrors.MissingDay)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, null, "4", "2020", false, DateInputParseErrors.MissingDay)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "", "2020", false, DateInputParseErrors.MissingMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", null, "2020", false, DateInputParseErrors.MissingMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "4", null, false, DateInputParseErrors.MissingYear)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "4", "", false, DateInputParseErrors.MissingYear)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "0", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "-1", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "32", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "x", "4", "2020", false, DateInputParseErrors.InvalidDay)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "0", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "-1", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "13", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "x", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "4", "15", false, DateInputParseErrors.InvalidYear)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "4", "0", false, DateInputParseErrors.InvalidYear)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "4", "-1", false, DateInputParseErrors.InvalidYear)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "4", "10000", false, DateInputParseErrors.InvalidYear)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "4", "x", false, DateInputParseErrors.InvalidYear)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "x", "2020", true, DateInputParseErrors.InvalidMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "1", "dec", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "31", "January", "2020", false, DateInputParseErrors.InvalidMonth)]
+        [InlineData(DateInputItemTypes.DayMonthAndYear, "29", "February", "2023", true, DateInputParseErrors.InvalidDay)]
+        [InlineData(DateInputItemTypes.DayAndMonth, "29", "February", null, true, DateInputParseErrors.InvalidDay)]
+        public void Parse_InvalidDate_ComputesExpectedParseErrors(DateInputItemTypes itemTypes,
             string? day, string? month, string? year, bool acceptMonthNames, DateInputParseErrors expectedParseErrors)
         {
             // Arrange
 
             // Act
-            var result = UmbracoDateInputModelBinder.Parse(DateInputItemTypes.DayMonthAndYear, day, month, year, acceptMonthNames, out var dateComponents);
+            var result = UmbracoDateInputModelBinder.Parse(itemTypes, day, month, year, acceptMonthNames, out var dateComponents);
 
             // Assert
             Assert.Null(dateComponents.Day);

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -465,6 +465,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
         [InlineData("1", "dec", "2020", false, DateInputParseErrors.InvalidMonth)]
         [InlineData("31", "January", "2020", false, DateInputParseErrors.InvalidMonth)]
         [InlineData("29", "February", "2023", true, DateInputParseErrors.InvalidDay)]
+        [InlineData("29", "February", "1900", true, DateInputParseErrors.InvalidDay)]
         public void Parse_InvalidDate_ComputesExpectedParseErrors(
             string? day, string? month, string? year, bool acceptMonthNames, DateInputParseErrors expectedParseErrors)
         {

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
@@ -271,6 +271,10 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.ModelBinding
                 {
                     errors |= DateInputParseErrors.InvalidDay;
                 }
+                else if (parsedYear == 1900 && parsedMonth == 2 && parsedDay == 29)
+                {
+                    errors |= DateInputParseErrors.InvalidDay;
+                }
             }
 
             dateParts = errors == DateInputParseErrors.None ? new(

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
@@ -271,7 +271,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.ModelBinding
                 {
                     errors |= DateInputParseErrors.InvalidDay;
                 }
-                else if (parsedYear == 1900 && parsedMonth == 2 && parsedDay == 29)
+                else if (!expectYear && parsedMonth == 2 && parsedDay == 29)
                 {
                     errors |= DateInputParseErrors.InvalidDay;
                 }


### PR DESCRIPTION
[AB#274812](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/274812) change to return error message in front end when 29th February entered in day and month date controls.