### PR TITLE
Feature/javascript select

### DIFF
--- a/GovUk.Frontend.ExampleApp/Views/JavaScriptComponents/index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/JavaScriptComponents/index.cshtml
@@ -15,6 +15,9 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-coulmn input-target"></div>
 </div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-coulmn select-target"></div>
+</div>
 
 @section scripts {
     <script src="~/js/javascript-components-examples.js" type="module"></script>

--- a/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
+++ b/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
@@ -1,5 +1,5 @@
 import { createButton, createButtonGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/button.js";
-import { createTextInputFormGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/inputs.js";
+import { createTextInputFormGroup, createSelectFormGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/inputs.js";
 
 document.addEventListener("DOMContentLoaded", function () {
     const buttonTarget = document.querySelector(".button-target");
@@ -50,4 +50,23 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     inputTarget.appendChild(postcodeInput);
+
+    const selectTarget = document.querySelector(".select-target");
+    const select = createSelectFormGroup({
+        labelText: "Select an option",
+        hintText: "For example, choose one",
+        select: {
+            id: "example-select",
+            name: "example-select",
+            width: "large",
+            options: [
+                { value: "", text: "Please select" },
+                { value: "option1", text: "Option 1" },
+                { value: "option2", text: "Option 2" },
+            ],
+            attributes: {},
+        },
+    });
+
+    selectTarget.appendChild(select);
 });

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/inputs.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/inputs.ts
@@ -1,10 +1,14 @@
 import {
     FormGroupOptions,
     HintOptions,
-    InputWidth,
+    FormControlWidth,
     LabelOptions,
+    SelectFormGroupOptions,
+    Option,
+    SelectOptions,
     TextInputFormGroupOptions,
     TextInputOptions,
+    LabeledControlFormGroupOptions,
 } from "./types";
 
 export function createFormGroup(formGroupOptions: FormGroupOptions): HTMLElement {
@@ -18,6 +22,30 @@ export function createFormGroup(formGroupOptions: FormGroupOptions): HTMLElement
     div.appendChild(formGroupOptions.control);
 
     return div;
+}
+
+function createLabeledControlFormGroup(options: LabeledControlFormGroupOptions): HTMLElement {
+    const hintId = `${options.control.id}-hint`;
+
+    if (options.hintText) {
+        const describedBy = options.control.getAttribute("aria-describedby");
+
+        options.control.setAttribute(
+            "aria-describedby",
+            [describedBy, hintId].filter(Boolean).join(" ")
+        );
+    }
+
+    return createFormGroup({
+        label: createLabel({
+            labelText: options.labelText,
+            htmlFor: options.control.id,
+        }),
+        hint: options.hintText
+            ? createHint({ hintText: options.hintText, id: hintId })
+            : undefined,
+        control: options.control,
+    });
 }
 
 export function createLabel(labelOptions: LabelOptions): HTMLLabelElement {
@@ -56,25 +84,73 @@ export function createTextInput(options: TextInputOptions): HTMLInputElement {
     return input;
 }
 
-export function createTextInputFormGroup(options: TextInputFormGroupOptions): HTMLElement {
-    const hintId = `${options.input.id}-hint`;
-    const inputAttributes = { ...options.input.attributes };
+
+export function createTextInputFormGroup(
+    options: TextInputFormGroupOptions
+): HTMLElement {
+    return createLabeledControlFormGroup({
+        labelText: options.labelText,
+        hintText: options.hintText,
+        control: createTextInput(options.input),
+    });
+}
+
+export function createSelect(options: SelectOptions): HTMLSelectElement {
+    const select = document.createElement("select");
+    select.className = "govuk-select";
+    select.id = options.id;
+    select.name = options.name;
+    setAttributes(select, options.attributes);
+    
+    if (options.width) {
+        select.classList.add(inputWidthClasses[options.width]);
+    }
+    
+    for (const option of options.options) {
+        select.appendChild(createSelectOption(option));
+    }
+
+    if (options.value !== undefined) {
+        select.value = options.value;
+    }
+
+    return select;
+}
+
+function createSelectOption(option: Option): HTMLOptionElement {
+    const optionElement = document.createElement("option");
+    optionElement.value = option.value;
+    optionElement.textContent = option.text;
+    
+    if (option.disabled) {
+        optionElement.disabled = true;
+    }
+    if (option.attributes) {
+        setAttributes(optionElement, option.attributes);
+    }
+
+    return optionElement;
+}
+
+export function createSelectFormGroup(options: SelectFormGroupOptions): HTMLElement {
+    const hintId = `${options.select.id}-hint`;
+    const selectAttributes = { ...options.select.attributes };
 
     if (options.hintText) {
-        inputAttributes["aria-describedby"] = [inputAttributes["aria-describedby"], hintId]
+        selectAttributes["aria-describedby"] = [selectAttributes["aria-describedby"], hintId]
             .filter(Boolean)
             .join(" ");
     }
 
     return createFormGroup({
-        label: createLabel({ labelText: options.labelText, htmlFor: options.input.id }),
+        label: createLabel({ labelText: options.labelText, htmlFor: options.select.id }),
         hint: options.hintText ? createHint({ hintText: options.hintText, id: hintId }) : undefined,
-        control: createTextInput({ ...options.input, attributes: inputAttributes }),
+        control: createSelect({ ...options.select, attributes: selectAttributes }),
     });
 }
 
 
-const inputWidthClasses: Record<InputWidth, string> = {
+const inputWidthClasses: Record<FormControlWidth, string> = {
     "xx-small": "govuk-input--width-2",
     "x-small": "govuk-input--width-3",
     "small": "govuk-input--width-4",

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts
@@ -21,7 +21,7 @@ export interface HintOptions {
   attributes?: Record<string, string>;
 }
 
-export type InputWidth = 
+export type FormControlWidth = 
     |"xx-small" 
     | "x-small" 
     | "small" 
@@ -35,8 +35,14 @@ export interface TextInputOptions {
   name: string;
   type?: HTMLInputElement["type"];
   value?: string;
-  width?: InputWidth;
+  width?: FormControlWidth;
   attributes?: Record<string, string>;
+}
+
+export interface LabeledControlFormGroupOptions {
+    labelText: string;
+    hintText?: string;
+    control: FormControl;
 }
 
 export interface TextInputFormGroupOptions {
@@ -49,4 +55,26 @@ export interface FormGroupOptions {
     control: FormControl,
     label: HTMLLabelElement,
   hint?: HTMLDivElement,
+}
+
+export interface Option {
+    value: string;
+    text: string;
+    disabled?: boolean;
+    attributes?: Record<string, string>;
+}
+
+export interface SelectOptions {
+    id: string;
+    name: string;
+    value?: string;
+    options: Option[];
+    attributes?: Record<string, string>;
+    width?: FormControlWidth;
+}
+
+export interface SelectFormGroupOptions {
+    labelText: string;
+    hintText?: string;
+    select: SelectOptions;
 }

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/select.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/select.tests.ts
@@ -1,0 +1,187 @@
+import {
+    createSelect,
+    createSelectFormGroup,
+} from "../../../ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/inputs";
+import "@testing-library/jest-dom";
+
+describe("createSelect", () => {
+    it("should render a select element with the correct css class", () => {
+        const select = createSelect({ id: "test-select", name: "test-select", options: [{ value: "1", text: "Option 1" }] });
+   
+        expect(select.tagName).toBe("SELECT");
+        expect(select).toHaveClass("govuk-select");
+    });
+
+    it("should set the id and name attributes correctly", () => {
+        const select = createSelect({ id: "test-select", name: "test-select", options: [] });
+        
+        expect(select.id).toBe("test-select");
+        expect(select.name).toBe("test-select");
+    });
+
+    it.each([        
+        ["xx-small", "govuk-input--width-2"],
+        ["x-small", "govuk-input--width-3"],
+        ["small", "govuk-input--width-4"],
+        ["medium", "govuk-input--width-5"],
+        ["large", "govuk-input--width-10"],
+        ["x-large", "govuk-input--width-20"],
+        ["xx-large", "govuk-input--width-30"]
+    ] as const)
+        ("should map width %s to %s class", (width, expectedClass) => {
+        const select = createSelect({ id: "test-select", name: "test-select", options: [], width });
+        
+        expect(select).toHaveClass(expectedClass);
+    });
+
+    it("should render options correctly", () => {
+        const options = [
+            { value: "1", text: "Option 1" },
+            { value: "2", text: "Option 2", disabled: true }
+        ];
+        const select = createSelect({ id: "test-select", name: "test-select", options });
+        
+        expect(select.options.length).toBe(options.length);
+        expect(select.options[0].value).toBe("1");
+        expect(select.options[0].text).toBe("Option 1");
+        expect(select.options[1].value).toBe("2");
+        expect(select.options[1].text).toBe("Option 2");
+        expect(select.options[1].disabled).toBe(true);
+    });
+
+    it("should select the option matching the supplied value", () => {
+        const select = createSelect({
+            id: "test-select",
+            name: "test-select",
+            value: "2",
+            options: [
+                { value: "1", text: "Option 1" },
+                { value: "2", text: "Option 2" },
+            ],
+        });
+
+        expect(select).toHaveValue("2");
+        expect(select.selectedOptions[0]).toHaveTextContent("Option 2");
+    });
+
+    it("should select the first option when no value is supplied", () => {
+        const select = createSelect({
+            id: "test-select",
+            name: "test-select",
+            options: [
+                { value: "1", text: "Option 1" },
+                { value: "2", text: "Option 2" },
+            ],
+        });
+
+        expect(select).toHaveValue("1");
+    });
+
+    it("should have no selected value when the supplied value does not match an option", () => {
+        const select = createSelect({
+            id: "test-select",
+            name: "test-select",
+            value: "missing",
+            options: [{ value: "1", text: "Option 1" }],
+        });
+
+        expect(select.value).toBe("");
+        expect(select.selectedIndex).toBe(-1);
+    });
+
+    it("should apply custom select attributes", () => {
+        const select = createSelect({
+            id: "test-select",
+            name: "test-select",
+            options: [],
+            attributes: {
+                autocomplete: "country",
+                "data-test": "country-select",
+            },
+        });
+
+        expect(select).toHaveAttribute("autocomplete", "country");
+        expect(select).toHaveAttribute("data-test", "country-select");
+    });
+
+    it("should apply custom option attributes", () => {
+        const select = createSelect({
+            id: "test-select",
+            name: "test-select",
+            options: [
+                {
+                    value: "uk",
+                    text: "United Kingdom",
+                    attributes: { "data-country-id": "826" },
+                },
+            ],
+        });
+
+        expect(select.options[0]).toHaveAttribute("data-country-id", "826");
+    });
+
+    it("should render option text as text rather than HTML", () => {
+        const select = createSelect({
+            id: "test-select",
+            name: "test-select",
+            options: [{ value: "1", text: "<strong>Option 1</strong>" }],
+        });
+
+        expect(select.options[0].textContent).toBe("<strong>Option 1</strong>");
+        expect(select.options[0].querySelector("strong")).toBeNull();
+    });
+});
+
+describe("createSelectFormGroup", () => {
+    it("should associate the label with the select", () => {
+        const formGroup = createSelectFormGroup({
+            labelText: "Country",
+            select: {
+                id: "country",
+                name: "country",
+                options: [],
+            },
+        });
+
+        const label = formGroup.querySelector("label");
+        const select = formGroup.querySelector("select");
+
+        expect(label).toHaveAttribute("for", "country");
+        expect(select).toHaveAttribute("id", "country");
+    });
+
+    it("should include the hint and aria-describedby when hint text is supplied", () => {
+        const formGroup = createSelectFormGroup({
+            labelText: "Country",
+            hintText: "Select your country",
+            select: {
+                id: "country",
+                name: "country",
+                options: [],
+            },
+        });
+
+        const hint = formGroup.querySelector(".govuk-hint");
+        const select = formGroup.querySelector("select");
+
+        expect(hint).toHaveAttribute("id", "country-hint");
+        expect(hint).toHaveTextContent("Select your country");
+        expect(select).toHaveAttribute("aria-describedby", "country-hint");
+    });
+
+    it("should render the label, hint, and select in order", () => {
+        const formGroup = createSelectFormGroup({
+            labelText: "Country",
+            hintText: "Select your country",
+            select: {
+                id: "country",
+                name: "country",
+                options: [],
+            },
+        });
+
+        expect(formGroup.children[0]).toHaveClass("govuk-label");
+        expect(formGroup.children[1]).toHaveClass("govuk-hint");
+        expect(formGroup.children[2]).toHaveClass("govuk-select");
+    });
+});


### PR DESCRIPTION
This pull request adds support for rendering select (dropdown) form controls in the GOV.UK Frontend component library, including both the core implementation and comprehensive tests. It introduces new types and utility functions for select controls, refactors form group creation for better code reuse, and demonstrates usage in the example app.

**New select component support:**

* Added `createSelect` and `createSelectFormGroup` functions to `inputs.ts` for rendering select elements and their associated form groups, including support for options, widths, custom attributes, and accessibility features.
* Introduced new types (`Option`, `SelectOptions`, `SelectFormGroupOptions`, `FormControlWidth`) in `types.ts` to support select controls and unify width handling for form controls. [[1]](diffhunk://#diff-7981e7d81b0edb36d2334fbbe589332cbf146d3669e1a6e81f08cf74bb4368baL24-R24) [[2]](diffhunk://#diff-7981e7d81b0edb36d2334fbbe589332cbf146d3669e1a6e81f08cf74bb4368baR59-R80)

**Refactoring and code reuse:**

* Added `createLabeledControlFormGroup` helper to reduce duplication between text input and select form group creation, and refactored `createTextInputFormGroup` to use this helper. [[1]](diffhunk://#diff-783f38a6fda667aa86622c55e5b9ff642a903937eb0dd4a130528c22193fa616R27-R50) [[2]](diffhunk://#diff-783f38a6fda667aa86622c55e5b9ff642a903937eb0dd4a130528c22193fa616L59-R153)

**Testing:**

* Added a comprehensive test suite for select controls in `select.tests.ts`, covering rendering, attributes, option selection, accessibility, and custom attributes.

**Example application updates:**

* Updated the example app to demonstrate the new select component, including changes to the view (`index.cshtml`) and JavaScript initialization (`javascript-components-examples.js`). [[1]](diffhunk://#diff-71504f21ef6290fff8644944485e2fc566696b1a6fee124331829ddc9282f00bR18-R20) [[2]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fL2-R2) [[3]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fR53-R71)