### PR TITLE
Feature/fieldsets

### DIFF
--- a/GovUk.Frontend.ExampleApp/Views/JavaScriptComponents/index.cshtml
+++ b/GovUk.Frontend.ExampleApp/Views/JavaScriptComponents/index.cshtml
@@ -13,10 +13,13 @@
     <div class="govuk-grid-column button-target"></div>
 </div>
 <div class="govuk-grid-row">
-    <div class="govuk-grid-coulmn input-target"></div>
+    <div class="govuk-grid-column input-target"></div>
 </div>
 <div class="govuk-grid-row">
-    <div class="govuk-grid-coulmn select-target"></div>
+    <div class="govuk-grid-column select-target"></div>
+</div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column fieldset-target"></div>
 </div>
 
 @section scripts {

--- a/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
+++ b/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
@@ -1,5 +1,6 @@
 import { createButton, createButtonGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/button.js";
 import { createTextInputFormGroup, createSelectFormGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/inputs.js";
+import { createFieldset } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/fieldset.js";
 
 document.addEventListener("DOMContentLoaded", function () {
     const buttonTarget = document.querySelector(".button-target");
@@ -69,4 +70,31 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     selectTarget.appendChild(select);
+
+    const fieldsetTarget = document.querySelector(".fieldset-target");
+    const fieldset = createFieldset({
+        legendText: "Contact details",
+        legendSize: "medium",
+        children: [
+            createTextInputFormGroup({
+                labelText: "First name",
+                input: {
+                    id: "first-name",
+                    name: "first-name",
+                    width: "x-large",
+                },
+            }),
+            createTextInputFormGroup({
+                labelText: "Last name",
+                input: {
+                    id: "last-name",
+                    name: "last-name",
+                    width: "x-large",
+                },
+            }),
+        ],
+    });
+
+    fieldsetTarget.appendChild(fieldset);
+
 });

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/fieldset.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/fieldset.ts
@@ -1,0 +1,35 @@
+import { FieldsetOptions } from "./types";
+
+export function createFieldset(fieldsetOptions: FieldsetOptions): HTMLFieldSetElement {
+    const fieldset = document.createElement("fieldset");
+    fieldset.className = "govuk-fieldset";
+
+    if (fieldsetOptions.attributes) {
+        for (const [name, value] of Object.entries(fieldsetOptions.attributes)) {
+            fieldset.setAttribute(name, value);
+        }
+    }
+    
+    const legend = document.createElement("legend");
+    legend.className = "govuk-fieldset__legend";
+    legend.textContent = fieldsetOptions.legendText;
+    
+    if (fieldsetOptions.legendSize) {
+        legend.classList.add(legendSizeClassMap[fieldsetOptions.legendSize]);
+    }
+
+    fieldset.appendChild(legend);
+
+    fieldsetOptions.children.forEach(child => {
+        fieldset.appendChild(child);
+    });
+
+    return fieldset;
+}
+
+const legendSizeClassMap: Record<string, string> = {
+    "small": "govuk-fieldset__legend--s",
+    "medium": "govuk-fieldset__legend--m",
+    "large": "govuk-fieldset__legend--l",
+    "x-large": "govuk-fieldset__legend--xl"
+};

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/inputs.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/inputs.ts
@@ -8,8 +8,13 @@ import {
     SelectOptions,
     TextInputFormGroupOptions,
     TextInputOptions,
-    LabeledControlFormGroupOptions,
 } from "./types";
+
+interface LabeledControlFormGroupOptions {
+    labelText: string;
+    hintText?: string;
+    control: HTMLInputElement | HTMLSelectElement;
+}
 
 export function createFormGroup(formGroupOptions: FormGroupOptions): HTMLElement {
     const div = document.createElement("div");
@@ -133,19 +138,10 @@ function createSelectOption(option: Option): HTMLOptionElement {
 }
 
 export function createSelectFormGroup(options: SelectFormGroupOptions): HTMLElement {
-    const hintId = `${options.select.id}-hint`;
-    const selectAttributes = { ...options.select.attributes };
-
-    if (options.hintText) {
-        selectAttributes["aria-describedby"] = [selectAttributes["aria-describedby"], hintId]
-            .filter(Boolean)
-            .join(" ");
-    }
-
-    return createFormGroup({
-        label: createLabel({ labelText: options.labelText, htmlFor: options.select.id }),
-        hint: options.hintText ? createHint({ hintText: options.hintText, id: hintId }) : undefined,
-        control: createSelect({ ...options.select, attributes: selectAttributes }),
+    return createLabeledControlFormGroup({
+        labelText: options.labelText,
+        hintText: options.hintText,
+        control: createSelect(options.select),
     });
 }
 

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts
@@ -39,12 +39,6 @@ export interface TextInputOptions {
   attributes?: Record<string, string>;
 }
 
-export interface LabeledControlFormGroupOptions {
-    labelText: string;
-    hintText?: string;
-    control: FormControl;
-}
-
 export interface TextInputFormGroupOptions {
   labelText: string;
   hintText?: string;
@@ -77,4 +71,13 @@ export interface SelectFormGroupOptions {
     labelText: string;
     hintText?: string;
     select: SelectOptions;
+}
+
+export type LegendSize = "small" | "medium" | "large" | "x-large";
+
+export interface FieldsetOptions {
+    legendText: string;
+    legendSize?: LegendSize;
+    children: HTMLElement[];
+    attributes?: Record<string, string>;
 }

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/fieldset.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/fieldset.tests.ts
@@ -1,0 +1,79 @@
+import { createFieldset } from "../../Scripts/govuk-components/fieldset";
+import "@testing-library/jest-dom";
+
+describe("createFieldset", () => {
+	it("should render a fieldset with the GOV.UK fieldset class", () => {
+		const fieldset = createFieldset({
+			legendText: "Your address",
+			children: [],
+		});
+
+		expect(fieldset.tagName).toBe("FIELDSET");
+		expect(fieldset).toHaveClass("govuk-fieldset");
+	});
+
+	it("should render a GOV.UK legend with the supplied text", () => {
+		const fieldset = createFieldset({
+			legendText: "Your address",
+			children: [],
+		});
+
+		const legend = fieldset.querySelector("legend");
+
+		expect(legend).toHaveClass("govuk-fieldset__legend");
+		expect(legend).toHaveTextContent("Your address");
+	});
+
+	it.each([
+		["small", "govuk-fieldset__legend--s"],
+		["medium", "govuk-fieldset__legend--m"],
+		["large", "govuk-fieldset__legend--l"],
+		["x-large", "govuk-fieldset__legend--xl"],
+	] as const)("should map the %s legend size to %s", (legendSize, expectedClass) => {
+		const fieldset = createFieldset({
+			legendText: "Your address",
+			legendSize,
+			children: [],
+		});
+
+		expect(fieldset.querySelector("legend")).toHaveClass(expectedClass);
+	});
+
+	it("should append child elements after the legend in the supplied order", () => {
+		const firstChild = document.createElement("div");
+		const secondChild = document.createElement("div");
+
+		const fieldset = createFieldset({
+			legendText: "Your address",
+			children: [firstChild, secondChild],
+		});
+
+		expect(fieldset.children[0].tagName).toBe("LEGEND");
+		expect(fieldset.children[1]).toBe(firstChild);
+		expect(fieldset.children[2]).toBe(secondChild);
+	});
+
+	it("should render legend text as text rather than HTML", () => {
+		const fieldset = createFieldset({
+			legendText: "<strong>Your address</strong>",
+			children: [],
+		});
+
+		const legend = fieldset.querySelector("legend");
+
+		expect(legend).toHaveTextContent("<strong>Your address</strong>");
+		expect(legend?.querySelector("strong")).toBeNull();
+	});
+
+	it("should apply custom fieldset attributes", () => {
+		const fieldset = createFieldset({
+			legendText: "Your address",
+			children: [],
+			attributes: {
+				"data-testid": "address-fieldset",
+			},
+		});
+
+		expect(fieldset).toHaveAttribute("data-testid", "address-fieldset");
+	});
+});


### PR DESCRIPTION
This pull request introduces a new reusable `fieldset` component for GOV.UK-style forms, integrates it into the JavaScript component examples, and adds comprehensive unit tests. It also refactors some input form group logic for better maintainability and fixes a typo in the example app's markup.**New fieldset component and integration:*** Added a new `createFieldset` function in `fieldset.ts` to generate GOV.UK-compliant fieldsets with support for legend text, size, children, and custom attributes. (`ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/fieldset.ts` [ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/fieldset.tsR1-R35](diffhunk://#diff-7bf04293b837388240fd88cc857039203bf6abe905064882c94b1f0a03ddf7a5R1-R35))* Defined the `FieldsetOptions` interface and related types in `types.ts` to support the new component. (`ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts` [ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.tsR75-R83](diffhunk://#diff-7981e7d81b0edb36d2334fbbe589332cbf146d3669e1a6e81f08cf74bb4368baR75-R83))* Added comprehensive unit tests for the `fieldset` component, covering rendering, legend sizes, children order, text handling, and custom attributes. (`ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/fieldset.tests.ts` [ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/fieldset.tests.tsR1-R79](diffhunk://#diff-046dccfbea55bd6cad032239a45c156c8f293bd709f4dfb2c6c3b818c24df360R1-R79))**Example app and demo improvements:*** Integrated the new `fieldset` component into the JavaScript components example page, including a fieldset with two text inputs for "Contact details". (`GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js` [[1]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fR3) [[2]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fR73-R99)* Updated the example app's markup to add a new fieldset target and fixed a typo in the class name (`govuk-grid-coulmn` → `govuk-grid-column`). (`GovUk.Frontend.ExampleApp/Views/JavaScriptComponents/index.cshtml` [GovUk.Frontend.ExampleApp/Views/JavaScriptComponents/index.cshtmlL16-R22](diffhunk://#diff-71504f21ef6290fff8644944485e2fc566696b1a6fee124331829ddc9282f00bL16-R22))**Input form group refactoring:*** Refactored `createSelectFormGroup` to use a new local `LabeledControlFormGroupOptions` interface for improved clarity and modularity. (`ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/inputs.ts` [[1]](diffhunk://#diff-783f38a6fda667aa86622c55e5b9ff642a903937eb0dd4a130528c22193fa616L11-R18) [[2]](diffhunk://#diff-783f38a6fda667aa86622c55e5b9ff642a903937eb0dd4a130528c22193fa616L136-R144)* Removed the now-unused `LabeledControlFormGroupOptions` export from `types.ts`. (`ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts` [ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.tsL42-L47](diffhunk://#diff-7981e7d81b0edb36d2334fbbe589332cbf146d3669e1a6e81f08cf74bb4368baL42-L47))

---
Related work item(s): [AB#276951](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/276951)