### PR TITLE
AB#274812 change to use 2000 rather than 1900 in Date month and year pickers to avoid errors with invalid leap years

### DIFF
--- a/GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
+++ b/GovUk.Frontend.Umbraco.Tests/ModelBinding/UmbracoDateInputModelBinderTests.cs
@@ -449,6 +449,7 @@ namespace GovUk.Frontend.Umbraco.Tests.ModelBinding
         [TestCase(DateInputItemTypes.DayMonthAndYear, "31", "dec", 12, "2020")]
         [TestCase(DateInputItemTypes.DayMonthAndYear, "31", "January", 1, "2020")]
         [TestCase(DateInputItemTypes.DayMonthAndYear, "29", "February", 2, "2024")]
+        [TestCase(DateInputItemTypes.DayAndMonth, "29", "February", 2, "2000")]
         public void Parse_ValidDate_Returns_Date(DateInputItemTypes itemTypes, string? day, string month, int expectedMonth, string year)
         {
             // Arrange

--- a/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
+++ b/GovUk.Frontend.Umbraco/ModelBinding/UmbracoDateInputModelBinder.cs
@@ -277,7 +277,7 @@ namespace GovUk.Frontend.Umbraco.ModelBinding
             dateParts = errors == DateInputParseErrors.None ? new(
                 expectDay ? parsedDay : 1,
                 expectMonth ? parsedMonth : null,
-                expectYear ? parsedYear : 1900) : default;
+                expectYear ? parsedYear : 2000) : default;
             return errors;
 
             bool TryParseDay(string value, out int result) => int.TryParse(value, out result);


### PR DESCRIPTION
[AB#274812](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/274812) change to use 2000 rather than 1900 in Date month and year pickers to avoid errors with invalid leap years.