### PR TITLE
Duplicate form id in global search

### DIFF
--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderMenuTagHelperTest.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderMenuTagHelperTest.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using ThePensionsRegulator.Frontend.TagHelpers;
 
 namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
@@ -19,11 +16,10 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
             var expectedItemAriaLabel = "Nav Item";
             var expectedSearchId = "form-1";
 
-
             var tagHelper = new TprHeaderMenuTagHelper
             {
                 MenuAriaLabel = expectedAriaLabel,
-                NoJsNavPage =  expectedNoJSNavPage,
+                NoJsNavPage = expectedNoJSNavPage,
                 ToggleClosed = expectedToggleClosed,
                 ToggleOpen = expectedToggleOpen,
                 MenuItemAriaLabel = expectedItemAriaLabel,

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderMenuTagHelperTest.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderMenuTagHelperTest.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ThePensionsRegulator.Frontend.TagHelpers;
+
+namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
+{
+    public class TprHeaderMenuTagHelperTest
+    {
+        [Fact]
+        public async Task All_values_are_correctly_stored_in_context()
+        {
+            // Arrange
+            var expectedAriaLabel = "Main Navigation";
+            var expectedNoJSNavPage = "/site-map";
+            var expectedToggleClosed = "Menu";
+            var expectedToggleOpen = "Closed";
+            var expectedItemAriaLabel = "Nav Item";
+            var expectedSearchId = "form-1";
+
+
+            var tagHelper = new TprHeaderMenuTagHelper
+            {
+                MenuAriaLabel = expectedAriaLabel,
+                NoJsNavPage =  expectedNoJSNavPage,
+                ToggleClosed = expectedToggleClosed,
+                ToggleOpen = expectedToggleOpen,
+                MenuItemAriaLabel = expectedItemAriaLabel,
+                SearchFormId = expectedSearchId
+            };
+
+            var attributes = new TagHelperAttributeList();
+
+            var headerBarContext = new TprHeaderBarContext();
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object> { { typeof(TprHeaderBarContext), headerBarContext } }, Guid.NewGuid().ToString());
+
+            var output = new TagHelperOutput("tpr-header-menu", attributes, (result, encoder) =>
+            {
+                return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+            });
+
+            // Act
+            await tagHelper.ProcessAsync(context, output);
+
+            // Assert
+            Assert.Equal(expectedAriaLabel, headerBarContext.HeaderMenuAriaLabel);
+            Assert.Equal(expectedNoJSNavPage, headerBarContext.MobileMenuNoJsNavPage);
+            Assert.Equal(expectedToggleClosed, headerBarContext.HeaderMenuToggleClosed);
+            Assert.Equal(expectedToggleOpen, headerBarContext.HeaderMenuToggleOpen);
+            Assert.Equal(expectedItemAriaLabel, headerBarContext.HeaderMenuItemAriaLabel);
+            Assert.Equal(expectedSearchId, headerBarContext.HeaderMenuSearchFormId);
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderSearchTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderSearchTagHelperTests.cs
@@ -16,7 +16,6 @@ namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
             var expectedAriaLabel = "search";
             var expectedInputName = "query";
 
-
             var tagHelper = new TprHeaderSearchTagHelper
             {
                 FormId = expectedFormId,

--- a/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderSearchTagHelperTests.cs
+++ b/ThePensionsRegulator.Frontend.Tests/TagHelpers/TprHeaderSearchTagHelperTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using ThePensionsRegulator.Frontend.TagHelpers;
+
+namespace ThePensionsRegulator.Frontend.Tests.TagHelpers
+{
+    public class TprHeaderSearchTagHelperTests
+    {
+        [Fact]
+        public async Task All_values_are_correctly_stored_in_context()
+        {
+            // Arrange
+            var expectedFormId = "form-1";
+            var expectedActionPath = "/search";
+            var expectedAutoCompleteUrl = "/autocomplete";
+            var expectedPlaceholderText = "Search";
+            var expectedAriaLabel = "search";
+            var expectedInputName = "query";
+
+
+            var tagHelper = new TprHeaderSearchTagHelper
+            {
+                FormId = expectedFormId,
+                ActionPath = expectedActionPath,
+                AutocompleteUrl = expectedAutoCompleteUrl,
+                PlaceholderText = expectedPlaceholderText,
+                AriaLabel = expectedAriaLabel,
+                InputName = expectedInputName
+            };
+
+            var attributes = new TagHelperAttributeList { { "data-test", "value" } };
+
+            var headerBarContext = new TprHeaderBarContext();
+
+            var context = new TagHelperContext(attributes, new Dictionary<object, object> { { typeof(TprHeaderBarContext), headerBarContext } }, Guid.NewGuid().ToString());
+
+            var output = new TagHelperOutput("tpr-header-search", attributes, (result, encoder) =>
+            {
+                return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+            });
+
+            // Act
+            await tagHelper.ProcessAsync(context, output);
+
+            // Assert
+            Assert.True(headerBarContext.ShowSearch);
+            Assert.Equal(expectedFormId, headerBarContext.SearchFormId);
+            Assert.Equal(expectedActionPath, headerBarContext.ActionPath);
+            Assert.Equal(expectedAutoCompleteUrl, headerBarContext.AutoCompleteUrl);
+            Assert.Equal(expectedPlaceholderText, headerBarContext.SearchPlaceholderText);
+            Assert.Equal(expectedAriaLabel, headerBarContext.SearchAriaLabel);
+            Assert.Equal(expectedInputName, headerBarContext.SearchInputName);
+            Assert.NotNull(headerBarContext.SearchAttributes);
+            Assert.True(headerBarContext.SearchAttributes.ContainsKey("data-test"));
+        }
+    }
+}

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
@@ -140,7 +140,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             {
                 form.Attributes.Add("action", tprHeaderBar.ActionPath);
             }
-            form.Attributes.Add("id", "tpr-header-search__form");
+
             form.Attributes.Add("method", "get");
 
             var searchField = new TagBuilder("div");

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
@@ -97,7 +97,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             else if (tprHeaderBar.ShowSearch)
             {
 
-                var headerSearch = GenerateTprHeaderSearch(tprHeaderBar);
+                var headerSearch = GenerateTprHeaderSearch(tprHeaderBar, tprHeaderBar.SearchFormId);
                 headerContent.InnerHtml.AppendHtml(headerSearch);
             }
             if (tprHeaderBar?.DisplayHeaderMenu ?? false)
@@ -129,7 +129,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             return tagBuilder;
         }
 
-        public virtual TagBuilder GenerateTprHeaderSearch(TprHeaderBar tprHeaderBar, bool includeId = true )
+        public virtual TagBuilder GenerateTprHeaderSearch(TprHeaderBar tprHeaderBar, string? formId = null)
         {
             var divTag = new TagBuilder("div");
             if (tprHeaderBar.SearchAttributes != null) { divTag.MergeAttributes(tprHeaderBar.SearchAttributes); }
@@ -141,9 +141,9 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 form.Attributes.Add("action", tprHeaderBar.ActionPath);
             }
 
-            if (includeId)
+            if (!string.IsNullOrEmpty(formId))
             {
-                form.Attributes.Add("id", "tpr-header-search__form");
+                form.Attributes.Add("id", formId);
             }
 
             form.Attributes.Add("method", "get");

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderBar.cs
@@ -129,7 +129,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             return tagBuilder;
         }
 
-        public virtual TagBuilder GenerateTprHeaderSearch(TprHeaderBar tprHeaderBar)
+        public virtual TagBuilder GenerateTprHeaderSearch(TprHeaderBar tprHeaderBar, bool includeId = true )
         {
             var divTag = new TagBuilder("div");
             if (tprHeaderBar.SearchAttributes != null) { divTag.MergeAttributes(tprHeaderBar.SearchAttributes); }
@@ -139,6 +139,11 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
             if (!string.IsNullOrEmpty(tprHeaderBar.ActionPath))
             {
                 form.Attributes.Add("action", tprHeaderBar.ActionPath);
+            }
+
+            if (includeId)
+            {
+                form.Attributes.Add("id", "tpr-header-search__form");
             }
 
             form.Attributes.Add("method", "get");

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderMenu.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderMenu.cs
@@ -129,7 +129,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 var searchContainer = new TagBuilder("li");
                 searchContainer.AddCssClass("tpr-mobile-menu__header-search-container");
                 headerMenuList.InnerHtml.AppendHtml(searchContainer);
-                var tprHeaderSearch = GenerateTprHeaderSearch(tprHeaderBar);
+                var tprHeaderSearch = GenerateTprHeaderSearch(tprHeaderBar, false);
                 tprHeaderSearch.AddCssClass("tpr-header-search__mobile");
                 searchContainer.InnerHtml.AppendHtml(tprHeaderSearch);
             }

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderMenu.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/ComponentGenerator.TprHeaderMenu.cs
@@ -129,7 +129,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
                 var searchContainer = new TagBuilder("li");
                 searchContainer.AddCssClass("tpr-mobile-menu__header-search-container");
                 headerMenuList.InnerHtml.AppendHtml(searchContainer);
-                var tprHeaderSearch = GenerateTprHeaderSearch(tprHeaderBar, false);
+                var tprHeaderSearch = GenerateTprHeaderSearch(tprHeaderBar, tprHeaderBar.HeaderMenuSearchFormId);
                 tprHeaderSearch.AddCssClass("tpr-header-search__mobile");
                 searchContainer.InnerHtml.AppendHtml(tprHeaderSearch);
             }

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/TprHeaderBar.cs
@@ -18,6 +18,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         public bool ContentAllowHtml { get; set; }
         public bool ShowSearch {  get; set; }
         public AttributeDictionary? SearchAttributes { get; set; }
+        public string? SearchFormId { get; set; }
         public string? ActionPath {  get; set; }     
         public string? AutoCompleteUrl {  get; set; }     
         public string? SearchPlaceholderText {  get; set; }

--- a/ThePensionsRegulator.Frontend/HtmlGeneration/TprHeaderBar.cs
+++ b/ThePensionsRegulator.Frontend/HtmlGeneration/TprHeaderBar.cs
@@ -32,6 +32,7 @@ namespace ThePensionsRegulator.Frontend.HtmlGeneration
         public string? MobileMenuNoJsNavPage { get; set; }
         public string? HeaderMenuToggleClosed { get; set; }
         public string? HeaderMenuToggleOpen { get; set; }
+        public string? HeaderMenuSearchFormId { get; set; }
 
     }
 }

