### PR TITLE
AB#274812 change to use 2000 rather than 1900 in Date month and year pickers to avoid errors with invalid leap years

### DIFF
--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -424,6 +424,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.Tests.ModelBinding
         [InlineData(DateInputItemTypes.DayMonthAndYear, "31", "dec", 12, "2020")]
         [InlineData(DateInputItemTypes.DayMonthAndYear, "31", "January", 1, "2020")]
         [InlineData(DateInputItemTypes.DayMonthAndYear, "29", "February", 2, "2024")]
+        [InlineData(DateInputItemTypes.DayAndMonth, "29", "February", 2, "2000")]
         public void Parse_ValidDate_Returns_Date(DateInputItemTypes itemTypes, string? day, string month, int expectedMonth, string year)
         {
             // Arrange

--- a/ThePensionsRegulator.GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
+++ b/ThePensionsRegulator.GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
@@ -276,7 +276,7 @@ namespace ThePensionsRegulator.GovUk.Frontend.Umbraco.ModelBinding
             dateParts = errors == DateInputParseErrors.None ? new(
                 expectDay ? parsedDay : 1,
                 expectMonth ? parsedMonth : null,
-                expectYear ? parsedYear : 1900) : default;
+                expectYear ? parsedYear : 2000) : default;
             return errors;
 
             bool TryParseDay(string value, out int result) => int.TryParse(value, out result);


### PR DESCRIPTION
Change to use 2000 rather than 1900 in Date month and year pickers to avoid errors with invalid leap years.