### PR TITLE
Add reusable dynamic GOV.UK validation support

### DIFF
--- a/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
+++ b/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
@@ -104,19 +104,21 @@ document.addEventListener("DOMContentLoaded", function () {
     selectTarget.appendChild(select);
 
     const fieldsetTarget = document.querySelector(".fieldset-target");
-    const fieldset = createFieldsetFormGroup({
-        id: "contact-details",
-        legendText: "Contact details",
-        legendSize: "medium",
-        children: [
-            createTextInputFormGroup({
+    const firstInput = createTextInputFormGroup({
                 labelText: "First name",
                 input: {
                     id: "first-name",
                     name: "first-name",
                     width: "x-large",
                 },
-            }),
+            });
+
+    const fieldset = createFieldsetFormGroup({
+        id: "contact-details",
+        legendText: "Contact details",
+        legendSize: "medium",
+        children: [
+            firstInput,
             createTextInputFormGroup({
                 labelText: "Last name",
                 input: {
@@ -131,6 +133,11 @@ document.addEventListener("DOMContentLoaded", function () {
     const showFieldsetErrorButton = createButton({
         labelText: "Show fieldset error"
     });
+    const showFirstNameErrorButton = createButton({
+        labelText: "Show first name error",
+        variant: "secondary",
+        type: "button",
+    });
     const updateFieldsetErrorButton = createButton({
         labelText: "Update fieldset error",
         variant: "secondary"
@@ -139,10 +146,17 @@ document.addEventListener("DOMContentLoaded", function () {
         labelText: "Clear fieldset error",
         variant: "warning"
     });
+    const clearFirstNameErrorButton = createButton({
+        labelText: "Clear first name error",
+        variant: "secondary-warning",
+    });
     const fieldsetButtonGroup = createButtonGroup();
 
     showFieldsetErrorButton.addEventListener("click", () => {
         showFormGroupError(fieldset, "Enter valid contact details");
+    });
+    showFirstNameErrorButton.addEventListener("click", () => {
+        showFormGroupError(firstInput, "Enter a first name");
     });
     updateFieldsetErrorButton.addEventListener("click", () => {
         showFormGroupError(fieldset, "Enter valid contact details (updated)");
@@ -150,10 +164,15 @@ document.addEventListener("DOMContentLoaded", function () {
     clearFieldsetErrorButton.addEventListener("click", () => {
         clearFormGroupError(fieldset);
     });
-
+    clearFirstNameErrorButton.addEventListener("click", () => {
+        clearFormGroupError(firstInput);
+    });
+    
     fieldsetTarget.appendChild(fieldset);
     fieldsetButtonGroup.appendChild(showFieldsetErrorButton);
     fieldsetButtonGroup.appendChild(updateFieldsetErrorButton);
+    fieldsetButtonGroup.appendChild(showFirstNameErrorButton);
     fieldsetButtonGroup.appendChild(clearFieldsetErrorButton);
+    fieldsetButtonGroup.appendChild(clearFirstNameErrorButton);
     fieldsetTarget.appendChild(fieldsetButtonGroup);
 });

--- a/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
+++ b/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
@@ -1,6 +1,7 @@
 import { createButton, createButtonGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/button.js";
 import { createTextInputFormGroup, createSelectFormGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/inputs.js";
 import { createFieldset } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/fieldset.js";
+import { clearControlError, showControlError } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/validation.js";
 
 document.addEventListener("DOMContentLoaded", function () {
     const buttonTarget = document.querySelector(".button-target");
@@ -51,6 +52,38 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     inputTarget.appendChild(postcodeInput);
+
+    const postcodeControl = postcodeInput.querySelector("input");
+    const validationButtonGroup = createButtonGroup();
+    const showErrorButton = createButton({
+        labelText: "Show input error",
+        type: "button",
+    });
+    const updateErrorButton = createButton({
+        labelText: "Update input error",
+        variant: "secondary"
+    });
+
+    const clearErrorButton = createButton({
+        labelText: "Clear input error",
+        type: "button",
+        variant: "warning",
+    });
+
+    showErrorButton.addEventListener("click", () => {
+        showControlError(postcodeControl, "Enter a valid postcode");
+    });
+    updateErrorButton.addEventListener("click", () => {
+        showControlError(postcodeControl, "Enter a valid postcode (updated)");
+    });
+    clearErrorButton.addEventListener("click", () => {
+        clearControlError(postcodeControl);
+    });
+
+    validationButtonGroup.appendChild(showErrorButton);
+    validationButtonGroup.appendChild(updateErrorButton);
+    validationButtonGroup.appendChild(clearErrorButton);
+    inputTarget.appendChild(validationButtonGroup);
 
     const selectTarget = document.querySelector(".select-target");
     const select = createSelectFormGroup({

--- a/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
+++ b/GovUk.Frontend.ExampleApp/wwwroot/js/javascript-components-examples.js
@@ -1,7 +1,7 @@
 import { createButton, createButtonGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/button.js";
 import { createTextInputFormGroup, createSelectFormGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/inputs.js";
-import { createFieldset } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/fieldset.js";
-import { clearControlError, showControlError } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/validation.js";
+import { createFieldsetFormGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/fieldset.js";
+import { clearFormGroupError, showFormGroupError } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/validation.js";
 
 document.addEventListener("DOMContentLoaded", function () {
     const buttonTarget = document.querySelector(".button-target");
@@ -53,7 +53,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
     inputTarget.appendChild(postcodeInput);
 
-    const postcodeControl = postcodeInput.querySelector("input");
     const validationButtonGroup = createButtonGroup();
     const showErrorButton = createButton({
         labelText: "Show input error",
@@ -71,13 +70,13 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     showErrorButton.addEventListener("click", () => {
-        showControlError(postcodeControl, "Enter a valid postcode");
+        showFormGroupError(postcodeInput, "Enter a valid postcode");
     });
     updateErrorButton.addEventListener("click", () => {
-        showControlError(postcodeControl, "Enter a valid postcode (updated)");
+        showFormGroupError(postcodeInput, "Enter a valid postcode (updated)");
     });
     clearErrorButton.addEventListener("click", () => {
-        clearControlError(postcodeControl);
+        clearFormGroupError(postcodeInput);
     });
 
     validationButtonGroup.appendChild(showErrorButton);
@@ -105,7 +104,8 @@ document.addEventListener("DOMContentLoaded", function () {
     selectTarget.appendChild(select);
 
     const fieldsetTarget = document.querySelector(".fieldset-target");
-    const fieldset = createFieldset({
+    const fieldset = createFieldsetFormGroup({
+        id: "contact-details",
         legendText: "Contact details",
         legendSize: "medium",
         children: [
@@ -128,6 +128,32 @@ document.addEventListener("DOMContentLoaded", function () {
         ],
     });
 
-    fieldsetTarget.appendChild(fieldset);
+    const showFieldsetErrorButton = createButton({
+        labelText: "Show fieldset error"
+    });
+    const updateFieldsetErrorButton = createButton({
+        labelText: "Update fieldset error",
+        variant: "secondary"
+    });
+    const clearFieldsetErrorButton = createButton({
+        labelText: "Clear fieldset error",
+        variant: "warning"
+    });
+    const fieldsetButtonGroup = createButtonGroup();
 
+    showFieldsetErrorButton.addEventListener("click", () => {
+        showFormGroupError(fieldset, "Enter valid contact details");
+    });
+    updateFieldsetErrorButton.addEventListener("click", () => {
+        showFormGroupError(fieldset, "Enter valid contact details (updated)");
+    });
+    clearFieldsetErrorButton.addEventListener("click", () => {
+        clearFormGroupError(fieldset);
+    });
+
+    fieldsetTarget.appendChild(fieldset);
+    fieldsetButtonGroup.appendChild(showFieldsetErrorButton);
+    fieldsetButtonGroup.appendChild(updateFieldsetErrorButton);
+    fieldsetButtonGroup.appendChild(clearFieldsetErrorButton);
+    fieldsetTarget.appendChild(fieldsetButtonGroup);
 });

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/postcode-normaliser.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/postcode-normaliser.ts
@@ -1,0 +1,9 @@
+export function normalisePostcode(postcode: string): string {
+    const compactPostcode = postcode.split(" ").join("").toUpperCase();
+    
+    if (compactPostcode.length <= 3) {
+        return compactPostcode;
+    }
+
+    return `${compactPostcode.slice(0, -3)} ${compactPostcode.slice(-3)}`;
+}

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/postcode-sanitiser.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/postcode-sanitiser.ts
@@ -1,0 +1,14 @@
+export function sanitisePostcode(postcode: string): string {
+    let sanitised = "";
+    for (const char of postcode.trim().toUpperCase()) {
+        const isLetter = char >= "A" && char <= "Z";
+        const isDigit = char >= "0" && char <= "9";
+        const isSpace = char === " ";
+        
+        if (isLetter || isDigit || isSpace) {
+            sanitised += char;
+        }
+    }
+
+    return sanitised;
+}

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/postcode-validator.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/postcode-validator.ts
@@ -1,0 +1,66 @@
+type PostcodeValidationResult = 
+    | { isValid: true; } 
+    | { isValid: false; error: "required" | "invalid-format" };
+
+export function validatePostcode(postcode: string): PostcodeValidationResult {
+    if (postcode.length === 0) {
+        return { isValid: false, error: "required" };
+    }
+
+    if (isSpecialPostcode(postcode) || isValidStandardPostcode(postcode)) {
+        return { isValid: true };
+    }
+
+    return { isValid: false, error: "invalid-format" };
+}
+
+function isSpecialPostcode(postcode: string): boolean {
+    return postcode === "GIR 0AA";
+}
+
+function isValidStandardPostcode(postcode: string): boolean {
+    const [outwardCode, inwardCode] = postcode.split(" ");
+
+    if (!outwardCode || !inwardCode || postcode.split(" ").length !== 2) {
+        return false;
+    }
+
+    return isValidOutwardCode(outwardCode) && isValidInwardCode(inwardCode);
+}
+
+function isValidOutwardCode(outwardCode: string): boolean {
+    const firstCharacter = outwardCode[0];
+    const firstCharacterIsValid = firstCharacter >= "A" && firstCharacter <= "Z"
+        && firstCharacter !== "Q"
+        && firstCharacter !== "V"
+        && firstCharacter !== "X";
+
+    if (!firstCharacterIsValid) {
+        return false;
+    }
+
+    const remainder = outwardCode.slice(1);
+    const isDigit = (character: string) => character >= "0" && character <= "9";
+    const isLetter = (character: string) => character >= "A" && character <= "Z";
+
+    return (
+        (remainder.length === 1 && isDigit(remainder[0])) ||
+        (remainder.length === 2 && isDigit(remainder[0]) && isDigit(remainder[1])) ||
+        (remainder.length === 2 && isLetter(remainder[0]) && isDigit(remainder[1])) ||
+        (remainder.length === 3 && isLetter(remainder[0]) && isDigit(remainder[1]) && isDigit(remainder[2])) ||
+        (remainder.length === 3 && isLetter(remainder[0]) && isDigit(remainder[1]) && isLetter(remainder[2])) ||
+        (remainder.length === 2 && isDigit(remainder[0]) && isLetter(remainder[1]))
+    );
+}
+
+function isValidInwardCode(inwardCode: string): boolean {
+    if (inwardCode.length !== 3) {
+        return false;
+    }
+
+    const isDigit = (character: string) => character >= "0" && character <= "9";
+    const disallowedLetters = "CIKMOV";
+    const isLetter = (character: string) => character >= "A" && character <= "Z" && !disallowedLetters.includes(character);
+
+    return isDigit(inwardCode[0]) && isLetter(inwardCode[1]) && isLetter(inwardCode[2]);
+}

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/postcode-normaliser.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/postcode-normaliser.tests.ts
@@ -1,0 +1,28 @@
+import { normalisePostcode } from "../../Scripts/address-lookup/postcode-normaliser";
+
+describe("Postcode normaliser", () => {;
+
+    /********************************************************************************
+    * "A" indicates an alphabetic character and "N" indicates a numeric character. *
+    *  Format         Example Postcode                                             *
+    *  AN NAA         M1 1AA                                                       *
+    *  ANN NAA        M60 1NW                                                      *
+    *  AAN NAA        CR2 6XH                                                      *
+    *  AANN NAA       DN55 1PT                                                     *
+    *  ANA NAA        W1A 1HP                                                      *
+    *  AANA NAA       EC1A 1BB                                                     *
+    ********************************************************************************/
+
+    it.each([
+        ["m11aa", "M1 1AA"],
+        ["m601nw", "M60 1NW"],
+        ["cr26 xh", "CR2 6XH"],
+        ["dn551p t", "DN55 1PT"],
+        ["w1a1hp", "W1A 1HP"],
+        ["ec1a1bb", "EC1A 1BB"],
+        ["SW1", "SW1"]
+    ])("puts all letters to upper and ensures there is a single space between the outward and inward code", (userInput, expected) => {
+        const result = normalisePostcode(userInput);
+        expect(result).toBe(expected);
+    });
+});

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/postcode-sanitiser.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/postcode-sanitiser.tests.ts
@@ -1,0 +1,31 @@
+import { sanitisePostcode } from "../../Scripts/address-lookup/postcode-sanitiser";
+
+describe("sanitisePostcode", () => {
+    it("should trim whitespace from the start and end of the postcode", () => {
+        const input = "  AB1 2CD  ";
+        const expectedOutput = "AB1 2CD";
+        
+        expect(sanitisePostcode(input)).toBe(expectedOutput);
+    });
+
+    it("should convert the postcode to uppercase", () => {
+        const input = "ab1 2cd";
+        const expectedOutput = "AB1 2CD";
+   
+        expect(sanitisePostcode(input)).toBe(expectedOutput);
+    });
+
+    it("should remove any hyphens from the postcode", () => {
+        const input = "AB1-2CD";
+        const expectedOutput = "AB12CD";
+       
+        expect(sanitisePostcode(input)).toBe(expectedOutput);
+    });
+
+    it("should remove any special characters from the postcode", () => {
+        const input = "AB1@2#CD!";
+        const expectedOutput = "AB12CD";
+
+        expect(sanitisePostcode(input)).toBe(expectedOutput);
+    });
+});

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/postcode-validator.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/postcode-validator.tests.ts
@@ -1,0 +1,36 @@
+import {validatePostcode} from "../../Scripts/address-lookup/postcode-validator";
+
+describe("validatePostcode", () => {
+    it.each([
+        "GIR 0AA",
+        "M1 1AE",
+        "M11 1AE",
+        "CR2 6XH",
+        "DN55 1PT",
+        "W1A 1HQ",
+        "EC1A 1BB",
+        "SW1A 1AA",
+        "BN1 4DW",
+        "BN1 6AF"])
+        ("%s is a valid postcode", (postcode) => {
+            const result = validatePostcode(postcode);
+            expect(result.isValid).toBeTruthy(); 
+    });
+
+    it("should return a required error when the postcode is empty", () => {
+        const result = validatePostcode("");
+        expect(result).toEqual({ isValid: false, error: "required" });
+    });
+
+    it.each([
+        "SW1A2AA",  // invalid if validator expects normalised input
+        "SW1A 22A", // inward code must begin with one digit
+        "SW1A 2A",  // inward code too short
+        "SW1A 2AAA",// inward code too long
+        "123 4AB",  // outward code must begin with letters
+        "ABCDE"     // not a postcode
+    ])("%s is an invalid postcode", (postcode) => {
+        const result = validatePostcode(postcode);
+        expect(result).toEqual({ isValid: false, error: "invalid-format" });
+    });
+});

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/error-summary.js
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/error-summary.js
@@ -1,0 +1,200 @@
+// Intentionally a .js file, so it can be imported into a .ts file without needing to be compiled first. This is because the govuk-validation.js file is imported into the validator.ts file, which is then compiled into govuk-validation.js. If this file was a .ts file, it would create a circular dependency and cause an error when compiling.
+
+export function ensureErrorSummary() {
+    const existingErrorSummary = document.querySelector(".govuk-error-summary");
+
+    if (existingErrorSummary) {
+        return existingErrorSummary;
+    }
+
+    const newErrorSummary = createErrorSummary();
+    const main = document.querySelector("main");
+    main?.insertBefore(newErrorSummary, main.firstChild);
+
+    return newErrorSummary;
+}
+
+function createErrorSummary() {
+    const errorSummary = document.createElement("div");
+    errorSummary.className = "govuk-error-summary";
+    errorSummary.setAttribute("role", "alert");
+    errorSummary.setAttribute("aria-labelledby", "error-summary-title");
+    errorSummary.setAttribute("data-module", "govuk-error-summary");
+    errorSummary.classList.add("govuk-!-display-none");
+
+    const h2 = document.createElement("h2");
+    h2.className = "govuk-error-summary__title";
+    h2.id = "error-summary-title";
+    h2.appendChild(document.createTextNode("There is a problem"));
+    errorSummary.appendChild(h2);
+
+    const body = document.createElement("div");
+    body.className = "govuk-error-summary__body";
+    errorSummary.appendChild(body);
+
+    const ul = document.createElement("ul");
+    ul.className = "govuk-list govuk-error-summary__list";
+    body.appendChild(ul);
+
+    return errorSummary;
+}
+
+export function updateErrorSummary() {
+    const summary = document.querySelector(".govuk-error-summary");
+    if (!summary) {
+        return;
+    }
+
+    const errorSummaryBody = summary.querySelector(".govuk-error-summary__body");
+    if (!errorSummaryBody) {
+        return;
+    }
+
+    let list = errorSummaryBody.querySelector("ul");
+    if (!list) {
+        const ul = document.createElement("ul");
+        ul.classList.add("govuk-list");
+        ul.classList.add("govuk-error-summary__list");
+        errorSummaryBody.appendChild(ul);
+        list = ul;
+    }
+
+    const textNode = 3;
+
+    // Get the current links in the error summary, and the links that need to be there
+    const currentErrors = [].slice.call(list.querySelectorAll("a"));
+
+    const updatedErrors = [].slice
+        .call(
+          document.querySelectorAll(
+            ".govuk-error-message:not(.govuk-character-count__status)"
+          )
+        )
+        .map(function (error) {
+          const link = document.createElement("a");
+          const prefix = error.querySelector(".govuk-visually-hidden");
+          [].slice.call(error.childNodes).map(function (x) {
+            if (
+              x !== prefix &&
+              (x.nodeType !== textNode || x.textContent.trim())
+            ) {
+              link.appendChild(x.cloneNode(true));
+            }
+          });
+          if (!link.hasChildNodes()) {
+            return;
+          }
+          link.href = "#" + error.id.substring(0, error.id.length - 6);
+          return link;
+        })
+        .filter(function (link) {
+          return link !== undefined;
+        });
+
+    function findErrorsNotMatched(errorsToLookFor, errorsToSearch) {
+        const result = [];
+        for (let i = 0; i < errorsToLookFor.length; i++) {
+            let matchingErrors = errorsToSearch.filter(function (link) {
+                return matchErrorLink(link, errorsToLookFor[i]);
+            });
+            if (!matchingErrors.length) {
+                result.push(errorsToLookFor[i]);
+            }
+        }
+        return result;
+    }
+
+    function matchErrorLink(link1, link2) {
+        return (
+            link1.href === link2.href && link1.textContent == link2.textContent
+        );
+    }
+
+    // Remove any errors from the error summary that are no longer in the page.
+    const errorsToRemove = findErrorsNotMatched(currentErrors, updatedErrors);
+
+    for (let i = 0; i < errorsToRemove.length; i++) {
+        list.removeChild(errorsToRemove[i].parentElement);
+    }
+
+    // Find any new errors and insert them at the correct position in the error summary.
+    // It's important to leave existing links untouched. If your focus is in a field and you click
+    // on an error summary link, validation will run on focusout of the field before the link is followed.
+    // If validation removes the link (even if it recreates an identical one) it cannot be followed.
+    let errorsToAdd = findErrorsNotMatched(updatedErrors, currentErrors);
+
+    for (let i = 0; i < errorsToAdd.length; i++) {
+        let summaryError = document.createElement("li");
+        summaryError.appendChild(errorsToAdd[i]);
+
+        if (list.childNodes.length == 0) {
+            list.appendChild(summaryError);
+        } else {
+            let indexOfThisError = updatedErrors.indexOf(errorsToAdd[i]);
+            if (indexOfThisError === 0) {
+                list.insertBefore(summaryError, list.firstChild);
+            } else {
+                let errorToInsertAfter = updatedErrors[indexOfThisError - 1];
+                for (let j = 0; j < list.childNodes.length; j++) {
+                    let link = list.childNodes[j].querySelector("a");
+                    if (matchErrorLink(link, errorToInsertAfter)) {
+                        if (list.childNodes[j].nextSibling) {
+                            list.insertBefore(
+                                summaryError,
+                                list.childNodes[j].nextSibling
+                            );
+                        } else {
+                            list.appendChild(summaryError);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    const hasError = list.querySelector("li");
+    summary.classList.remove(
+        hasError ? "govuk-!-display-none" : "govuk-!-display-block"
+    );
+    summary.classList.add(
+        hasError ? "govuk-!-display-block" : "govuk-!-display-none"
+    );
+}
+
+export function updateTitle() {
+    const titleTag = document.getElementsByTagName("title")[0];
+    let prefix = "";
+
+    if (!titleTag || titleTag.getAttribute("data-govuk-error-prefix") == null) {
+        prefix = "Error: ";
+    } else {
+        prefix = titleTag.getAttribute("data-govuk-error-prefix");
+    }
+
+    const hasError = [].slice
+        .call(document.querySelectorAll(".govuk-error-message"))
+        .filter(function (error) {
+            const errorPrefix = error.querySelector(".govuk-visually-hidden");
+            const textNode = 3;
+
+            for (let i = 0; i < error.childNodes.length; i++) {
+                let childNode = error.childNodes[i];
+                if (
+                    childNode !== errorPrefix &&
+                    (childNode.nodeType !== textNode || childNode.textContent.trim())
+                ) {
+                    return true;
+                }
+            }
+
+            return false;
+        }).length;
+
+    const index = document.title.indexOf(prefix);
+    if (hasError && index !== 0) {
+        document.title = prefix + document.title;
+    } else if (!hasError && index === 0) {
+        document.title = document.title.substring(prefix.length);
+    }
+}

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/fieldset.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/fieldset.ts
@@ -1,4 +1,4 @@
-import { FieldsetOptions } from "./types";
+import { FieldsetFormGroupOptions, FieldsetOptions } from "./types";
 
 export function createFieldset(fieldsetOptions: FieldsetOptions): HTMLFieldSetElement {
     const fieldset = document.createElement("fieldset");
@@ -25,6 +25,17 @@ export function createFieldset(fieldsetOptions: FieldsetOptions): HTMLFieldSetEl
     });
 
     return fieldset;
+}
+
+export function createFieldsetFormGroup(fieldsetOptions: FieldsetFormGroupOptions): HTMLElement {
+    const formGroup = document.createElement("div");
+    formGroup.className = "govuk-form-group";
+
+    const fieldset = createFieldset(fieldsetOptions);
+    fieldset.id = fieldsetOptions.id;
+    formGroup.appendChild(fieldset);
+
+    return formGroup;
 }
 
 const legendSizeClassMap: Record<string, string> = {

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/types.ts
@@ -81,3 +81,7 @@ export interface FieldsetOptions {
     children: HTMLElement[];
     attributes?: Record<string, string>;
 }
+
+export interface FieldsetFormGroupOptions extends FieldsetOptions {
+    id: string;
+}

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
@@ -1,0 +1,66 @@
+export function showControlError(control: HTMLInputElement | HTMLSelectElement, errorMessage: string): void {
+    const formGroup = control.closest(".govuk-form-group");
+    if (!formGroup){
+        return;
+    }
+    formGroup.classList.add("govuk-form-group--error");
+    
+    if (control instanceof HTMLInputElement) {
+        control.classList.add("govuk-input--error");
+    }else if (control instanceof HTMLSelectElement) {
+        control.classList.add("govuk-select--error");
+    }
+
+    let errorMessageElement = formGroup.querySelector<HTMLElement>(".govuk-error-message");
+    if (!errorMessageElement){ 
+        errorMessageElement = document.createElement("p");
+        errorMessageElement.className = "govuk-error-message";
+        errorMessageElement.id = `${control.id}-error`;
+        
+        formGroup.insertBefore(errorMessageElement, control);
+    }
+
+    setErrorMessage(errorMessageElement, errorMessage);
+
+    const errorId = `${control.id}-error`;
+    const describedBy = control.getAttribute("aria-describedby")?.split(" ") ?? [];
+    if(!describedBy.includes(errorId)){
+        describedBy.push(errorId);
+        control.setAttribute("aria-describedby", describedBy.join(" "));    
+    }
+}
+
+function setErrorMessage(errorMessageElement: HTMLElement, errorMessage: string): void {
+    errorMessageElement.replaceChildren();
+
+    const errorPrefix = document.createElement("span");
+    errorPrefix.className = "govuk-visually-hidden";
+    errorPrefix.textContent = "Error: ";
+    
+    errorMessageElement.appendChild(errorPrefix);
+    errorMessageElement.appendChild(document.createTextNode(errorMessage));
+}
+
+export function clearControlError(control: HTMLInputElement | HTMLSelectElement): void {
+    const formGroup = control.closest(".govuk-form-group.govuk-form-group--error");
+    if (!formGroup) {
+        return;
+    }
+
+    formGroup.classList.remove("govuk-form-group--error");
+    control.classList.remove("govuk-input--error", "govuk-select--error");
+
+    const errorMessageElement = formGroup.querySelector(".govuk-error-message");
+    if (errorMessageElement) {
+        errorMessageElement.remove();
+    }
+
+    const errorId = `${control.id}-error`;
+    const describedBy = control.getAttribute("aria-describedby")?.split(" ") ?? [];
+    const updatedDescribedBy = describedBy.filter(id => id !== errorId);
+    if (updatedDescribedBy.length > 0) {
+        control.setAttribute("aria-describedby", updatedDescribedBy.join(" "));
+    } else {
+        control.removeAttribute("aria-describedby");
+    }
+}

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
@@ -23,7 +23,6 @@ export function showFormGroupError(formGroup: HTMLElement, errorMessage: string)
 
     const validatableElement = getValidatableElement(formGroup);
     if (validatableElement instanceof HTMLFieldSetElement) {
-        console.log("is a fieldset");
         showFieldsetError(formGroup, validatableElement, errorMessage);
     }else{
         showControlError(formGroup, validatableElement as HTMLInputElement | HTMLSelectElement, errorMessage);
@@ -39,7 +38,7 @@ function showControlError(formGroup: HTMLElement, control: HTMLInputElement | HT
     }
 
     const errorId = `${control.id}-error`;
-    let errorMessageElement = formGroup.querySelector<HTMLElement>(".govuk-error-message");
+    let errorMessageElement = formGroup.querySelector<HTMLElement>(`#${errorId}`);
     if (!errorMessageElement){ 
         errorMessageElement = document.createElement("p");
         errorMessageElement.className = "govuk-error-message";
@@ -50,6 +49,7 @@ function showControlError(formGroup: HTMLElement, control: HTMLInputElement | HT
 
     setErrorMessage(errorMessageElement, errorMessage);
     addDescriptionId(control, errorId);
+    setFieldsetFormGroupError(control);
 
     ensureErrorSummary();
     updateErrorSummary();
@@ -60,7 +60,7 @@ function showFieldsetError(formGroup: HTMLElement, fieldset: HTMLFieldSetElement
     const errorId = `${fieldset.id}-error`;
     formGroup.classList.add("govuk-form-group--error");
 
-    let errorMessageElement = formGroup.querySelector<HTMLElement>(".govuk-error-message");
+    let errorMessageElement = formGroup.querySelector<HTMLElement>(`#${errorId}`);
     if (!errorMessageElement) {
         errorMessageElement = document.createElement("p");
         errorMessageElement.className = "govuk-error-message";
@@ -129,6 +129,7 @@ function clearControlError(formGroup: HTMLElement, control: HTMLInputElement | H
     removeErrorMessage(formGroup, control.id);
 
     removeDescriptionId(control, control.id + "-error");
+    clearFieldsetFormGroupError(control);
 
     updateErrorSummary();
     updateTitle();
@@ -138,6 +139,27 @@ function removeErrorMessage(formGroup: HTMLElement, validatableElementId: string
     const errorMessageElement = formGroup.querySelector(`#${validatableElementId}-error`);
     if (errorMessageElement) {
         errorMessageElement.remove();
+    }
+}
+
+function setFieldsetFormGroupError(control: HTMLInputElement | HTMLSelectElement): void {
+    const fieldset = control.closest("fieldset");
+    const fieldsetFormGroup = fieldset?.parentElement;
+
+    if (fieldsetFormGroup?.classList.contains("govuk-form-group")) {
+        fieldsetFormGroup.classList.add("govuk-form-group--error");
+    }
+}
+
+function clearFieldsetFormGroupError(control: HTMLInputElement | HTMLSelectElement): void {
+    const fieldset = control.closest("fieldset");
+    const fieldsetFormGroup = fieldset?.parentElement;
+
+    if (
+        fieldsetFormGroup?.classList.contains("govuk-form-group") &&
+        !fieldset?.querySelector(".govuk-form-group--error")
+    ) {
+        fieldsetFormGroup.classList.remove("govuk-form-group--error");
     }
 }
 

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
@@ -1,3 +1,5 @@
+import { ensureErrorSummary, updateErrorSummary, updateTitle } from "./error-summary.js";
+
 export function showControlError(control: HTMLInputElement | HTMLSelectElement, errorMessage: string): void {
     const formGroup = control.closest(".govuk-form-group");
     if (!formGroup){
@@ -28,6 +30,10 @@ export function showControlError(control: HTMLInputElement | HTMLSelectElement, 
         describedBy.push(errorId);
         control.setAttribute("aria-describedby", describedBy.join(" "));    
     }
+
+    ensureErrorSummary();
+    updateErrorSummary();
+    updateTitle();
 }
 
 function setErrorMessage(errorMessageElement: HTMLElement, errorMessage: string): void {
@@ -63,4 +69,7 @@ export function clearControlError(control: HTMLInputElement | HTMLSelectElement)
     } else {
         control.removeAttribute("aria-describedby");
     }
+
+    updateErrorSummary();
+    updateTitle();
 }

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-components/validation.ts
@@ -1,35 +1,77 @@
 import { ensureErrorSummary, updateErrorSummary, updateTitle } from "./error-summary.js";
 
-export function showControlError(control: HTMLInputElement | HTMLSelectElement, errorMessage: string): void {
-    const formGroup = control.closest(".govuk-form-group");
-    if (!formGroup){
-        return;
+type ValidatableElement = 
+    | HTMLInputElement 
+    | HTMLSelectElement 
+    | HTMLFieldSetElement;
+
+function getValidatableElement(formGroup: HTMLElement) : ValidatableElement | null {
+    for (const child of formGroup.children) {
+        if (
+            child instanceof HTMLInputElement || 
+            child instanceof HTMLSelectElement || 
+            child instanceof HTMLFieldSetElement
+        ) {
+            return child;
+        }
     }
+    return null;
+}
+
+export function showFormGroupError(formGroup: HTMLElement, errorMessage: string): void {
     formGroup.classList.add("govuk-form-group--error");
-    
+
+    const validatableElement = getValidatableElement(formGroup);
+    if (validatableElement instanceof HTMLFieldSetElement) {
+        console.log("is a fieldset");
+        showFieldsetError(formGroup, validatableElement, errorMessage);
+    }else{
+        showControlError(formGroup, validatableElement as HTMLInputElement | HTMLSelectElement, errorMessage);
+    }
+}
+
+
+function showControlError(formGroup: HTMLElement, control: HTMLInputElement | HTMLSelectElement, errorMessage: string): void {
     if (control instanceof HTMLInputElement) {
         control.classList.add("govuk-input--error");
     }else if (control instanceof HTMLSelectElement) {
         control.classList.add("govuk-select--error");
     }
 
+    const errorId = `${control.id}-error`;
     let errorMessageElement = formGroup.querySelector<HTMLElement>(".govuk-error-message");
     if (!errorMessageElement){ 
         errorMessageElement = document.createElement("p");
         errorMessageElement.className = "govuk-error-message";
-        errorMessageElement.id = `${control.id}-error`;
+        errorMessageElement.id = errorId;
         
-        formGroup.insertBefore(errorMessageElement, control);
+        control.insertAdjacentElement("beforebegin", errorMessageElement);
     }
 
     setErrorMessage(errorMessageElement, errorMessage);
+    addDescriptionId(control, errorId);
 
-    const errorId = `${control.id}-error`;
-    const describedBy = control.getAttribute("aria-describedby")?.split(" ") ?? [];
-    if(!describedBy.includes(errorId)){
-        describedBy.push(errorId);
-        control.setAttribute("aria-describedby", describedBy.join(" "));    
+    ensureErrorSummary();
+    updateErrorSummary();
+    updateTitle();
+}
+
+function showFieldsetError(formGroup: HTMLElement, fieldset: HTMLFieldSetElement, errorMessage: string): void {
+    const errorId = `${fieldset.id}-error`;
+    formGroup.classList.add("govuk-form-group--error");
+
+    let errorMessageElement = formGroup.querySelector<HTMLElement>(".govuk-error-message");
+    if (!errorMessageElement) {
+        errorMessageElement = document.createElement("p");
+        errorMessageElement.className = "govuk-error-message";
+        errorMessageElement.id = errorId;
+
+        const legend = fieldset.querySelector("legend");
+        legend?.insertAdjacentElement("afterend", errorMessageElement);
     }
+
+    setErrorMessage(errorMessageElement, errorMessage);
+    addDescriptionId(fieldset, errorId);
 
     ensureErrorSummary();
     updateErrorSummary();
@@ -47,29 +89,64 @@ function setErrorMessage(errorMessageElement: HTMLElement, errorMessage: string)
     errorMessageElement.appendChild(document.createTextNode(errorMessage));
 }
 
-export function clearControlError(control: HTMLInputElement | HTMLSelectElement): void {
-    const formGroup = control.closest(".govuk-form-group.govuk-form-group--error");
-    if (!formGroup) {
-        return;
+function addDescriptionId(element: HTMLElement, descriptionId: string): void {
+    const describedBy = element
+        .getAttribute("aria-describedby")
+        ?.split(" ")
+        .filter(Boolean) ?? [];
+
+    if (!describedBy.includes(descriptionId)) {
+        describedBy.push(descriptionId);
+        element.setAttribute("aria-describedby", describedBy.join(" "));
     }
+}
 
-    formGroup.classList.remove("govuk-form-group--error");
-    control.classList.remove("govuk-input--error", "govuk-select--error");
+export function clearFormGroupError(formGroup: HTMLElement): void {
+    const validatableElement = getValidatableElement(formGroup);
 
-    const errorMessageElement = formGroup.querySelector(".govuk-error-message");
-    if (errorMessageElement) {
-        errorMessageElement.remove();
-    }
-
-    const errorId = `${control.id}-error`;
-    const describedBy = control.getAttribute("aria-describedby")?.split(" ") ?? [];
-    const updatedDescribedBy = describedBy.filter(id => id !== errorId);
-    if (updatedDescribedBy.length > 0) {
-        control.setAttribute("aria-describedby", updatedDescribedBy.join(" "));
+    if (validatableElement instanceof HTMLFieldSetElement) {
+        clearFieldsetError(formGroup, validatableElement);
     } else {
-        control.removeAttribute("aria-describedby");
+        clearControlError(formGroup, validatableElement as HTMLInputElement | HTMLSelectElement);
     }
+}
+
+function clearFieldsetError(formGroup: HTMLElement, fieldset: HTMLFieldSetElement): void {
+    formGroup.classList.remove("govuk-form-group--error");
+    fieldset.classList.remove("govuk-fieldset--error");
+
+    removeErrorMessage(formGroup, fieldset.id);
+    removeDescriptionId(fieldset, fieldset.id + "-error");
 
     updateErrorSummary();
     updateTitle();
+}
+
+function clearControlError(formGroup: HTMLElement, control: HTMLInputElement | HTMLSelectElement): void {
+    formGroup.classList.remove("govuk-form-group--error");
+    control.classList.remove("govuk-input--error", "govuk-select--error");
+
+    removeErrorMessage(formGroup, control.id);
+
+    removeDescriptionId(control, control.id + "-error");
+
+    updateErrorSummary();
+    updateTitle();
+}
+
+function removeErrorMessage(formGroup: HTMLElement, validatableElementId: string): void {
+    const errorMessageElement = formGroup.querySelector(`#${validatableElementId}-error`);
+    if (errorMessageElement) {
+        errorMessageElement.remove();
+    }
+}
+
+function removeDescriptionId(element: HTMLElement, descriptionId: string): void {
+    const describedBy = element.getAttribute("aria-describedby")?.split(" ") ?? [];
+    const updatedDescribedBy = describedBy.filter(id => id !== descriptionId);
+    if (updatedDescribedBy.length > 0) {
+        element.setAttribute("aria-describedby", updatedDescribedBy.join(" "));
+    } else {
+        element.removeAttribute("aria-describedby");
+    }
 }

--- a/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-validation.js
+++ b/ThePensionsRegulator.GovUk.Frontend/Scripts/govuk-validation.js
@@ -1,4 +1,5 @@
-﻿"use strict";
+﻿import { ensureErrorSummary, updateErrorSummary, updateTitle } from "./govuk-components/error-summary.js";
+"use strict";
 
 // For Jest tests
 if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
@@ -32,38 +33,8 @@ function createGovUkValidator() {
     /**
      * Ensures the page title is prefixed with the data-govuk-error-prefix attribute, or 'Error: ' when there is at least one .govuk-error-message displayed
      */
-      updateTitle: function () {
-          const titleTag = document.getElementsByTagName("title")[0];
-          let prefix = "";
-          if (!titleTag || titleTag.getAttribute("data-govuk-error-prefix") == null) {
-              prefix = "Error: "
-          }
-          else {
-              prefix = titleTag.getAttribute("data-govuk-error-prefix")
-          };
-         
-      const hasError = [].slice
-        .call(document.querySelectorAll(".govuk-error-message"))
-        .filter(function (error) {
-          const prefix = error.querySelector(".govuk-visually-hidden");
-          const textNode = 3;
-          for (let i = 0; i < error.childNodes.length; i++) {
-            let x = error.childNodes[i];
-            if (
-              x !== prefix &&
-              (x.nodeType !== textNode || x.textContent.trim())
-            ) {
-              return true;
-            }
-          }
-          return false;
-        }).length;
-      const index = document.title.indexOf(prefix);
-      if (hasError && index !== 0) {
-        document.title = prefix + document.title;
-      } else if (!hasError && index === 0) {
-        document.title = document.title.substring(prefix.length);
-      }
+    updateTitle: function () {
+      return updateTitle();
     },
 
     /**
@@ -71,32 +42,7 @@ function createGovUkValidator() {
      * @returns void
      */
     createErrorSummary: function () {
-      if (!document.querySelector(".govuk-error-summary")) {
-        const summary = document.createElement("div");
-        summary.classList.add("govuk-error-summary");
-        summary.setAttribute("aria-labelledby", "error-summary-title");
-        summary.setAttribute("role", "alert");
-        summary.setAttribute("data-module", "govuk-error-summary");
-        summary.classList.add("govuk-!-display-none");
-
-        const h2 = document.createElement("h2");
-        h2.classList.add("govuk-error-summary__title");
-        h2.setAttribute("id", "error-summary-title");
-        h2.appendChild(document.createTextNode("There is a problem"));
-        summary.appendChild(h2);
-
-        const body = document.createElement("div");
-        body.classList.add("govuk-error-summary__body");
-        summary.appendChild(body);
-
-        const ul = document.createElement("ul");
-        ul.classList.add("govuk-list");
-        ul.classList.add("govuk-error-summary__list");
-        body.appendChild(ul);
-
-        const main = document.querySelector("main");
-        main.insertBefore(summary, main.firstChild);
-      }
+      return ensureErrorSummary();
     },
 
     /**
@@ -104,127 +50,7 @@ function createGovUkValidator() {
      * @returns void
      */
     updateErrorSummary: function () {
-      const summary = document.querySelector(".govuk-error-summary");
-      if (!summary) {
-        return;
-      }
-
-      const errorSummaryBody = summary.querySelector(".govuk-error-summary__body");
-      if (!errorSummaryBody) {
-          return;
-      }
-
-      let list = errorSummaryBody.querySelector("ul"); 
-      if (!list) {
-        const ul = document.createElement("ul");
-        ul.classList.add("govuk-list");
-        ul.classList.add("govuk-error-summary__list");
-        errorSummaryBody.appendChild(ul);
-        list = ul;
-      }
-
-      const textNode = 3;
-
-      // Get the current links in the error summary, and the links that need to be there
-
-      const currentErrors = [].slice.call(list.querySelectorAll("a"));
-
-      const updatedErrors = [].slice
-        .call(
-          document.querySelectorAll(
-            ".govuk-error-message:not(.govuk-character-count__status)"
-          )
-        )
-        .map(function (error) {
-          const link = document.createElement("a");
-          const prefix = error.querySelector(".govuk-visually-hidden");
-          [].slice.call(error.childNodes).map(function (x) {
-            if (
-              x !== prefix &&
-              (x.nodeType !== textNode || x.textContent.trim())
-            ) {
-              link.appendChild(x.cloneNode(true));
-            }
-          });
-          if (!link.hasChildNodes()) {
-            return;
-          }
-          link.href = "#" + error.id.substring(0, error.id.length - 6);
-          return link;
-        })
-        .filter(function (link) {
-          return link !== undefined;
-        });
-
-      function findErrorsNotMatched(errorsToLookFor, errorsToSearch) {
-        const result = [];
-        for (let i = 0; i < errorsToLookFor.length; i++) {
-          let matchingErrors = errorsToSearch.filter(function (link) {
-            return matchErrorLink(link, errorsToLookFor[i]);
-          });
-          if (!matchingErrors.length) {
-            result.push(errorsToLookFor[i]);
-          }
-        }
-        return result;
-      }
-
-      function matchErrorLink(link1, link2) {
-        return (
-          link1.href === link2.href && link1.textContent == link2.textContent
-        );
-      }
-
-      // Remove any errors from the error summary that are no longer in the page.
-      const errorsToRemove = findErrorsNotMatched(currentErrors, updatedErrors);
-
-      for (let i = 0; i < errorsToRemove.length; i++) {
-        list.removeChild(errorsToRemove[i].parentElement);
-      }
-
-      // Find any new errors and insert them at the correct position in the error summary.
-      // It's important to leave existing links untouched. If your focus is in a field and you click
-      // on an error summary link, validation will run on focusout of the field before the link is followed.
-      // If validation removes the link (even if it recreates an identical one) it cannot be followed.
-      let errorsToAdd = findErrorsNotMatched(updatedErrors, currentErrors);
-
-      for (let i = 0; i < errorsToAdd.length; i++) {
-        let summaryError = document.createElement("li");
-        summaryError.appendChild(errorsToAdd[i]);
-
-        if (list.childNodes.length == 0) {
-          list.appendChild(summaryError);
-        } else {
-          let indexOfThisError = updatedErrors.indexOf(errorsToAdd[i]);
-          if (indexOfThisError === 0) {
-            list.insertBefore(summaryError, list.firstChild);
-          } else {
-            let errorToInsertAfter = updatedErrors[indexOfThisError - 1];
-            for (let j = 0; j < list.childNodes.length; j++) {
-              let link = list.childNodes[j].querySelector("a");
-              if (matchErrorLink(link, errorToInsertAfter)) {
-                if (list.childNodes[j].nextSibling) {
-                  list.insertBefore(
-                    summaryError,
-                    list.childNodes[j].nextSibling
-                  );
-                } else {
-                  list.appendChild(summaryError);
-                }
-                break;
-              }
-            }
-          }
-        }
-      }
-
-      const hasError = list.querySelector("li");
-      summary.classList.remove(
-        hasError ? "govuk-!-display-none" : "govuk-!-display-block"
-      );
-      summary.classList.add(
-        hasError ? "govuk-!-display-block" : "govuk-!-display-none"
-      );
+      return updateErrorSummary();
     },
 
     /**

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/error-summary.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/error-summary.tests.ts
@@ -1,0 +1,206 @@
+import {
+	ensureErrorSummary,
+	updateErrorSummary,
+	updateTitle,
+} from "../../Scripts/govuk-components/error-summary.js";
+import "@testing-library/jest-dom";
+
+describe("ensureErrorSummary", () => {
+	beforeEach(() => {
+		document.body.innerHTML = "<main><div id='page-content'></div></main>";
+	});
+
+	it("should create and insert an error summary as the first child of main", () => {
+		const summary = ensureErrorSummary();
+		const main = document.querySelector("main");
+
+		expect(summary).toBe(main?.firstElementChild);
+		expect(summary).toHaveClass("govuk-error-summary", "govuk-!-display-none");
+	});
+
+	it("should return the created error summary", () => {
+		const summary = ensureErrorSummary();
+
+		expect(summary).toBe(document.querySelector(".govuk-error-summary"));
+	});
+
+	it("should create the GOV.UK error summary markup", () => {
+		const summary = ensureErrorSummary();
+		const heading = summary.querySelector("h2");
+		const errorList = summary.querySelector("ul");
+
+		expect(summary).toHaveAttribute("role", "alert");
+		expect(summary).toHaveAttribute("data-module", "govuk-error-summary");
+		expect(summary).toHaveAttribute("aria-labelledby", "error-summary-title");
+		expect(heading).toHaveAttribute("id", "error-summary-title");
+		expect(heading).toHaveClass("govuk-error-summary__title");
+		expect(heading).toHaveTextContent("There is a problem");
+		expect(errorList).toHaveClass("govuk-list", "govuk-error-summary__list");
+		expect(errorList?.parentElement).toHaveClass("govuk-error-summary__body");
+	});
+
+	it("should return an existing error summary without creating a duplicate", () => {
+		const existingSummary = document.createElement("div");
+		existingSummary.className = "govuk-error-summary";
+		document.querySelector("main")?.prepend(existingSummary);
+
+		const summary = ensureErrorSummary();
+
+		expect(summary).toBe(existingSummary);
+		expect(document.querySelectorAll(".govuk-error-summary")).toHaveLength(1);
+		expect(existingSummary).toBeEmptyDOMElement();
+	});
+});
+
+describe("updateTitle", () => {
+	beforeEach(() => {
+		document.head.innerHTML = "<title>Example</title>";
+		document.body.innerHTML = "";
+	});
+
+	it("should add the default error prefix when an error has visible content", () => {
+		document.body.innerHTML = `
+			<p class="govuk-error-message">
+				<span class="govuk-visually-hidden">Error: </span>
+				Enter a valid postcode
+			</p>`;
+
+		updateTitle();
+
+		expect(document.title).toBe("Error: Example");
+	});
+
+	it("should not add the error prefix for an empty error placeholder", () => {
+		document.body.innerHTML = `
+			<p class="govuk-error-message">
+				<span class="govuk-visually-hidden">Error: </span>
+			</p>`;
+
+		updateTitle();
+
+		expect(document.title).toBe("Example");
+	});
+
+	it("should not add the error prefix multiple times", () => {
+		document.title = "Error: Example";
+		document.body.innerHTML = "<p class='govuk-error-message'>Enter a valid postcode</p>";
+
+		updateTitle();
+
+		expect(document.title).toBe("Error: Example");
+	});
+
+	it("should remove the error prefix when no visible errors remain", () => {
+		document.title = "Error: Example";
+
+		updateTitle();
+
+		expect(document.title).toBe("Example");
+	});
+
+	it("should use a configured error prefix from the title element", () => {
+		const title = document.querySelector("title");
+		title?.setAttribute("data-govuk-error-prefix", "There is a problem: ");
+		document.body.innerHTML = "<p class='govuk-error-message'>Enter a valid postcode</p>";
+
+		updateTitle();
+
+		expect(document.title).toBe("There is a problem: Example");
+	});
+});
+
+describe("updateErrorSummary", () => {
+	beforeEach(() => {
+		document.body.innerHTML = "<main></main>";
+		ensureErrorSummary();
+	});
+
+	it("should display the summary and link to each error message", () => {
+		const firstError = document.createElement("p");
+		firstError.id = "postcode-error";
+		firstError.className = "govuk-error-message";
+		firstError.textContent = "Enter a valid postcode";
+		document.body.appendChild(firstError);
+
+		const secondError = document.createElement("p");
+		secondError.id = "country-error";
+		secondError.className = "govuk-error-message";
+		secondError.textContent = "Select a country";
+		document.body.appendChild(secondError);
+
+		updateErrorSummary();
+
+		const summary = document.querySelector(".govuk-error-summary");
+		const links = summary?.querySelectorAll(".govuk-error-summary__list a");
+
+		expect(summary).toHaveClass("govuk-!-display-block");
+		expect(links).toHaveLength(2);
+		expect(links?.[0]).toHaveAttribute("href", "#postcode");
+		expect(links?.[0]).toHaveTextContent("Enter a valid postcode");
+		expect(links?.[1]).toHaveAttribute("href", "#country");
+	});
+
+	it("should not copy the visually hidden error prefix into a summary link", () => {
+		const error = document.createElement("p");
+		error.id = "postcode-error";
+		error.className = "govuk-error-message";
+
+		const prefix = document.createElement("span");
+		prefix.className = "govuk-visually-hidden";
+		prefix.textContent = "Error: ";
+		error.appendChild(prefix);
+		error.appendChild(document.createTextNode("Enter a valid postcode"));
+		document.body.appendChild(error);
+
+		updateErrorSummary();
+
+		const link = document.querySelector(".govuk-error-summary__list a");
+
+		expect(link).toHaveTextContent("Enter a valid postcode");
+		expect(link?.querySelector(".govuk-visually-hidden")).toBeNull();
+	});
+
+	it("should ignore error messages without visible content", () => {
+		const error = document.createElement("p");
+		error.id = "postcode-error";
+		error.className = "govuk-error-message";
+		error.innerHTML = "<span class='govuk-visually-hidden'>Error: </span> ";
+		document.body.appendChild(error);
+
+		updateErrorSummary();
+
+		const summary = document.querySelector(".govuk-error-summary");
+
+		expect(summary?.querySelectorAll(".govuk-error-summary__list li")).toHaveLength(0);
+		expect(summary).toHaveClass("govuk-!-display-none");
+	});
+
+	it("should remove stale links and hide the summary when errors are removed", () => {
+		const error = document.createElement("p");
+		error.id = "postcode-error";
+		error.className = "govuk-error-message";
+		error.textContent = "Enter a valid postcode";
+		document.body.appendChild(error);
+
+		updateErrorSummary();
+		error.remove();
+		updateErrorSummary();
+
+		const summary = document.querySelector(".govuk-error-summary");
+
+		expect(summary?.querySelectorAll(".govuk-error-summary__list li")).toHaveLength(0);
+		expect(summary).toHaveClass("govuk-!-display-none");
+	});
+
+	it("should create an error list when the summary body does not contain one", () => {
+		document.body.innerHTML = `
+			<div class="govuk-error-summary">
+				<div class="govuk-error-summary__body"></div>
+			</div>
+			<p id="postcode-error" class="govuk-error-message">Enter a valid postcode</p>`;
+
+		updateErrorSummary();
+
+		expect(document.querySelector(".govuk-error-summary__list")).not.toBeNull();
+	});
+});

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/fieldset.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/fieldset.tests.ts
@@ -1,5 +1,42 @@
-import { createFieldset } from "../../Scripts/govuk-components/fieldset";
+import { createFieldset, createFieldsetFormGroup } from "../../Scripts/govuk-components/fieldset";
 import "@testing-library/jest-dom";
+
+describe("createFieldsetFormGroup", () => {
+	it("should wrap a fieldset in a GOV.UK form group", () => {
+        const formGroup = createFieldsetFormGroup({
+            id: "address",
+            legendText: "Your address",
+            children: [],
+        });
+
+        expect(formGroup.tagName).toBe("DIV");
+        expect(formGroup).toHaveClass("govuk-form-group");
+    });
+
+    it("should assign the supplied ID to the fieldset", () => {
+        const formGroup = createFieldsetFormGroup({
+            id: "address",
+            legendText: "Your address",
+            children: [],
+        });
+
+        expect(formGroup.querySelector("fieldset")).toHaveAttribute(
+            "id",
+            "address"
+        );
+    });
+
+    it("should contain the fieldset as its only child", () => {
+        const formGroup = createFieldsetFormGroup({
+            id: "address",
+            legendText: "Your address",
+            children: [],
+        });
+
+        expect(formGroup.children).toHaveLength(1);
+        expect(formGroup.children[0].tagName).toBe("FIELDSET");
+    });
+});
 
 describe("createFieldset", () => {
 	it("should render a fieldset with the GOV.UK fieldset class", () => {

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
@@ -1,6 +1,22 @@
-import { clearControlError, showControlError } from "../../Scripts/govuk-components/validation";
+import { jest } from "@jest/globals";
 import { createTextInputFormGroup } from "../../Scripts/govuk-components/inputs";
 import "@testing-library/jest-dom";
+
+
+const ensureErrorSummary = jest.fn();
+const updateErrorSummary = jest.fn();
+const updateTitle = jest.fn();
+
+jest.unstable_mockModule(
+	"../../Scripts/govuk-components/error-summary.js",
+    () => ({
+        ensureErrorSummary,
+        updateErrorSummary,
+        updateTitle,
+    })
+);
+
+const { clearControlError, showControlError } = await import("../../Scripts/govuk-components/validation");
 
 function createInputFormGroup(id: string): { formGroup: HTMLElement; input: HTMLInputElement } {
 	const formGroup = createTextInputFormGroup({
@@ -19,6 +35,10 @@ function createInputFormGroup(id: string): { formGroup: HTMLElement; input: HTML
 
 	return { formGroup, input };
 }
+
+beforeEach(() => {
+	jest.clearAllMocks();
+});
 
 describe("showControlError", () => {
 	const id = "postcode";
@@ -65,6 +85,16 @@ describe("showControlError", () => {
 		);
 		expect(input).toHaveAttribute("aria-describedby", `${id}-hint ${id}-error`);
 	});
+
+	it("should update the page error summary and title", () => {
+    	const { input } = createInputFormGroup("postcode");
+
+    	showControlError(input, "Enter a valid postcode");
+
+    	expect(ensureErrorSummary).toHaveBeenCalledTimes(1);
+    	expect(updateErrorSummary).toHaveBeenCalledTimes(1);
+    	expect(updateTitle).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("clearControlError", () => {
@@ -92,5 +122,18 @@ describe("clearControlError", () => {
 		clearControlError(input);
 
 		expect(input).not.toHaveAttribute("aria-describedby");
+	});
+
+	it("should update the page error summary and title after clearing", () => {
+    	const { input } = createInputFormGroup("postcode");
+
+    	showControlError(input, "Enter a valid postcode");
+    	jest.clearAllMocks();
+
+    	clearControlError(input);
+
+    	expect(ensureErrorSummary).not.toHaveBeenCalled();
+    	expect(updateErrorSummary).toHaveBeenCalledTimes(1);
+    	expect(updateTitle).toHaveBeenCalledTimes(1);
 	});
 });

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
@@ -1,0 +1,96 @@
+import { clearControlError, showControlError } from "../../Scripts/govuk-components/validation";
+import { createTextInputFormGroup } from "../../Scripts/govuk-components/inputs";
+import "@testing-library/jest-dom";
+
+function createInputFormGroup(id: string): { formGroup: HTMLElement; input: HTMLInputElement } {
+	const formGroup = createTextInputFormGroup({
+		labelText: "Postcode",
+		hintText: "For example, SW1A 2AA",
+		input: {
+			id,
+			name: id,
+		},
+	});
+	const input = formGroup.querySelector("input");
+
+	if (!input) {
+		throw new Error("Expected an input control");
+	}
+
+	return { formGroup, input };
+}
+
+describe("showControlError", () => {
+	const id = "postcode";
+	it("should apply GOV.UK error classes to an input and its form group", () => {
+		const { formGroup, input } = createInputFormGroup(id);
+
+		showControlError(input, "Enter a valid postcode");
+
+		expect(formGroup).toHaveClass("govuk-form-group--error");
+		expect(input).toHaveClass("govuk-input--error");
+	});
+
+	it("should create an accessible error message before the control", () => {
+		const { formGroup, input } = createInputFormGroup(id);
+
+		showControlError(input, "Enter a valid postcode");
+
+		const errorMessage = formGroup.querySelector(`#${id}-error`);
+
+		expect(errorMessage).toHaveClass("govuk-error-message");
+		expect(errorMessage).toHaveTextContent("Error: Enter a valid postcode");
+		expect(errorMessage?.querySelector(".govuk-visually-hidden")).toHaveTextContent("Error:");
+		expect(formGroup.children[2]).toBe(errorMessage);
+		expect(formGroup.children[3]).toBe(input);
+	});
+
+	it("should add the error ID to aria-describedby without removing the hint ID", () => {
+		const { input } = createInputFormGroup(id);
+
+		showControlError(input, "Enter a valid postcode");
+
+		expect(input).toHaveAttribute("aria-describedby", `${id}-hint ${id}-error`);
+	});
+
+	it("should update an existing error message without adding another error ID", () => {
+		const { formGroup, input } = createInputFormGroup(id);
+
+		showControlError(input, "Enter a valid postcode");
+		showControlError(input, "Postcode is not recognised");
+
+		expect(formGroup.querySelectorAll(".govuk-error-message")).toHaveLength(1);
+		expect(formGroup.querySelector(`#${id}-error`)).toHaveTextContent(
+			"Error: Postcode is not recognised"
+		);
+		expect(input).toHaveAttribute("aria-describedby", `${id}-hint ${id}-error`);
+	});
+});
+
+describe("clearControlError", () => {
+	const id = "first-name";
+	it("should remove error classes and the error message while preserving the hint Id and aria-describedby", () => {
+		const { formGroup, input } = createInputFormGroup(id);
+		showControlError(input, "Enter a valid postcode");
+
+		clearControlError(input);
+
+		expect(formGroup).not.toHaveClass("govuk-form-group--error");
+		expect(input).not.toHaveClass("govuk-input--error");
+		expect(formGroup.querySelector(`#${id}-error`)).toBeNull();
+		expect(input).toHaveAttribute("aria-describedby", `${id}-hint`);
+	});
+
+	it("should remove aria-describedby when it only contained the error ID", () => {
+		const input = document.createElement("input");
+		input.id = id;
+		const formGroup = document.createElement("div");
+		formGroup.className = "govuk-form-group";
+		formGroup.appendChild(input);
+
+		showControlError(input, "Enter a valid postcode");
+		clearControlError(input);
+
+		expect(input).not.toHaveAttribute("aria-describedby");
+	});
+});

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import { createFieldsetFormGroup } from "../../Scripts/govuk-components/fieldset";
 import { createTextInputFormGroup } from "../../Scripts/govuk-components/inputs";
 import "@testing-library/jest-dom";
 
@@ -34,6 +35,49 @@ function createInputFormGroup(id: string): { formGroup: HTMLElement; input: HTML
 	}
 
 	return { formGroup, input };
+}
+
+function createFieldsetWithInputs(): {
+	fieldsetFormGroup: HTMLElement;
+	firstInputFormGroup: HTMLElement;
+	firstInput: HTMLInputElement;
+	secondInputFormGroup: HTMLElement;
+	secondInput: HTMLInputElement;
+} {
+	const firstInputFormGroup = createTextInputFormGroup({
+		labelText: "First name",
+		input: { id: "first-name", name: "first-name" },
+	});
+	const secondInputFormGroup = createTextInputFormGroup({
+		labelText: "Last name",
+		input: { id: "last-name", name: "last-name" },
+	});
+	const firstInput = firstInputFormGroup.querySelector("input");
+	const secondInput = secondInputFormGroup.querySelector("input");
+
+	if (!firstInput || !secondInput) {
+		throw new Error("Expected input controls");
+	}
+
+	return {
+		fieldsetFormGroup: createFieldsetFormGroup({
+			id: "contact-details",
+			legendText: "Contact details",
+			children: [firstInputFormGroup, secondInputFormGroup],
+		}),
+		firstInputFormGroup,
+		firstInput,
+		secondInputFormGroup,
+		secondInput,
+	};
+}
+
+function createContactDetailsFieldsetFormGroup(): HTMLElement {
+	return createFieldsetFormGroup({
+		id: "contact-details",
+		legendText: "Contact details",
+		children: [],
+	});
 }
 
 beforeEach(() => {
@@ -134,5 +178,106 @@ describe("clearFormGroupError", () => {
     	expect(ensureErrorSummary).not.toHaveBeenCalled();
     	expect(updateErrorSummary).toHaveBeenCalledTimes(1);
     	expect(updateTitle).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("nested control errors", () => {
+	it("should style the containing fieldset form group while retaining the input error", () => {
+		const {
+			fieldsetFormGroup,
+			firstInputFormGroup,
+			firstInput,
+		} = createFieldsetWithInputs();
+
+		showFormGroupError(firstInputFormGroup, "Enter a first name");
+
+		expect(fieldsetFormGroup).toHaveClass("govuk-form-group--error");
+		expect(firstInputFormGroup).toHaveClass("govuk-form-group--error");
+		expect(firstInput).toHaveClass("govuk-input--error");
+		expect(firstInputFormGroup.querySelector("#first-name-error")).toHaveTextContent(
+			"Error: Enter a first name"
+		);
+		expect(firstInput).toHaveAttribute("aria-describedby", "first-name-error");
+	});
+
+	it("should preserve the fieldset error styling while another nested input has an error", () => {
+		const {
+			fieldsetFormGroup,
+			firstInputFormGroup,
+			secondInputFormGroup,
+		} = createFieldsetWithInputs();
+
+		showFormGroupError(firstInputFormGroup, "Enter a first name");
+		showFormGroupError(secondInputFormGroup, "Enter a last name");
+		clearFormGroupError(firstInputFormGroup);
+
+		expect(fieldsetFormGroup).toHaveClass("govuk-form-group--error");
+	});
+
+	it("should clear the fieldset error styling after its final nested input error is cleared", () => {
+		const {
+			fieldsetFormGroup,
+			firstInputFormGroup,
+		} = createFieldsetWithInputs();
+
+		showFormGroupError(firstInputFormGroup, "Enter a first name");
+		clearFormGroupError(firstInputFormGroup);
+
+		expect(fieldsetFormGroup).not.toHaveClass("govuk-form-group--error");
+	});
+});
+
+describe("fieldset form group errors", () => {
+	it("should add a fieldset error without replacing a nested input error", () => {
+		const {
+			fieldsetFormGroup,
+			firstInputFormGroup,
+			firstInput,
+		} = createFieldsetWithInputs();
+
+		showFormGroupError(firstInputFormGroup, "Enter a first name");
+		showFormGroupError(fieldsetFormGroup, "Enter valid contact details");
+
+		expect(firstInputFormGroup.querySelector("#first-name-error")).toHaveTextContent(
+			"Error: Enter a first name"
+		);
+		expect(firstInput).toHaveAttribute("aria-describedby", "first-name-error");
+		expect(fieldsetFormGroup.querySelector("#contact-details-error")).toHaveTextContent(
+			"Error: Enter valid contact details"
+		);
+		expect(fieldsetFormGroup.querySelectorAll(".govuk-error-message")).toHaveLength(2);
+	});
+
+	it("should add a fieldset error after the legend and describe the fieldset", () => {
+		const formGroup = createContactDetailsFieldsetFormGroup();
+		const fieldset = formGroup.querySelector("fieldset");
+
+		showFormGroupError(formGroup, "Enter valid contact details");
+
+		const errorMessage = formGroup.querySelector("#contact-details-error");
+
+		expect(formGroup).toHaveClass("govuk-form-group--error");
+		expect(errorMessage).toHaveTextContent("Error: Enter valid contact details");
+		expect(fieldset?.children[1]).toBe(errorMessage);
+		expect(fieldset).toHaveAttribute("aria-describedby", "contact-details-error");
+		expect(ensureErrorSummary).toHaveBeenCalledTimes(1);
+		expect(updateErrorSummary).toHaveBeenCalledTimes(1);
+		expect(updateTitle).toHaveBeenCalledTimes(1);
+	});
+
+	it("should clear a fieldset error and remove its description", () => {
+		const formGroup = createContactDetailsFieldsetFormGroup();
+		const fieldset = formGroup.querySelector("fieldset");
+		showFormGroupError(formGroup, "Enter valid contact details");
+		jest.clearAllMocks();
+
+		clearFormGroupError(formGroup);
+
+		expect(formGroup).not.toHaveClass("govuk-form-group--error");
+		expect(formGroup.querySelector("#contact-details-error")).toBeNull();
+		expect(fieldset).not.toHaveAttribute("aria-describedby");
+		expect(ensureErrorSummary).not.toHaveBeenCalled();
+		expect(updateErrorSummary).toHaveBeenCalledTimes(1);
+		expect(updateTitle).toHaveBeenCalledTimes(1);
 	});
 });

--- a/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
+++ b/ThePensionsRegulator.GovUk.Frontend/__tests__/govuk-components/validation.tests.ts
@@ -16,7 +16,7 @@ jest.unstable_mockModule(
     })
 );
 
-const { clearControlError, showControlError } = await import("../../Scripts/govuk-components/validation");
+const { clearFormGroupError, showFormGroupError } = await import("../../Scripts/govuk-components/validation");
 
 function createInputFormGroup(id: string): { formGroup: HTMLElement; input: HTMLInputElement } {
 	const formGroup = createTextInputFormGroup({
@@ -40,12 +40,12 @@ beforeEach(() => {
 	jest.clearAllMocks();
 });
 
-describe("showControlError", () => {
+describe("showFormGroupError", () => {
 	const id = "postcode";
 	it("should apply GOV.UK error classes to an input and its form group", () => {
 		const { formGroup, input } = createInputFormGroup(id);
 
-		showControlError(input, "Enter a valid postcode");
+		showFormGroupError(formGroup, "Enter a valid postcode");
 
 		expect(formGroup).toHaveClass("govuk-form-group--error");
 		expect(input).toHaveClass("govuk-input--error");
@@ -54,7 +54,7 @@ describe("showControlError", () => {
 	it("should create an accessible error message before the control", () => {
 		const { formGroup, input } = createInputFormGroup(id);
 
-		showControlError(input, "Enter a valid postcode");
+		showFormGroupError(formGroup, "Enter a valid postcode");
 
 		const errorMessage = formGroup.querySelector(`#${id}-error`);
 
@@ -66,9 +66,9 @@ describe("showControlError", () => {
 	});
 
 	it("should add the error ID to aria-describedby without removing the hint ID", () => {
-		const { input } = createInputFormGroup(id);
+		const { formGroup, input } = createInputFormGroup(id);
 
-		showControlError(input, "Enter a valid postcode");
+		showFormGroupError(formGroup, "Enter a valid postcode");
 
 		expect(input).toHaveAttribute("aria-describedby", `${id}-hint ${id}-error`);
 	});
@@ -76,8 +76,8 @@ describe("showControlError", () => {
 	it("should update an existing error message without adding another error ID", () => {
 		const { formGroup, input } = createInputFormGroup(id);
 
-		showControlError(input, "Enter a valid postcode");
-		showControlError(input, "Postcode is not recognised");
+		showFormGroupError(formGroup, "Enter a valid postcode");
+		showFormGroupError(formGroup, "Postcode is not recognised");
 
 		expect(formGroup.querySelectorAll(".govuk-error-message")).toHaveLength(1);
 		expect(formGroup.querySelector(`#${id}-error`)).toHaveTextContent(
@@ -87,9 +87,9 @@ describe("showControlError", () => {
 	});
 
 	it("should update the page error summary and title", () => {
-    	const { input } = createInputFormGroup("postcode");
+    	const { formGroup } = createInputFormGroup("postcode");
 
-    	showControlError(input, "Enter a valid postcode");
+    	showFormGroupError(formGroup, "Enter a valid postcode");
 
     	expect(ensureErrorSummary).toHaveBeenCalledTimes(1);
     	expect(updateErrorSummary).toHaveBeenCalledTimes(1);
@@ -97,13 +97,12 @@ describe("showControlError", () => {
 	});
 });
 
-describe("clearControlError", () => {
+describe("clearFormGroupError", () => {
 	const id = "first-name";
 	it("should remove error classes and the error message while preserving the hint Id and aria-describedby", () => {
 		const { formGroup, input } = createInputFormGroup(id);
-		showControlError(input, "Enter a valid postcode");
-
-		clearControlError(input);
+		showFormGroupError(formGroup, "Enter a valid postcode");
+		clearFormGroupError(formGroup);
 
 		expect(formGroup).not.toHaveClass("govuk-form-group--error");
 		expect(input).not.toHaveClass("govuk-input--error");
@@ -118,19 +117,19 @@ describe("clearControlError", () => {
 		formGroup.className = "govuk-form-group";
 		formGroup.appendChild(input);
 
-		showControlError(input, "Enter a valid postcode");
-		clearControlError(input);
+		showFormGroupError(formGroup, "Enter a valid postcode");
+		clearFormGroupError(formGroup);
 
 		expect(input).not.toHaveAttribute("aria-describedby");
 	});
 
 	it("should update the page error summary and title after clearing", () => {
-    	const { input } = createInputFormGroup("postcode");
+    	const { formGroup } = createInputFormGroup("postcode");
 
-    	showControlError(input, "Enter a valid postcode");
+    	showFormGroupError(formGroup, "Enter a valid postcode");
     	jest.clearAllMocks();
 
-    	clearControlError(input);
+    	clearFormGroupError(formGroup);
 
     	expect(ensureErrorSummary).not.toHaveBeenCalled();
     	expect(updateErrorSummary).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This pull request introduces postcode sanitisation, normalisation, and validation utilities with comprehensive tests, and enhances the GOV.UK frontend example app with improved form validation UI and error summary handling. The changes are grouped into two main themes: postcode utilities and validation, and frontend UI improvements.**Postcode utilities and validation:*** Added `sanitisePostcode`, `normalisePostcode`, and `validatePostcode` functions for cleaning, formatting, and validating UK postcodes, along with corresponding unit tests to ensure correct behavior. (`ThePensionsRegulator.Frontend/Scripts/address-lookup/postcode-sanitiser.ts`, `postcode-normaliser.ts`, `postcode-validator.ts`, and their respective test files) [[1]](diffhunk://#diff-260a922ebe1761ed77adb5dee73ba61774afc963f34ffc3fbbd428555943926aR1-R14) [[2]](diffhunk://#diff-ea7eba0582b016c6c3f936ea6e737c6f97035042f8f3d639ab5fe87d9367120cR1-R9) [[3]](diffhunk://#diff-ce955966f765ab5a91487767f8030106d36c01e2c180e4c7bd3e7a3db4749df2R1-R66) [[4]](diffhunk://#diff-06d837730a85f8b1bcc84cb07aaba236129f7dc52ece77bfc310b8e7ecc48d81R1-R31) [[5]](diffhunk://#diff-eff40cc1491061fce2cf97dc8cb6f7160cdd9fa65551543c80877fe24b1a539eR1-R28) [[6]](diffhunk://#diff-0ffde8f30d990264528f0cb228f3fbf61a0c0bc6b81ec380a041eaf78434b93bR1-R36)**Frontend UI improvements:*** Enhanced the example app's JavaScript (`javascript-components-examples.js`) to demonstrate dynamic form validation: added buttons to show, update, and clear errors on input fields and fieldsets, and switched to using `createFieldsetFormGroup` for better structure. [[1]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fL3-R4) [[2]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fR56-R86) [[3]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fL75-R121) [[4]](diffhunk://#diff-82d69c96d4ccecb57763664de4ad08b870128037c3f769d3735fcf41a2b8af6fL98-R177)* Added `ensureErrorSummary`, `updateErrorSummary`, and `updateTitle` functions to manage the display and content of error summaries and document titles, improving accessibility and user feedback for form errors. (`govuk-components/error-summary.js`)* Introduced `createFieldsetFormGroup` and its options interface to wrap fieldsets in a `.govuk-form-group` container, enabling better error styling and validation integration. (`govuk-components/fieldset.ts`, `govuk-components/types.ts`) [[1]](diffhunk://#diff-7bf04293b837388240fd88cc857039203bf6abe905064882c94b1f0a03ddf7a5L1-R1) [[2]](diffhunk://#diff-7bf04293b837388240fd88cc857039203bf6abe905064882c94b1f0a03ddf7a5R30-R40) [[3]](diffhunk://#diff-7981e7d81b0edb36d2334fbbe589332cbf146d3669e1a6e81f08cf74bb4368baR84-R87)

---
Related work item(s): [AB#276952](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/276952), [AB#276953](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/276953)