--- a/ThePensionsRegulator.Frontend/Models/TprHeaderLockupModel.cs
+++ b/ThePensionsRegulator.Frontend/Models/TprHeaderLockupModel.cs
@@ -28,6 +28,7 @@ namespace ThePensionsRegulator.Frontend.Models
         public virtual string? Context2 { get; set; }
         public virtual string? Context3 { get; set; }
         public virtual bool ShowSearch { get; init; }
+        public virtual string? SearchFormId { get; set; }
         public virtual string? HeaderSearchActionPath { get; set; } 
         public virtual string? HeaderSearchAutocompleteUrl { get; set; }
         public virtual string? HeaderSearchPlaceholderText { get; set; } 
@@ -39,6 +40,7 @@ namespace ThePensionsRegulator.Frontend.Models
         public virtual string? HeaderMenuNoJSNavPage { get; set; }
         public virtual string? HeaderMenuToggleOpen { get; set; }
         public virtual string? HeaderMenuToggleClosed { get; set; }
+        public virtual string? HeaderMenuSearchFormId { get; set; }
         public virtual IList<TprHeaderMenuItem>? HeaderMenuItems { get; set; }
     }
 }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarContext.cs
@@ -36,6 +36,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         public string? MobileMenuNoJsNavPage => _headerMenuContext?.MobileMenuNoJsNavPage;
         public string? HeaderMenuToggleClosed => _headerMenuContext?.HeaderMenuToggleClosed;
         public string? HeaderMenuToggleOpen => _headerMenuContext?.HeaderMenuToggleOpen;
+        public string? HeaderMenuSearchFormId => _headerMenuContext?.HeaderMenuSearchFormId;
 
 
         public void SetLogo(AttributeDictionary attributes, string? href, string? alternativeText)

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarContext.cs
@@ -9,7 +9,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         private (AttributeDictionary Attributes, string? Href, string? AlternativeText)? _logo;
         private (AttributeDictionary Attributes, IHtmlContent? Label, bool AllowHtml)? _label;
         private (AttributeDictionary Attributes, IHtmlContent? Content, bool AllowHtml)? _content;
-        private (AttributeDictionary Attributes, bool ShowSearch, string? ActionPath,string? AutocompleteUrl, string? PlaceholderText, string? SearchAriaLabel, string? SearchInputName)? _search;
+        private (AttributeDictionary Attributes, bool ShowSearch, string? FormId, string? ActionPath, string? AutocompleteUrl, string? PlaceholderText, string? SearchAriaLabel, string? SearchInputName)? _search;
         private TprHeaderMenuContext? _headerMenuContext;
 
         public AttributeDictionary? LogoAttributes => _logo?.Attributes;
@@ -23,6 +23,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         public bool ContentAllowHtml => _content?.AllowHtml ?? false;
         public bool ShowSearch => _search?.ShowSearch ?? false;
         public AttributeDictionary? SearchAttributes => _search?.Attributes;
+        public string? SearchFormId => _search?.FormId;
         public string? ActionPath => _search?.ActionPath;
         public string? AutoCompleteUrl => _search?.AutocompleteUrl;
         public string? SearchPlaceholderText => _search?.PlaceholderText;
@@ -73,7 +74,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             _content = (attributes, htmlContent, allowHtml);
         }
 
-        public void SetSearch(AttributeDictionary attributes, bool showSearch, string? actionPath,string? autocompleteUrl, string? placeholderText, string? ariaLabel, string? inputName)
+        public void SetSearch(AttributeDictionary attributes, bool showSearch, string? formId, string? actionPath, string? autocompleteUrl, string? placeholderText, string? ariaLabel, string? inputName)
         {
             if (_search != null)
             {
@@ -82,7 +83,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                 TprHeaderBarTagHelper.TagName);
             }
 
-            _search = (attributes, showSearch, actionPath, autocompleteUrl, placeholderText, ariaLabel, inputName);
+            _search = (attributes, showSearch, formId, actionPath, autocompleteUrl, placeholderText, ariaLabel, inputName);
         }
         public void SetHeaderMenu(TprHeaderMenuContext tprHeaderMenuContext)
         {

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarTagHelper.cs
@@ -93,7 +93,8 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                 HeaderMenuItemAriaLabel = barContext?.HeaderMenuItemAriaLabel,
                 MobileMenuNoJsNavPage = barContext?.MobileMenuNoJsNavPage,
                 HeaderMenuToggleClosed = barContext?.HeaderMenuToggleClosed,
-                HeaderMenuToggleOpen = barContext?.HeaderMenuToggleOpen
+                HeaderMenuToggleOpen = barContext?.HeaderMenuToggleOpen,
+                HeaderMenuSearchFormId = barContext?.HeaderMenuSearchFormId
 
             });
 

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderBarTagHelper.cs
@@ -80,6 +80,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
                 ContentAllowHtml = barContext.ContentAllowHtml,
                 ShowSearch = barContext.ShowSearch,
                 SearchAttributes = barContext?.SearchAttributes,
+                SearchFormId = barContext?.SearchFormId,
                 ActionPath = barContext?.ActionPath,
                 AutoCompleteUrl = barContext?.AutoCompleteUrl,
                 SearchPlaceholderText = barContext?.SearchPlaceholderText,

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderMenuContext.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderMenuContext.cs
@@ -14,6 +14,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         public string? MobileMenuNoJsNavPage {  get; set; }
         public string? HeaderMenuToggleOpen {  get; set; }
         public string? HeaderMenuToggleClosed {  get; set; }
+        public string? HeaderMenuSearchFormId { get; set; }
      
         public void AddMenuItem(TprHeaderMenuItemContext item)
         {

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderMenuTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderMenuTagHelper.cs
@@ -15,6 +15,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         private const string NoJsNavPageName = "no-js-destination";
         private const string ToggleClosedName = "close-label";
         private const string ToggleOpenName = "open-label";
+        private const string SearchFormIdAttribute = "search-id";
 
         [HtmlAttributeName(MenuAriaLabelName)]
         public string? MenuAriaLabel { get; set; }
@@ -31,6 +32,9 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         [HtmlAttributeName(ToggleOpenName)]
         public string? ToggleOpen { get; set; }
 
+        [HtmlAttributeName(SearchFormIdAttribute)]
+        public string? SearchFormId { get; set; }
+
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             var headerMenuContext = new TprHeaderMenuContext();
@@ -39,6 +43,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             headerMenuContext.MobileMenuNoJsNavPage = NoJsNavPage;
             headerMenuContext.HeaderMenuToggleClosed = ToggleClosed;
             headerMenuContext.HeaderMenuToggleOpen = ToggleOpen;
+            headerMenuContext.HeaderMenuSearchFormId = SearchFormId;
 
             if (output.Attributes != null)
             {

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderSearchTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderSearchTagHelper.cs
@@ -1,6 +1,5 @@
 ﻿using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using System.Threading.Tasks;
 using ThePensionsRegulator.GovUk.Frontend;
 
 namespace ThePensionsRegulator.Frontend.TagHelpers
@@ -25,11 +24,11 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
         [HtmlAttributeName(AutocompleteUrlAttribute)]
         public string? AutocompleteUrl { get; set; }
 
-        [HtmlAttributeName(PlaceholderAttribute)]    
-        public string? PlaceholderText {  get; set; }
-       
+        [HtmlAttributeName(PlaceholderAttribute)]
+        public string? PlaceholderText { get; set; }
+
         [HtmlAttributeName(AriaLabelAttribute)]
-        public string? AriaLabel {  get; set; }
+        public string? AriaLabel { get; set; }
 
         [HtmlAttributeName(InputNameAttribute)]
         public string? InputName { get; set; }
@@ -41,7 +40,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
             var content = await output.GetChildContentAsync();
 
             headerSearchContext.SetSearch(output.Attributes.ToAttributeDictionary(), true, FormId, ActionPath, AutocompleteUrl, PlaceholderText, AriaLabel, InputName);
-           
+
             output.SuppressOutput();
         }
     }

--- a/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderSearchTagHelper.cs
+++ b/ThePensionsRegulator.Frontend/TagHelpers/TprHeaderSearchTagHelper.cs
@@ -9,11 +9,15 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
     public class TprHeaderSearchTagHelper : TagHelper
     {
         internal const string TagName = "tpr-header-search";
+        private const string FormIdAttribute = "form-id";
         private const string ActionAttributeName = "action";
         private const string AutocompleteUrlAttribute = "autocomplete-url";
         private const string PlaceholderAttribute = "placeholder";
         private const string AriaLabelAttribute = "aria-label";
         private const string InputNameAttribute = "input-name";
+
+        [HtmlAttributeName(FormIdAttribute)]
+        public string? FormId { get; set; }
 
         [HtmlAttributeName(ActionAttributeName)]
         public string? ActionPath { get; set; }
@@ -36,7 +40,7 @@ namespace ThePensionsRegulator.Frontend.TagHelpers
 
             var content = await output.GetChildContentAsync();
 
-            headerSearchContext.SetSearch(output.Attributes.ToAttributeDictionary(), true, ActionPath, AutocompleteUrl, PlaceholderText, AriaLabel, InputName);
+            headerSearchContext.SetSearch(output.Attributes.ToAttributeDictionary(), true, FormId, ActionPath, AutocompleteUrl, PlaceholderText, AriaLabel, InputName);
            
             output.SuppressOutput();
         }

--- a/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRHeaderLockup.cshtml
+++ b/ThePensionsRegulator.Frontend/Views/Shared/TPR/TPRHeaderLockup.cshtml
@@ -30,11 +30,11 @@
                 <tpr-header-bar-content allow-html="@Model.HeaderBarContentAllowHtml">@Html.Raw(Model.HeaderBarContent)</tpr-header-bar-content>
                 @if (Model.HeaderBarContent == null && Model.ShowSearch)
                 {
-                    <tpr-header-search action="@Model.HeaderSearchActionPath" autocomplete-url="@Model.HeaderSearchAutocompleteUrl" placeholder="@Model.HeaderSearchPlaceholderText" aria-label="@Model.HeaderSearchAriaLabel" input-name="@Model.HeaderSearchInputName"></tpr-header-search>
+                    <tpr-header-search action="@Model.HeaderSearchActionPath" autocomplete-url="@Model.HeaderSearchAutocompleteUrl" placeholder="@Model.HeaderSearchPlaceholderText" aria-label="@Model.HeaderSearchAriaLabel" input-name="@Model.HeaderSearchInputName" form-id="@Model.SearchFormId"></tpr-header-search>
                 }
                 @if (Model.HeaderBarContent == null && Model.ShowHeaderMenu)
                 {
-                    <tpr-header-menu aria-label="@Model.HeaderMenuAriaLabel" menu-item-aria-label="@Model.HeaderMenuItemAriaLabel" open-label="@Model.HeaderMenuToggleOpen" close-label="@Model.HeaderMenuToggleClosed">
+                    <tpr-header-menu aria-label="@Model.HeaderMenuAriaLabel" menu-item-aria-label="@Model.HeaderMenuItemAriaLabel" open-label="@Model.HeaderMenuToggleOpen" close-label="@Model.HeaderMenuToggleClosed" search-id="@Model.HeaderMenuSearchFormId">
                         @if (Model.HeaderMenuItems != null)
                         {
                             @foreach (var item in Model.HeaderMenuItems.OfType<TprHeaderMenuItem>())

--- a/docs/components/tpr-header-bar.md
+++ b/docs/components/tpr-header-bar.md
@@ -78,6 +78,7 @@ Must be inside a `<govuk-header-bar>` element.
 | `placeholder`      | `string` | Supports setting custom placeholder for generated input elements.                                                                                                              |
 | `aria-label`       | `string` | Programmatically setting aria-label value of button element                                                                                                                    |
 | `input-name`       | `string` | Enables configuration so that destination page can choose what query string parameter it wants to handle (value for name attribute on input element). Default value is "query" |
+| `form-id`          | `string` | Sets the ID for the search form element.                                                                                                                                       |
 
 TPR Header Search will display when there is no header content and DisplayHeaderSearch property is set to true. On smaller screen sizes the TPR mobile menu component will take over, and the header search will display as part of the mobile menu when expanded.
 Mobile Menu behaviour has not yet been implemented therefore is a desktop-only component at this time.
@@ -95,6 +96,7 @@ Views which require the `<tpr-header-search>` should also include the `TPRHeader
 | `no-js-navigation`     | `string` | Sets destination for a page that displays all navigation items in the mobile menu when JavaScript is disabled. |
 | `open-label`           | `string` | Sets value for the mobile menu toggle label when the menu is expanded.                                         |
 | `close-label`          | `string` | Sets value for the mobile menu toggle label when the menu is collapsed.                                        |
+| `search-id`            | `string` | Sets the ID of the search form element to be used in the mobile menu.                                         |
 
 Using the `<tpr-header-menu>` tag will generate the toggle as part of the header bar and the associated nav which will dispay underneath the header.
 Adding `<tpr-header-menu-item>` will create items to populate the the menu and `<tpr-header-menu-child-item>` can be nested inside these parent items to populate each sub menu.


### PR DESCRIPTION
Why:

The header search component is generating invalid HTML because multiple form elements share the same id attribute value. IDs must be unique within a page.

In this PR:

- Add support to control whether an ID is assigned to form element, preventing duplicate IDs while minimising the impact on existing consuming projects.