### PR TITLE
Feature/address lookup manual

### DIFF
--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-confirmed.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-confirmed.ts
@@ -32,11 +32,11 @@ function createAddressParagraph(address: ConfirmedAddress): HTMLParagraphElement
         address.postTown,
         address.postCounty,
         ...(address.countryId !== "GB" && address.countryName ? [address.countryName] : []),
-        address.postCode
+        address.postcode
     ].filter(line => line !== undefined);
 
     filteredAddress.forEach((addressLine, index) => {
-        if (addressLine === address.postCode) {
+        if (addressLine === address.postcode) {
             paragraph.appendChild(document.createTextNode(addressLine));
         } else {
             const titleCase = toTitleCase(addressLine);
@@ -53,34 +53,34 @@ function createAddressParagraph(address: ConfirmedAddress): HTMLParagraphElement
 function createHiddenAddressInputs(address: ConfirmedAddress) : HTMLInputElement[] {
     const inputs: HTMLInputElement[] = [];
     
-    inputs.push(createHiddenInput("AddressLine1", address.addressLine1));
+    inputs.push(createHiddenInput("addressLine1", address.addressLine1));
     
     if (address.addressLine2 !== undefined) {
-        inputs.push(createHiddenInput("AddressLine2", address.addressLine2));
+        inputs.push(createHiddenInput("addressLine2", address.addressLine2));
     }
     if (address.addressLine3 !== undefined) {
-        inputs.push(createHiddenInput("AddressLine3", address.addressLine3));
+        inputs.push(createHiddenInput("addressLine3", address.addressLine3));
     }
     if (address.postTown !== undefined) {
-        inputs.push(createHiddenInput("PostTown", address.postTown));
+        inputs.push(createHiddenInput("postTown", address.postTown));
     }
     if (address.postCounty !== undefined) {
-        inputs.push(createHiddenInput("PostCounty", address.postCounty));
+        inputs.push(createHiddenInput("postCounty", address.postCounty));
     }
     if (address.countryId !== undefined) {
-        inputs.push(createHiddenInput("CountryId", address.countryId));
+        inputs.push(createHiddenInput("countryId", address.countryId));
     }
-    if (address.postCode !== undefined) {
-        inputs.push(createHiddenInput("PostCode", address.postCode));
+    if (address.postcode !== undefined) {
+        inputs.push(createHiddenInput("postcode", address.postcode));
     }
     if (address.uprnReference !== undefined) {
-        inputs.push(createHiddenInput("UPRNReference", address.uprnReference));
+        inputs.push(createHiddenInput("uprnReference", address.uprnReference));
     }
 
     return inputs;
 }
 
-function createHiddenInput(name: string, value: string): HTMLInputElement {
+function createHiddenInput(name: keyof ConfirmedAddress, value: string): HTMLInputElement {
     const input = document.createElement("input");
     input.type = "hidden";
     input.id = name;

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-international-manual-entry.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-international-manual-entry.ts
@@ -1,0 +1,136 @@
+import { InternationalManualEntryAddress } from "./types";
+import { createButton } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/button.js";
+import { createFieldset } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/fieldset.js";
+import { createSelectFormGroup, createTextInputFormGroup } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/inputs.js";
+import { createLink } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/link.js";
+import { clearFormGroupError, showFormGroupError } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/validation.js";
+
+export interface AddressInternationalManualEntryOptions {
+    onAddressSubmitted: (address: InternationalManualEntryAddress) => void;
+    onBackToSearchRequested: () => void;
+    countries: Array<{ value: string; text: string }>;
+}
+
+export function renderAddressInternationalManualEntry(options: AddressInternationalManualEntryOptions) : HTMLElement {
+    const div = document.createElement("div");
+    const addressLine1 = createTextInputFormGroup({ labelText: 'Address line 1', input: { id: 'address-line-1', name: 'address-line-1', type: "text", width: "x-large" }});
+    const addressLine2 = createTextInputFormGroup({ labelText: 'Address line 2', input: { id: 'address-line-2', name: 'address-line-2', type: "text", width: "x-large" }});
+    const addressLine3 = createTextInputFormGroup({ labelText: 'Address line 3', input: { id: 'address-line-3', name: 'address-line-3', type: "text", width: "x-large" }});
+    const postTown = createTextInputFormGroup({ labelText: 'Town or City', input: { id: 'post-town', name: 'post-town', type: "text", width: "x-large" }});
+    const countyStateProvince = createTextInputFormGroup({ labelText: 'County / State / Province', input: { id: 'county-state-province', name: 'county-state-province', type: "text", width: "x-large" }});
+    const country = createSelectFormGroup({ labelText: 'Country', select: { id: 'country', name: 'country', width: "x-large", options: [{ value: '', text: 'Select a country' }, ...options.countries] }});
+    const postcode = createTextInputFormGroup({ labelText: 'Postcode', input: { id: 'postcode', name: 'postcode', type: "text", width: "x-large" }});
+
+    const fieldset = createFieldset({ legendText: 'Enter an international address', children: [addressLine1, addressLine2, addressLine3, postTown, countyStateProvince, country, postcode]})
+    
+    div.appendChild(fieldset);
+
+    const confirmButton = createButton({ labelText: 'Confirm address', type: 'submit', variant: 'secondary' });
+    confirmButton.addEventListener("click", handleConfirmAddress);
+    div.appendChild(confirmButton);
+
+    const backToSearch = createLink({ labelText: "Back to postcode search" });
+    backToSearch.addEventListener("click", handleBackToSearch);
+
+    const nav = document.createElement("nav");
+    nav.appendChild(backToSearch);
+
+    div.appendChild(nav);
+
+    function handleBackToSearch(event: Event): void {
+        event.preventDefault();
+        options.onBackToSearchRequested();
+    }
+
+    return div;
+
+    function handleConfirmAddress(event: Event): void {
+        event.preventDefault();
+        const formGroupsByField: Record<FieldRuleSet["fieldName"], HTMLElement> = { addressLine1, addressLine2, addressLine3, postTown, countyStateProvince, countryId: country, postcode };
+        Object.values(formGroupsByField).forEach(clearFormGroupError);
+        const validationResult = validateInternationalUkManualEntryAddress(readValues(addressLine1, addressLine2, addressLine3, postTown, countyStateProvince, country, postcode));
+        if (!validationResult.isValid) {
+            validationResult.errorMessages.forEach(({ fieldName, message }) => showFormGroupError(formGroupsByField[fieldName], message));
+            return;
+        }
+
+        options.onAddressSubmitted(validationResult.address);
+    }
+}
+
+type FieldRuleSet = { fieldName: Exclude<keyof InternationalManualEntryAddress, "countryName">, validators: Array<{ message: string; isValid: () => boolean }> };
+type ErrorMessage = { fieldName: FieldRuleSet["fieldName"], message: string };
+type InternationalManualEntryValidationResult = 
+    | { isValid: true, address: InternationalManualEntryAddress }
+    | { isValid: false, errorMessages: ErrorMessage[] };
+
+export function validateInternationalUkManualEntryAddress(values: InternationalManualEntryAddress): InternationalManualEntryValidationResult {
+    const fieldRuleSets: FieldRuleSet[] = [
+        { fieldName: 'addressLine1', validators: [
+            { message: "Address line 1 is required", isValid: () => values.addressLine1.trim() !== "" },
+            { message: "Address line 1 must be 100 characters or fewer", isValid: () => values.addressLine1.trim().length <= 100 }
+        ] },
+        { fieldName: 'addressLine2', validators: [
+            { message: "Address line 2 must be 100 characters or fewer", isValid: () => values.addressLine2 != undefined && values.addressLine2.trim().length <= 100 }
+        ] },
+        { fieldName: 'addressLine3', validators: [
+            { message: "Address line 3 must be 100 characters or fewer", isValid: () => values.addressLine3 != undefined && values.addressLine3.trim().length <= 100 }
+        ] },
+        { fieldName: 'postTown', validators: [
+            { message: "Post town is required", isValid: () => values.postTown.trim() !== "" },
+            { message: "Post town must be 100 characters or fewer", isValid: () => values.postTown.trim().length <= 100 }
+        ] },
+        { fieldName: 'countyStateProvince', validators: [
+            { message: "County/State/Province must be 100 characters or fewer", isValid: () => values.countyStateProvince != undefined && values.countyStateProvince.trim().length <= 100 }
+        ]},
+        { fieldName: 'countryId', validators: [
+            { message: "Country is required", isValid: () => values.countryId !== undefined && values.countryId.trim() !== "" }
+        ]},
+        { fieldName: 'postcode', validators: [
+            { message: "Postcode must be 10 characters or fewer", isValid: () => values.postcode != undefined && values.postcode.trim().length <= 10 }
+        ]}
+    ];
+
+    const errorMessages: ErrorMessage[] = fieldRuleSets
+        .map(({ fieldName, validators }) => {
+            const firstFailure = validators.find(v => !v.isValid());
+            return firstFailure ? { fieldName: fieldName, message: firstFailure.message } : null;
+        })
+        .filter(x => x != null);
+    
+    if (errorMessages.length > 0) {
+        return { isValid: false, errorMessages };
+    }
+
+    return { isValid: true, address: {
+        addressLine1: values.addressLine1,
+        addressLine2: values.addressLine2,
+        addressLine3: values.addressLine3,
+        postTown: values.postTown,
+        countyStateProvince: values.countyStateProvince,
+        countryId: values.countryId,
+        countryName: values.countryName,
+        postcode: values.postcode
+    }};
+}
+
+function readValues(addressLine1: HTMLElement, addressLine2: HTMLElement, addressLine3: HTMLElement, postTown: HTMLElement, countyStateProvince: HTMLElement, country: HTMLElement, postcode: HTMLElement) : InternationalManualEntryAddress {
+    const addressLine1Value = (addressLine1.querySelector('input') as HTMLInputElement).value;
+    const addressLine2Value = (addressLine2.querySelector('input') as HTMLInputElement).value;
+    const addressLine3Value = (addressLine3.querySelector('input') as HTMLInputElement).value;
+    const postTownValue = (postTown.querySelector('input') as HTMLInputElement).value;
+    const countyStateProvinceValue = (countyStateProvince.querySelector('input') as HTMLInputElement).value;
+    const countrySelect = country.querySelector('select') as HTMLSelectElement;
+    const postcodeValue = (postcode.querySelector('input') as HTMLInputElement).value;
+
+    return {
+        addressLine1: addressLine1Value,
+        addressLine2: addressLine2Value,
+        addressLine3: addressLine3Value,
+        postTown: postTownValue,
+        countyStateProvince: countyStateProvinceValue,
+        countryId: countrySelect.value,
+        countryName: countrySelect.selectedOptions[0]?.text ?? '',
+        postcode: postcodeValue
+    };
+}

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup-state-machine.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup-state-machine.ts
@@ -1,9 +1,12 @@
-import type { AddressSearchCriteria, AddressSearchResult } from './types';
+import { mapAddressSearchResult, mapUkManualEntryAddress } from './address-result-mapper.js';
+import type { AddressSearchCriteria, AddressSearchResult, ConfirmedAddress, InternationalManualEntryAddress, UkManualEntryAddress } from './types';
 
 export type AddressLookupState = 
     | AddressLookupSearchState
     | AddressLookupResultState
-    | AddressLookupConfirmedState;
+    | AddressLookupConfirmedState
+    | AddressLookupUkManualEntryState
+    | AddressLookupInternationalManualEntryState
 
 export interface AddressLookupSearchState {
     status: "search";
@@ -18,13 +21,25 @@ export interface AddressLookupResultState {
 
 export interface AddressLookupConfirmedState {
     status: "confirmed";
-    address: AddressSearchResult;
+    address: ConfirmedAddress;
+}
+
+export interface AddressLookupUkManualEntryState{
+    status: "uk-manual-entry";
+}
+
+export interface AddressLookupInternationalManualEntryState {
+    status: "international-manual-entry";
 }
 
 export type AddressLookupEvent = 
     | { status: "search-succeeded", criteria: AddressSearchCriteria, addresses: AddressSearchResult[] }
     | { status: "address-selected", address: AddressSearchResult }
-    | { status: "back-to-search-requested" };
+    | { status: "back-to-search-requested" }
+    | { status: "uk-manual-entry-requested" }
+    | { status: "international-manual-entry-requested" }
+    | { status: "uk-manual-address-submitted", address: UkManualEntryAddress }
+    | { status: "international-manual-address-submitted", address: InternationalManualEntryAddress }
 
 export type AddressLookupStateListener = (state: AddressLookupState) => void;
 
@@ -54,24 +69,41 @@ export class AddressLookupStateMachine {
                 if (state.status !== "search") {
                     return undefined;
                 }
-
                 if (event.addresses.length === 1) {
-                    return { status: "confirmed", address: event.addresses[0] };
+                    const confirmedAddress = mapAddressSearchResult(event.addresses[0]);
+                    return { status: "confirmed", address: confirmedAddress };
                 } else {
                     return { status: "results", criteria: event.criteria, addresses: event.addresses };
                 }
+            
             case "address-selected":
                 if (state.status !== "results") {
                     return undefined;
                 }
-
-                return { status: "confirmed", address: event.address };
+                const confirmedAddress = mapAddressSearchResult(event.address);
+                return { status: "confirmed", address: confirmedAddress };
+            
             case "back-to-search-requested":
                 if (state.status === "search") {
                     return undefined;
                 }
-
                 return { status: "search", criteria: state.status === "results" ? state.criteria : undefined };
+            case "uk-manual-entry-requested":
+                return { status: "uk-manual-entry" }
+            case "international-manual-entry-requested":
+                return { status: "international-manual-entry" };
+            case "uk-manual-address-submitted":
+                if (state.status !== "uk-manual-entry") {
+                    return undefined;
+                }
+                const confirmedUkAddress = mapUkManualEntryAddress(event.address);
+                return { status: "confirmed", address: confirmedUkAddress };
+            // case "international-manual-address-submitted":
+            //     if (state.status !== "international-manual-entry") {
+            //         return undefined;
+            //     }
+            //     const confirmedInternationalAddress = mapInternationalManualEntryAddress(event.address);
+            //     return { status: "confirmed", address: confirmedInternationalAddress };
             default:
                 return undefined;
         }

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup-state-machine.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup-state-machine.ts
@@ -1,4 +1,4 @@
-import { mapAddressSearchResult, mapUkManualEntryAddress } from './address-result-mapper.js';
+import { mapAddressSearchResult, mapInternationalManualEntryAddress, mapUkManualEntryAddress } from './address-result-mapper.js';
 import type { AddressSearchCriteria, AddressSearchResult, ConfirmedAddress, InternationalManualEntryAddress, UkManualEntryAddress } from './types';
 
 export type AddressLookupState = 
@@ -98,12 +98,14 @@ export class AddressLookupStateMachine {
                 }
                 const confirmedUkAddress = mapUkManualEntryAddress(event.address);
                 return { status: "confirmed", address: confirmedUkAddress };
-            // case "international-manual-address-submitted":
-            //     if (state.status !== "international-manual-entry") {
-            //         return undefined;
-            //     }
-            //     const confirmedInternationalAddress = mapInternationalManualEntryAddress(event.address);
-            //     return { status: "confirmed", address: confirmedInternationalAddress };
+            case "international-manual-entry-requested":
+                return { status: "international-manual-entry" };
+            case "international-manual-address-submitted":
+                if (state.status !== "international-manual-entry") {
+                    return undefined;
+                }
+                const confirmedInternationalAddress = mapInternationalManualEntryAddress(event.address);
+                return { status: "confirmed", address: confirmedInternationalAddress };
             default:
                 return undefined;
         }

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup.ts
@@ -26,7 +26,8 @@ export function createAddressLookup(options: AddressLookupOptions){
                 container.appendChild(renderAddressSearch({
                     searchService: addressSearchService, 
                     onSearchSuccess: (results, criteria) => stateMachine.dispatch({ status: "search-succeeded", addresses: results, criteria: criteria }),
-                    criteria: state.criteria
+                    criteria: state.criteria,
+                    onInternationalEntryRequested: () => stateMachine.dispatch({ status: "international-manual-entry-requested" })
                 }));
                 break;
             case "results":
@@ -48,6 +49,7 @@ export function createAddressLookup(options: AddressLookupOptions){
                 }));
                 break;
             case "international-manual-entry":
+                break;
         }
     }
 }

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup.ts
@@ -5,6 +5,7 @@ import { AddressLookupState, AddressLookupStateMachine } from './address-lookup-
 import { renderAddressResults } from './address-results.js';
 import { renderAddressUkManualEntry } from './address-uk-manual-entry.js';
 import { renderConfirmedAddress } from './address-confirmed.js';
+import { renderAddressInternationalManualEntry } from './address-international-manual-entry.js';
 
 export function createAddressLookup(options: AddressLookupOptions){
     const container = document.createElement("div");
@@ -49,6 +50,11 @@ export function createAddressLookup(options: AddressLookupOptions){
                 }));
                 break;
             case "international-manual-entry":
+                container.appendChild(renderAddressInternationalManualEntry({
+                    onAddressSubmitted: (address) => stateMachine.dispatch({ status: "international-manual-address-submitted", address}),
+                    onBackToSearchRequested: () => stateMachine.dispatch({ status: "back-to-search-requested" }),
+                    countries: [{ value: 'FR', text: 'France' }]
+                }));
                 break;
         }
     }

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup.ts
@@ -3,7 +3,7 @@ import { FetchAddressSearchService } from './address-search-service.js';
 import { renderAddressSearch } from './address-search.js';
 import { AddressLookupState, AddressLookupStateMachine } from './address-lookup-state-machine.js';
 import { renderAddressResults } from './address-results.js';
-import { mapAddressSearchResult } from './address-result-mapper.js';
+import { renderAddressUkManualEntry } from './address-uk-manual-entry.js';
 import { renderConfirmedAddress } from './address-confirmed.js';
 
 export function createAddressLookup(options: AddressLookupOptions){
@@ -34,13 +34,21 @@ export function createAddressLookup(options: AddressLookupOptions){
                     addresses: state.addresses,
                     criteria: state.criteria,
                     onAddressSelected: (address) => stateMachine.dispatch({ status: "address-selected", address }),
-                    onBackToSearchRequested: () => stateMachine.dispatch({ status: "back-to-search-requested" })
+                    onBackToSearchRequested: () => stateMachine.dispatch({ status: "back-to-search-requested" }),
+                    onUkManualEntryRequested: () => stateMachine.dispatch({ status: "uk-manual-entry-requested" })
                 }));
                 break;
             case "confirmed":
-                const confirmedAddress = mapAddressSearchResult(state.address);
-                container.appendChild(renderConfirmedAddress(confirmedAddress, () => stateMachine.dispatch({ status: "back-to-search-requested" })));
+                container.appendChild(renderConfirmedAddress(state.address, () => stateMachine.dispatch({ status: "back-to-search-requested" })));
                 break;
+            case "uk-manual-entry":
+                container.appendChild(renderAddressUkManualEntry({
+                    onAddressSubmitted: (address) => stateMachine.dispatch({ status: "uk-manual-address-submitted", address}),
+                    onBackToSearchRequested: () => stateMachine.dispatch({ status: "back-to-search-requested" })
+                }));
+                break;
+            case "international-manual-entry":
         }
     }
 }
+

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-result-mapper.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-result-mapper.ts
@@ -89,6 +89,7 @@ export function mapInternationalManualEntryAddress(address: InternationalManualE
         postTown: address.postTown,
         postCounty: address.countyStateProvince ?? undefined,
         countryId: address.countryId ?? undefined,
+        countryName: address.countryName ?? undefined,
         postcode: address.postcode ?? undefined
     };
 }

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-result-mapper.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-result-mapper.ts
@@ -1,4 +1,4 @@
-import type { AddressSearchResult, ConfirmedAddress } from './types';
+import type { AddressSearchResult, ConfirmedAddress, UkManualEntryAddress } from './types';
 
 // const unitedKingdomCountryId = 'GB';
 // const unitedKingdomCountryName = 'United Kingdom';
@@ -63,10 +63,27 @@ export function mapAddressSearchResult(address: AddressSearchResult): ConfirmedA
         addressLine2: lines[1] ?? undefined,
         addressLine3: lines[2] ?? undefined,
         postTown: address.POST_TOWN?.trim() || undefined,
-        postCode: address.POSTCODE,
+        postcode: address.POSTCODE,
         uprnReference: address.UPRN ?? undefined
     };
 }
+
+export function mapUkManualEntryAddress(address: UkManualEntryAddress): ConfirmedAddress {
+    const confirmedAddress : ConfirmedAddress = {
+        addressLine1: address.addressLine1,
+        addressLine2: address.addressLine2 ?? undefined,
+        addressLine3: address.addressLine3 ?? undefined,
+        postTown: address.postTown,
+        postCounty: address.county ?? undefined,
+        postcode: address.postcode,
+    };
+
+    return confirmedAddress;
+}
+
+// export function mapInternationalManualEntryAddress(address: InternationalManualEntryAddress): ConfirmedAddress {
+    
+// }
 
 function pushStreetLine(lines: string[], buildingNumber: string, address: AddressSearchResult): void {
     const streetLine = buildStreetLine(buildingNumber, address);

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-result-mapper.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-result-mapper.ts
@@ -1,4 +1,4 @@
-import type { AddressSearchResult, ConfirmedAddress, UkManualEntryAddress } from './types';
+import type { AddressSearchResult, ConfirmedAddress, InternationalManualEntryAddress, UkManualEntryAddress } from './types';
 
 // const unitedKingdomCountryId = 'GB';
 // const unitedKingdomCountryName = 'United Kingdom';
@@ -81,9 +81,17 @@ export function mapUkManualEntryAddress(address: UkManualEntryAddress): Confirme
     return confirmedAddress;
 }
 
-// export function mapInternationalManualEntryAddress(address: InternationalManualEntryAddress): ConfirmedAddress {
-    
-// }
+export function mapInternationalManualEntryAddress(address: InternationalManualEntryAddress): ConfirmedAddress {
+    return {
+        addressLine1: address.addressLine1,
+        addressLine2: address.addressLine2 ?? undefined,
+        addressLine3: address.addressLine3 ?? undefined,
+        postTown: address.postTown,
+        postCounty: address.countyStateProvince ?? undefined,
+        countryId: address.countryId ?? undefined,
+        postcode: address.postcode ?? undefined
+    };
+}
 
 function pushStreetLine(lines: string[], buildingNumber: string, address: AddressSearchResult): void {
     const streetLine = buildStreetLine(buildingNumber, address);

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-results.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-results.ts
@@ -40,8 +40,15 @@ export function renderAddressResults(options: AddressResultsOptions): HTMLElemen
     backToSearchLink.addEventListener("click", handleBackToSearch);
 
     const nav = document.createElement("nav");
-    nav.appendChild(backToSearchLink);
-    nav.appendChild(ukManualEntryLink);
+    const ul = document.createElement("ul");
+    ul.classList = "govuk-list";
+    const backToSearchLi = document.createElement("li");
+    backToSearchLi.appendChild(backToSearchLink);
+    const ukManualEntryLi = document.createElement("li");
+    ukManualEntryLi.appendChild(ukManualEntryLink);
+    ul.appendChild(backToSearchLi);
+    ul.appendChild(ukManualEntryLi);
+    nav.appendChild(ul);
     addressResultsWrapper.appendChild(selectFormGroup);
     addressResultsWrapper.appendChild(button);
     addressResultsWrapper.appendChild(nav);

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-results.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-results.ts
@@ -9,6 +9,7 @@ export type AddressResultsOptions = {
     criteria: AddressSearchCriteria;
     onAddressSelected: (address: AddressSearchResult) => void;
     onBackToSearchRequested: () => void;
+    onUkManualEntryRequested: () => void;
 }
 
 export function renderAddressResults(options: AddressResultsOptions): HTMLElement {
@@ -32,11 +33,15 @@ export function renderAddressResults(options: AddressResultsOptions): HTMLElemen
     const button = createButton({labelText: "Confirm address", variant: "secondary", type: "button"});
     button.addEventListener("click", handleAddressSelect);
 
+    const ukManualEntryLink = createLink({labelText: "Enter address not on list"});
+    ukManualEntryLink.addEventListener("click", handleUkManualEntry);
+
     const backToSearchLink = createLink({labelText: "Return to postcode search"});
     backToSearchLink.addEventListener("click", handleBackToSearch);
 
     const nav = document.createElement("nav");
     nav.appendChild(backToSearchLink);
+    nav.appendChild(ukManualEntryLink);
     addressResultsWrapper.appendChild(selectFormGroup);
     addressResultsWrapper.appendChild(button);
     addressResultsWrapper.appendChild(nav);
@@ -59,5 +64,10 @@ export function renderAddressResults(options: AddressResultsOptions): HTMLElemen
     function handleBackToSearch(event: Event): void {
         event.preventDefault();
         options.onBackToSearchRequested();
+    }
+
+    function handleUkManualEntry(event: Event): void {
+        event.preventDefault();
+        options.onUkManualEntryRequested();
     }
 }

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-search.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-search.ts
@@ -13,6 +13,7 @@ import { validatePostcode } from "./postcode-validator.js";
 import { filterAddressesByBuilding } from "./address-filter.js";
 import { clearFormGroupError, showFormGroupError } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/validation.js";
 import type { AddressSearchCriteria, AddressSearchOptions } from "./types.js";
+import { createLink } from "/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/link.js";
 
 export function renderAddressSearch(options: AddressSearchOptions): HTMLElement {
     const addressSearchWrapper = document.createElement("div");
@@ -46,6 +47,10 @@ export function renderAddressSearch(options: AddressSearchOptions): HTMLElement 
     findAddressButton.addEventListener("click", handleAddressSearch);
     addressSearchWrapper.appendChild(findAddressButton);
 
+    const internationalEntryLink = createLink({labelText: "Enter an international address"});
+    internationalEntryLink.addEventListener("click", handleOnInternationalEntryClicked);
+    addressSearchWrapper.appendChild(internationalEntryLink);
+
     return addressSearchWrapper;
     
     async function handleAddressSearch(): Promise<void> {
@@ -77,6 +82,11 @@ export function renderAddressSearch(options: AddressSearchOptions): HTMLElement 
              findAddressButton.disabled = false;
         }
     } 
+
+    function handleOnInternationalEntryClicked(event: Event): void{
+        event.preventDefault();
+        options.onInternationalEntryRequested();
+    }
 }
 
 type CriteriaValidationResult =

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-search.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-search.ts
@@ -47,9 +47,14 @@ export function renderAddressSearch(options: AddressSearchOptions): HTMLElement 
     findAddressButton.addEventListener("click", handleAddressSearch);
     addressSearchWrapper.appendChild(findAddressButton);
 
+    
     const internationalEntryLink = createLink({labelText: "Enter an international address"});
     internationalEntryLink.addEventListener("click", handleOnInternationalEntryClicked);
-    addressSearchWrapper.appendChild(internationalEntryLink);
+    
+    const nav = document.createElement("nav");
+    nav.appendChild(internationalEntryLink);
+    
+    addressSearchWrapper.appendChild(nav);
 
     return addressSearchWrapper;
     

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-uk-manual-entry.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-uk-manual-entry.ts
@@ -8,7 +8,7 @@ import { createTextInputFormGroup } from '/ThePensionsRegulator.GovUk.Frontend/j
 import { createLink } from '/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/link.js';
 import { clearFormGroupError, showFormGroupError } from '/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/validation.js';
 
-export interface AddressUkManualEntryOptions{
+export interface AddressUkManualEntryOptions {
     onAddressSubmitted: (address: UkManualEntryAddress) => void;
     onBackToSearchRequested: () => void;
 }
@@ -45,7 +45,7 @@ export function renderAddressUkManualEntry(options: AddressUkManualEntryOptions)
         event.preventDefault();
         const formGroupsByField: Record<keyof UkManualEntryValues, HTMLElement> = { addressLine1, addressLine2, addressLine3, townOrCity, county, postcode };
         Object.values(formGroupsByField).forEach(clearFormGroupError);
-        var validationResult = validateUkManualEntryAddress(readValues(addressLine1, addressLine2, addressLine3, townOrCity, county, postcode));
+        const validationResult = validateUkManualEntryAddress(readValues(addressLine1, addressLine2, addressLine3, townOrCity, county, postcode));
         if (!validationResult.isValid) {
             validationResult.errorMessages.forEach(({ fieldName, message }) => showFormGroupError(formGroupsByField[fieldName], message));
             return;

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-uk-manual-entry.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/address-uk-manual-entry.ts
@@ -1,0 +1,137 @@
+import { normalisePostcode } from './postcode-normaliser.js';
+import { sanitisePostcode } from './postcode-sanitiser.js';
+import { validatePostcode } from './postcode-validator.js';
+import type { UkManualEntryAddress } from './types.js';
+import { createButton } from '/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/button.js';
+import { createFieldset } from '/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/fieldset.js';
+import { createTextInputFormGroup } from '/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/inputs.js';
+import { createLink } from '/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/link.js';
+import { clearFormGroupError, showFormGroupError } from '/ThePensionsRegulator.GovUk.Frontend/js/govuk-components/validation.js';
+
+export interface AddressUkManualEntryOptions{
+    onAddressSubmitted: (address: UkManualEntryAddress) => void;
+    onBackToSearchRequested: () => void;
+}
+
+export function renderAddressUkManualEntry(options: AddressUkManualEntryOptions): HTMLElement {    
+    const div = document.createElement('div');
+    const addressLine1 = createTextInputFormGroup({ labelText: 'Address line 1', input: { id: 'address-line-1', name: 'address-line-1', type: "text", width: "x-large" } });
+    const addressLine2 = createTextInputFormGroup({ labelText: 'Address line 2 (optional)', input: { id: 'address-line-2', name: 'address-line-2', type: "text", width: "x-large" } });
+    const addressLine3 = createTextInputFormGroup({ labelText: 'Address line 3 (optional)', input: { id: 'address-line-3', name: 'address-line-3', type: "text", width: "x-large" } });
+    const townOrCity = createTextInputFormGroup({ labelText: 'Town or city', input: { id: 'town-or-city', name: 'town-or-city', type: "text", width: "large" } });
+    const county = createTextInputFormGroup({ labelText: 'County (optional)', input: { id: 'county', name: 'county', type: "text", width: "large" } });
+    const postcode = createTextInputFormGroup({ labelText: 'Postcode', input: { id: 'postcode', name: 'postcode', type: "text", width: "medium" } });
+
+    const fieldset = createFieldset({ legendText: 'Enter new Uk address', children: [addressLine1, addressLine2, addressLine3, townOrCity, county, postcode] });
+
+    div.appendChild(fieldset);
+
+    const confirmButton = createButton({ labelText: 'Confirm address', type: 'submit', variant: 'secondary' });
+    confirmButton.addEventListener("click", handleConfirmAddress);
+    div.appendChild(confirmButton);
+
+    const backToSearch = createLink({ labelText: "Back to postcode search"});
+    backToSearch.addEventListener("click", handleBackToSearch);
+    div.appendChild(backToSearch);
+
+    function handleBackToSearch(event: Event): void {
+        event.preventDefault();
+        options.onBackToSearchRequested();
+    }
+
+    return div;
+    
+    function handleConfirmAddress(event: Event) {
+        event.preventDefault();
+        const formGroupsByField: Record<keyof UkManualEntryValues, HTMLElement> = { addressLine1, addressLine2, addressLine3, townOrCity, county, postcode };
+        Object.values(formGroupsByField).forEach(clearFormGroupError);
+        var validationResult = validateUkManualEntryAddress(readValues(addressLine1, addressLine2, addressLine3, townOrCity, county, postcode));
+        if (!validationResult.isValid) {
+            validationResult.errorMessages.forEach(({ fieldName, message }) => showFormGroupError(formGroupsByField[fieldName], message));
+            return;
+        }
+        
+        options.onAddressSubmitted(validationResult.address);
+    }
+}
+
+type FieldRuleSet = { fieldName: keyof UkManualEntryValues, validators: Array<{ message: string; isValid: () => boolean }>};
+type ErrorMessage = { fieldName: keyof UkManualEntryValues, message: string };
+type UkManualEntryValidationResult =
+    | { isValid: true; address: UkManualEntryAddress }
+    | { isValid: false; errorMessages: ErrorMessage[] };
+
+export function validateUkManualEntryAddress(values: UkManualEntryValues): UkManualEntryValidationResult {
+
+    const fieldRuleSets: FieldRuleSet[] = [
+        { fieldName: 'addressLine1', validators: [ 
+            { message: 'Address line 1 is required', isValid: () => values.addressLine1.trim() !== '' },
+            { message: 'Address line 1 must be 100 characters or fewer', isValid: () => values.addressLine1.trim().length <= 100 } 
+        ]},
+        { fieldName: 'addressLine2', validators: [ { message: 'Address line 2 must be 100 characters or fewer', isValid: () => values.addressLine2.trim().length <= 100 }] },
+        { fieldName: 'addressLine3', validators: [ { message: 'Address line 3 must be 100 characters or fewer', isValid: () => values.addressLine3.trim().length <= 100 }] },
+        { fieldName: 'townOrCity', validators: [ 
+            { message: 'Enter a post town', isValid: () => values.townOrCity.trim() !== '' },
+            { message: 'Town or city is required', isValid: () => values.townOrCity.trim() !== '' }, { message: 'Town or city must be 100 characters or fewer', isValid: () => values.townOrCity.trim().length <= 100 }
+        ]},
+        { fieldName: 'county', validators: [ { message: 'County must be 100 characters or fewer', isValid: () => values.county.trim().length <= 100 }] },
+        { fieldName: 'postcode', validators: [ 
+            { message: 'Enter a postcode', isValid: () => values.postcode.trim() !== '' },
+            { message: 'Enter a real postcode', isValid: () => validatePostcode(values.postcode).isValid },
+            { message: 'Postcode must be 10 characters or fewer', isValid: () => values.postcode.trim().length <= 10 }
+        ]}
+    ];
+
+    const errorMessages = fieldRuleSets
+        .map(({ fieldName, validators }) => {
+            const firstFailure = validators.find( v => !v.isValid()); // Run the validators foreach form group until one fails
+            return firstFailure ? { fieldName: fieldName, message: firstFailure.message } : null;
+        })
+        .filter(x => x != null);
+    
+
+    if (errorMessages.length > 0) {
+        return { isValid: false, errorMessages };
+    }
+
+    return {
+        isValid: true,
+        address: {
+            addressLine1: values.addressLine1,
+            addressLine2: values.addressLine2,
+            addressLine3: values.addressLine3,
+            postTown: values.townOrCity,
+            county: values.county,
+            postcode: values.postcode
+        }
+    };
+}
+
+type UkManualEntryValues = {
+    addressLine1: string;
+    addressLine2: string;
+    addressLine3: string;
+    townOrCity: string;
+    county: string;
+    postcode: string;
+}
+
+function readValues(addressLine1: HTMLElement, addressLine2: HTMLElement, addressLine3: HTMLElement, townOrCity: HTMLElement, county: HTMLElement, postcode: HTMLElement): UkManualEntryValues {
+    const addressLine1Value = (addressLine1.querySelector('input') as HTMLInputElement).value;
+    const addressLine2Value = (addressLine2.querySelector('input') as HTMLInputElement).value;
+    const addressLine3Value = (addressLine3.querySelector('input') as HTMLInputElement).value;
+    const townOrCityValue = (townOrCity.querySelector('input') as HTMLInputElement).value;
+    const countyValue = (county.querySelector('input') as HTMLInputElement).value;
+    const postcodeValue = (postcode.querySelector('input') as HTMLInputElement).value;
+    const sanitisedPostcode = sanitisePostcode(postcodeValue);
+    const normalisedPostcode = normalisePostcode(sanitisedPostcode);
+
+    return {
+        addressLine1: addressLine1Value,
+        addressLine2: addressLine2Value,
+        addressLine3: addressLine3Value,
+        townOrCity: townOrCityValue,
+        county: countyValue,
+        postcode: normalisedPostcode
+    };
+}

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/types.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/types.ts
@@ -77,6 +77,7 @@ export interface InternationalManualEntryAddress {
     postTown: string;
     countyStateProvince?: string;
     countryId?: string;
+    countryName?: string;
     postcode?: string;
 }
 

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/types.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/types.ts
@@ -17,6 +17,7 @@ export interface AddressSearchOptions {
     searchService: AddressSearchService;
     criteria?: AddressSearchCriteria;
     onSearchSuccess: (results: AddressSearchResult[], criteria: AddressSearchCriteria) => void;
+    onInternationalEntryRequested: () => void;
 }
 
 /** A Delivery Point Address as returned by the Ordnance Survey Places API. */
@@ -70,7 +71,13 @@ export interface UkManualEntryAddress {
 }
 
 export interface InternationalManualEntryAddress {
-
+    addressLine1: string;
+    addressLine2?: string;
+    addressLine3?: string;
+    postTown: string;
+    countyStateProvince?: string;
+    countryId?: string;
+    postcode?: string;
 }
 
 export interface ConfirmedAddress {

--- a/ThePensionsRegulator.Frontend/Scripts/address-lookup/types.ts
+++ b/ThePensionsRegulator.Frontend/Scripts/address-lookup/types.ts
@@ -60,6 +60,19 @@ export interface FetchAddressSearchServiceOptions{
     fetchFunction?: typeof globalThis.fetch;
 }
 
+export interface UkManualEntryAddress {
+    addressLine1: string;
+    addressLine2?: string;
+    addressLine3?: string;
+    postTown: string;
+    county?: string
+    postcode: string;
+}
+
+export interface InternationalManualEntryAddress {
+
+}
+
 export interface ConfirmedAddress {
     addressLine1: string;
     addressLine2?: string;
@@ -68,6 +81,6 @@ export interface ConfirmedAddress {
     postCounty?: string;
     countryId?: string;
     countryName?: string;
-    postCode?: string;
+    postcode?: string;
     uprnReference?: string;
 }

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-confirmed.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-confirmed.tests.ts
@@ -11,7 +11,7 @@ describe("renderConfirmedAddress", () => {
         postTown: "London",
         postCounty: "Greater London",
         countryId: "GB",
-        postCode: "SW1A 2AA",
+        postcode: "SW1A 2AA",
         uprnReference: "100000000001"
     };
 
@@ -27,7 +27,7 @@ describe("renderConfirmedAddress", () => {
     it("should omit optional fields without adding blank lines", () => {
         const address: ConfirmedAddress = {
             addressLine1: "10 High Street",
-            postCode: "SW1A 2AA",
+            postcode: "SW1A 2AA",
             uprnReference: "100000000001"
         };
 
@@ -46,7 +46,7 @@ describe("renderConfirmedAddress", () => {
             postTown: "Paris",
             countryId,
             countryName,
-            postCode: "75001",
+            postcode: "75001",
             uprnReference: ""
         };
 
@@ -61,15 +61,15 @@ describe("renderConfirmedAddress", () => {
 
     it("should create hidden inputs with the confirmed address field IDs", () => {
         const component = renderConfirmedAddress(completeAddress, jest.fn());
-        const expectedValues = {
-            AddressLine1: "10 High Street",
-            AddressLine2: "Flat 2",
-            AddressLine3: "West End",
-            PostTown: "London",
-            PostCounty: "Greater London",
-            CountryId: "GB",
-            PostCode: "SW1A 2AA",
-            UPRNReference: "100000000001"
+        const expectedValues : ConfirmedAddress = {
+            addressLine1: "10 High Street",
+            addressLine2: "Flat 2",
+            addressLine3: "West End",
+            postTown: "London",
+            postCounty: "Greater London",
+            countryId: "GB",
+            postcode: "SW1A 2AA",
+            uprnReference: "100000000001"
         };
 
         for (const [id, value] of Object.entries(expectedValues)) {
@@ -82,17 +82,17 @@ describe("renderConfirmedAddress", () => {
     it("should omit hidden inputs for absent optional values", () => {
         const address: ConfirmedAddress = {
             addressLine1: "10 High Street",
-            postCode: "SW1A 2AA",
+            postcode: "SW1A 2AA",
             uprnReference: "100000000001"
         };
 
         const component = renderConfirmedAddress(address, jest.fn());
 
-        expect(component.querySelector("#AddressLine2")).toBeNull();
-        expect(component.querySelector("#AddressLine3")).toBeNull();
-        expect(component.querySelector("#PostTown")).toBeNull();
-        expect(component.querySelector("#PostCounty")).toBeNull();
-        expect(component.querySelector("#CountryId")).toBeNull();
+        expect(component.querySelector("#addressLine2")).toBeNull();
+        expect(component.querySelector("#addressLine3")).toBeNull();
+        expect(component.querySelector("#postTown")).toBeNull();
+        expect(component.querySelector("#postCounty")).toBeNull();
+        expect(component.querySelector("#countryId")).toBeNull();
     });
 
     it("should report when the change address link is clicked", () => {

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-international-manual-entry.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-international-manual-entry.tests.ts
@@ -1,0 +1,172 @@
+import "@testing-library/jest-dom";
+import { jest } from "@jest/globals";
+import { renderAddressInternationalManualEntry, validateInternationalUkManualEntryAddress } from "../../Scripts/address-lookup/address-international-manual-entry.js";
+
+const countries = [
+	{ value: "FR", text: "France" },
+	{ value: "US", text: "United States" }
+];
+
+function createValidValues(overrides: Partial<Parameters<typeof validateInternationalUkManualEntryAddress>[0]> = {}) {
+	return {
+		addressLine1: "123 Rue de Rivoli",
+		addressLine2: "",
+		addressLine3: "",
+		postTown: "Paris",
+		countyStateProvince: "",
+		countryId: "FR",
+		countryName: "France",
+		postcode: "75001",
+		...overrides
+	};
+}
+
+describe("renderAddressInternationalManualEntry", () => {
+	function createComponent() {
+		const onAddressSubmitted = jest.fn();
+		const onBackToSearchRequested = jest.fn();
+		const component = renderAddressInternationalManualEntry({ onAddressSubmitted, onBackToSearchRequested, countries });
+
+		return { component, onAddressSubmitted, onBackToSearchRequested };
+	}
+
+	it("renders the international entry fields, country options, and secondary actions", () => {
+		const { component } = createComponent();
+		const country = component.querySelector<HTMLSelectElement>("#country");
+		const confirmButton = component.querySelector<HTMLButtonElement>("button");
+		const backLink = component.querySelector<HTMLAnchorElement>("nav a");
+
+		expect(component.querySelector("#address-line-1")).toHaveClass("govuk-input", "govuk-input--width-20");
+		expect(component.querySelector("#address-line-2")).toHaveClass("govuk-input", "govuk-input--width-20");
+		expect(component.querySelector("#address-line-3")).toHaveClass("govuk-input", "govuk-input--width-20");
+		expect(component.querySelector("#post-town")).toHaveClass("govuk-input", "govuk-input--width-20");
+		expect(component.querySelector("#county-state-province")).toHaveClass("govuk-input", "govuk-input--width-20");
+		expect(component.querySelector("#postcode")).toHaveClass("govuk-input", "govuk-input--width-20");
+		expect(country).toHaveClass("govuk-select", "govuk-input--width-20");
+		expect(Array.from(country!.options).map(option => [option.value, option.text])).toEqual([
+			["", "Select a country"],
+			["FR", "France"],
+			["US", "United States"]
+		]);
+		expect(confirmButton).toHaveTextContent("Confirm address");
+		expect(confirmButton).toHaveClass("govuk-button", "govuk-button--secondary");
+		expect(backLink).toHaveTextContent("Back to postcode search");
+	});
+
+	it("submits the selected country ID and name with a valid international address", () => {
+		const { component, onAddressSubmitted } = createComponent();
+		const addressLine1 = component.querySelector<HTMLInputElement>("#address-line-1");
+		const postTown = component.querySelector<HTMLInputElement>("#post-town");
+		const country = component.querySelector<HTMLSelectElement>("#country");
+		const confirmButton = component.querySelector<HTMLButtonElement>("button");
+
+		addressLine1!.value = "123 Rue de Rivoli";
+		postTown!.value = "Paris";
+		country!.value = "FR";
+
+		confirmButton!.click();
+
+		expect(onAddressSubmitted).toHaveBeenCalledWith({
+			addressLine1: "123 Rue de Rivoli",
+			addressLine2: "",
+			addressLine3: "",
+			postTown: "Paris",
+			countyStateProvince: "",
+			countryId: "FR",
+			countryName: "France",
+			postcode: ""
+		});
+	});
+
+	it("shows errors for invalid fields and does not submit", () => {
+		const { component, onAddressSubmitted } = createComponent();
+		const addressLine1 = component.querySelector<HTMLInputElement>("#address-line-1");
+		const postTown = component.querySelector<HTMLInputElement>("#post-town");
+		const country = component.querySelector<HTMLSelectElement>("#country");
+
+		component.querySelector<HTMLButtonElement>("button")!.click();
+
+		expect(onAddressSubmitted).not.toHaveBeenCalled();
+		expect(addressLine1).toHaveAttribute("aria-describedby", expect.stringContaining("address-line-1-error"));
+		expect(postTown).toHaveAttribute("aria-describedby", expect.stringContaining("post-town-error"));
+		expect(country).toHaveAttribute("aria-describedby", expect.stringContaining("country-error"));
+		expect(component.querySelector("#address-line-1-error")).toHaveClass("govuk-error-message");
+		expect(component.querySelector("#post-town-error")).toHaveClass("govuk-error-message");
+		expect(component.querySelector("#country-error")).toHaveClass("govuk-error-message");
+	});
+
+	it("clears validation errors when corrected values are confirmed", () => {
+		const { component, onAddressSubmitted } = createComponent();
+		const addressLine1 = component.querySelector<HTMLInputElement>("#address-line-1");
+		const postTown = component.querySelector<HTMLInputElement>("#post-town");
+		const country = component.querySelector<HTMLSelectElement>("#country");
+		const confirmButton = component.querySelector<HTMLButtonElement>("button");
+
+		confirmButton!.click();
+		addressLine1!.value = "123 Rue de Rivoli";
+		postTown!.value = "Paris";
+		country!.value = "FR";
+		confirmButton!.click();
+
+		expect(onAddressSubmitted).toHaveBeenCalledTimes(1);
+		expect(component.querySelector("#address-line-1-error")).toBeNull();
+		expect(component.querySelector("#post-town-error")).toBeNull();
+		expect(component.querySelector("#country-error")).toBeNull();
+	});
+
+	it("calls the back-to-search handler without navigating", () => {
+		const { component, onBackToSearchRequested } = createComponent();
+		const clickEvent = new MouseEvent("click", { cancelable: true });
+
+		component.querySelector<HTMLAnchorElement>("nav a")!.dispatchEvent(clickEvent);
+
+		expect(clickEvent.defaultPrevented).toBe(true);
+		expect(onBackToSearchRequested).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("validateInternationalUkManualEntryAddress", () => {
+	it("returns an international address when required fields are valid", () => {
+		expect(validateInternationalUkManualEntryAddress(createValidValues())).toEqual({
+			isValid: true,
+			address: createValidValues()
+		});
+	});
+
+	it.each([
+		["addressLine1", { addressLine1: "" }],
+		["addressLine1", { addressLine1: "a".repeat(101) }],
+		["addressLine2", { addressLine2: "a".repeat(101) }],
+		["addressLine3", { addressLine3: "a".repeat(101) }],
+		["postTown", { postTown: "" }],
+		["postTown", { postTown: "a".repeat(101) }],
+		["countyStateProvince", { countyStateProvince: "a".repeat(101) }],
+		["countryId", { countryId: "" }],
+		["postcode", { postcode: "a".repeat(11) }]
+	] as const)("returns one error for an invalid %s value", (fieldName, overrides) => {
+		const result = validateInternationalUkManualEntryAddress(createValidValues(overrides));
+
+		expect(result.isValid).toBe(false);
+		if (!result.isValid) {
+			expect(result.errorMessages).toHaveLength(1);
+			expect(result.errorMessages[0].fieldName).toBe(fieldName);
+		}
+	});
+
+	it("returns one error per invalid field in form order", () => {
+		const result = validateInternationalUkManualEntryAddress(createValidValues({
+			addressLine1: "",
+			postTown: "",
+			countryId: ""
+		}));
+
+		expect(result).toEqual({
+			isValid: false,
+			errorMessages: expect.arrayContaining([
+				expect.objectContaining({ fieldName: "addressLine1" }),
+				expect.objectContaining({ fieldName: "postTown" }),
+				expect.objectContaining({ fieldName: "countryId" })
+			])
+		});
+	});
+});

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup-state-machine.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup-state-machine.tests.ts
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 import { AddressLookupStateMachine, type AddressLookupEvent, type AddressLookupState } from "../../Scripts/address-lookup/address-lookup-state-machine";
-import { mapAddressSearchResult } from "../../Scripts/address-lookup/address-result-mapper";
-import type { AddressSearchCriteria, AddressSearchResult, UkManualEntryAddress } from "../../Scripts/address-lookup/types";
+import { mapAddressSearchResult, mapInternationalManualEntryAddress } from "../../Scripts/address-lookup/address-result-mapper";
+import type { AddressSearchCriteria, AddressSearchResult, InternationalManualEntryAddress, UkManualEntryAddress } from "../../Scripts/address-lookup/types";
 
 describe("AddressLookupStateMachine", () => {
     const criteria: AddressSearchCriteria = { buildingName: "1", postcode: "SW1A 2AA" };
@@ -16,6 +16,13 @@ describe("AddressLookupStateMachine", () => {
         addressLine2: "1 High Street",
         postTown: "London",
         county: "Greater London",
+        postcode: "SW1A 1AA"
+    };
+    const internationalAddress: InternationalManualEntryAddress = {
+        addressLine1: "Flat 2",
+        addressLine2: "1 High Street",
+        postTown: "London",
+        countryId: "1",
         postcode: "SW1A 1AA"
     };
 
@@ -70,6 +77,37 @@ describe("AddressLookupStateMachine", () => {
         stateMachine.dispatch({ status: "address-selected", address: addressTwo });
 
         expect(stateMachine.getState()).toEqual({ status: "confirmed", address: mapAddressSearchResult(addressTwo) });
+    });
+
+    it("should move to the international entry state when requested", () => {
+        const stateMachine = new AddressLookupStateMachine();
+        stateMachine.dispatch({ status: "international-manual-entry-requested" });
+
+        expect(stateMachine.getState()).toEqual({ status: "international-manual-entry" });
+    });
+
+    it("should move to the confirmed view when an international address is submitted", () => {
+        const stateMachine = new AddressLookupStateMachine();
+        stateMachine.dispatch({ status: "international-manual-entry-requested" });
+
+        stateMachine.dispatch({ status: "international-manual-address-submitted", address: internationalAddress });
+
+        expect(stateMachine.getState()).toEqual({
+            status: "confirmed",
+            address: mapInternationalManualEntryAddress(internationalAddress)
+        });
+    });
+
+    it("should reject international-manual-address-submitted when not in the international entry state", () => {
+        const stateMachine = new AddressLookupStateMachine();
+        const listener = jest.fn<(state: AddressLookupState) => void>();
+        stateMachine.subscribe(listener);
+
+        stateMachine.dispatch({ status: "back-to-search-requested" });
+        stateMachine.dispatch({ status: "international-manual-address-submitted", address: internationalAddress });
+
+        expect(stateMachine.getState()).toEqual({ status: "search" });
+        expect(listener).not.toHaveBeenCalled();
     });
 
     it("should map a submitted UK manual address and move to the confirmed state", () => {

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup-state-machine.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup-state-machine.tests.ts
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import { AddressLookupStateMachine, type AddressLookupEvent, type AddressLookupState } from "../../Scripts/address-lookup/address-lookup-state-machine";
-import type { AddressSearchCriteria, AddressSearchResult } from "../../Scripts/address-lookup/types";
+import { mapAddressSearchResult } from "../../Scripts/address-lookup/address-result-mapper";
+import type { AddressSearchCriteria, AddressSearchResult, UkManualEntryAddress } from "../../Scripts/address-lookup/types";
 
 describe("AddressLookupStateMachine", () => {
     const criteria: AddressSearchCriteria = { buildingName: "1", postcode: "SW1A 2AA" };
@@ -9,6 +10,13 @@ describe("AddressLookupStateMachine", () => {
     };
     const addressTwo: AddressSearchResult = {
         UPRN: "2", UDPRN: "2", ADDRESS: "2 High Street", POST_TOWN: "London", POSTCODE: "SW1A 2AA"
+    };
+    const manualUkAddress: UkManualEntryAddress = {
+        addressLine1: "Flat 2",
+        addressLine2: "1 High Street",
+        postTown: "London",
+        county: "Greater London",
+        postcode: "SW1A 1AA"
     };
 
     it("should start in the search state", () => {
@@ -30,7 +38,7 @@ describe("AddressLookupStateMachine", () => {
 
         stateMachine.dispatch({ status: "search-succeeded", criteria, addresses: [addressOne] });
 
-        expect(stateMachine.getState()).toEqual({ status: "confirmed", address: addressOne });
+        expect(stateMachine.getState()).toEqual({ status: "confirmed", address: mapAddressSearchResult(addressOne) });
     });
 
     it("should reject search-succeeded when not in the search state", () => {
@@ -61,7 +69,25 @@ describe("AddressLookupStateMachine", () => {
 
         stateMachine.dispatch({ status: "address-selected", address: addressTwo });
 
-        expect(stateMachine.getState()).toEqual({ status: "confirmed", address: addressTwo });
+        expect(stateMachine.getState()).toEqual({ status: "confirmed", address: mapAddressSearchResult(addressTwo) });
+    });
+
+    it("should map a submitted UK manual address and move to the confirmed state", () => {
+        const stateMachine = new AddressLookupStateMachine();
+        stateMachine.dispatch({ status: "uk-manual-entry-requested" });
+
+        stateMachine.dispatch({ status: "uk-manual-address-submitted", address: manualUkAddress });
+
+        expect(stateMachine.getState()).toEqual({
+            status: "confirmed",
+            address: {
+                addressLine1: "Flat 2",
+                addressLine2: "1 High Street",
+                postTown: "London",
+                postCounty: "Greater London",
+                postcode: "SW1A 1AA"
+            }
+        });
     });
 
     it("should reject address-selected when not in the results state", () => {

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup.tests.ts
@@ -153,4 +153,18 @@ describe("createAddressLookup", () => {
         expect(component.querySelector<HTMLInputElement>("#building")).toHaveValue("1");
         expect(component.querySelector<HTMLInputElement>("#postcode")).toHaveValue("SW1A 2AA");
     });
+
+    it("should confirm an international address with its country name and ID", () => {
+        const component = createAddressLookup({ searchEndpoint: "/api/address-search", addressByIdEndpoint: "/api/address" });
+
+        component.querySelector<HTMLAnchorElement>("nav a")!.click();
+
+        component.querySelector<HTMLInputElement>("#address-line-1")!.value = "123 Rue de Rivoli";
+        component.querySelector<HTMLInputElement>("#post-town")!.value = "Paris";
+        component.querySelector<HTMLSelectElement>("#country")!.value = "FR";
+        component.querySelector<HTMLButtonElement>("button")!.click();
+
+        expect(component.querySelector("p")).toHaveTextContent("France");
+        expect(component.querySelector<HTMLInputElement>("#countryId")).toHaveValue("FR");
+    });
 });

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-lookup.tests.ts
@@ -112,9 +112,9 @@ describe("createAddressLookup", () => {
         component.querySelector<HTMLButtonElement>("button")!.click();
 
         expect(component.querySelector("p")).toHaveTextContent("2 High StreetLondonSW1A 2AA");
-        expect(component.querySelector<HTMLInputElement>("#AddressLine1")).toHaveValue("2 High Street");
-        expect(component.querySelector<HTMLInputElement>("#PostCode")).toHaveValue("SW1A 2AA");
-        expect(component.querySelector<HTMLInputElement>("#UPRNReference")).toHaveValue("2");
+        expect(component.querySelector<HTMLInputElement>("#addressLine1")).toHaveValue("2 High Street");
+        expect(component.querySelector<HTMLInputElement>("#postcode")).toHaveValue("SW1A 2AA");
+        expect(component.querySelector<HTMLInputElement>("#uprnReference")).toHaveValue("2");
     });
 
     it("should render the confirmed view when a single address is found", async () => {
@@ -130,9 +130,9 @@ describe("createAddressLookup", () => {
         await flushPromises();
 
         expect(component.querySelector("p")).toHaveTextContent("1 High StreetLondonSW1A 2AA");
-        expect(component.querySelector<HTMLInputElement>("#AddressLine1")).toHaveValue("1 High Street");
-        expect(component.querySelector<HTMLInputElement>("#PostCode")).toHaveValue("SW1A 2AA");
-        expect(component.querySelector<HTMLInputElement>("#UPRNReference")).toHaveValue("1");
+        expect(component.querySelector<HTMLInputElement>("#addressLine1")).toHaveValue("1 High Street");
+        expect(component.querySelector<HTMLInputElement>("#postcode")).toHaveValue("SW1A 2AA");
+        expect(component.querySelector<HTMLInputElement>("#uprnReference")).toHaveValue("1");
     });
 
     it("should return to a pre-filled search form when back-to-search is requested", async () => {

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-result-mapper.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-result-mapper.tests.ts
@@ -1,5 +1,5 @@
-import { mapAddressSearchResult } from "../../Scripts/address-lookup/address-result-mapper";
-import type { AddressSearchResult, ConfirmedAddress } from "../../Scripts/address-lookup/types";
+import { mapAddressSearchResult, mapInternationalManualEntryAddress } from "../../Scripts/address-lookup/address-result-mapper";
+import type { AddressSearchResult, ConfirmedAddress, InternationalManualEntryAddress } from "../../Scripts/address-lookup/types";
 
 describe("mapAddressSearchResult", () => {
 	const baseAddress: AddressSearchResult = {
@@ -105,5 +105,46 @@ describe("mapAddressSearchResult", () => {
 		expect(mappedAddress).not.toHaveProperty("postCounty");
 		expect(mappedAddress).not.toHaveProperty("countryId");
 		expect(mappedAddress).not.toHaveProperty("countryName");
+	});
+});
+
+describe("mapInternationalManualEntryAddress", () => {
+	it("should map all international manual-entry fields to a confirmed address", () => {
+		const address: InternationalManualEntryAddress = {
+			addressLine1: "123 Rue de Rivoli",
+			addressLine2: "Apartment 4B",
+			addressLine3: "3rd arrondissement",
+			postTown: "Paris",
+			countyStateProvince: "Ile-de-France",
+			countryId: "FR",
+			postcode: "75001"
+		};
+
+		expect(mapInternationalManualEntryAddress(address)).toEqual({
+			addressLine1: "123 Rue de Rivoli",
+			addressLine2: "Apartment 4B",
+			addressLine3: "3rd arrondissement",
+			postTown: "Paris",
+			postCounty: "Ile-de-France",
+			countryId: "FR",
+			postcode: "75001"
+		});
+	});
+
+	it("should omit optional international manual-entry fields when they are not supplied", () => {
+		const address: InternationalManualEntryAddress = {
+			addressLine1: "123 Main Street",
+			postTown: "New York"
+		};
+
+		expect(mapInternationalManualEntryAddress(address)).toEqual({
+			addressLine1: "123 Main Street",
+			addressLine2: undefined,
+			addressLine3: undefined,
+			postTown: "New York",
+			postCounty: undefined,
+			countryId: undefined,
+			postcode: undefined
+		});
 	});
 });

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-result-mapper.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-result-mapper.tests.ts
@@ -99,7 +99,7 @@ describe("mapAddressSearchResult", () => {
 
 		expect(mappedAddress).toMatchObject({
 			postTown: "London",
-			postCode: "SW1A 2AA",
+			postcode: "SW1A 2AA",
 			uprnReference: "100000000001"
 		});
 		expect(mappedAddress).not.toHaveProperty("postCounty");

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-result-mapper.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-result-mapper.tests.ts
@@ -117,6 +117,7 @@ describe("mapInternationalManualEntryAddress", () => {
 			postTown: "Paris",
 			countyStateProvince: "Ile-de-France",
 			countryId: "FR",
+			countryName: "France",
 			postcode: "75001"
 		};
 
@@ -127,6 +128,7 @@ describe("mapInternationalManualEntryAddress", () => {
 			postTown: "Paris",
 			postCounty: "Ile-de-France",
 			countryId: "FR",
+			countryName: "France",
 			postcode: "75001"
 		});
 	});
@@ -144,6 +146,7 @@ describe("mapInternationalManualEntryAddress", () => {
 			postTown: "New York",
 			postCounty: undefined,
 			countryId: undefined,
+			countryName: undefined,
 			postcode: undefined
 		});
 	});

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-search.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-search.tests.ts
@@ -11,14 +11,16 @@ describe("renderAddressSearch", () => {
             .mockResolvedValue([]);
         searchService.searchAddress = searchAddress;
         const onSearchSuccess = jest.fn<(results: AddressSearchResult[], criteria: AddressSearchCriteria) => void>();
+        const onInternationalEntryRequested = jest.fn<() => void>(); 
 
-        const component = renderAddressSearch({ searchService, onSearchSuccess, criteria });
+        const component = renderAddressSearch({ searchService, onSearchSuccess, criteria, onInternationalEntryRequested });
 
         const buildingInput = component.querySelector<HTMLInputElement>("#building");
         const postcodeInput = component.querySelector<HTMLInputElement>("#postcode");
         const button = component.querySelector<HTMLButtonElement>("button");
+        const internationalLink = component.querySelector<HTMLAnchorElement>("a");
 
-        return { component, buildingInput, postcodeInput, button, searchOptions: searchAddress, onSearchSuccess };
+        return { component, buildingInput, postcodeInput, button, internationalLink, searchOptions: searchAddress, onSearchSuccess, onInternationalEntryRequested };
     }
     
     it("should leave the inputs empty when no criteria is provided", () => {
@@ -43,6 +45,18 @@ describe("renderAddressSearch", () => {
         expect(fieldset).toContainElement(buildingInput);
         expect(fieldset).toContainElement(postcodeInput);
         expect(component).toContainElement(button);
+    });
+
+    it("should render a 'Enter an international address' link", () => {
+        const { component, internationalLink } = createSearch();
+        
+        expect(component).toContainElement(internationalLink);
+    });
+
+    it("should call 'onInternationalEntryRequested' when the international link is clicked", () => {
+        const { internationalLink, onInternationalEntryRequested } = createSearch();
+        internationalLink?.click();
+        expect(onInternationalEntryRequested).toHaveBeenCalled();
     });
 
     it("should show a required error and not search when postcode is empty", () => {
@@ -145,5 +159,4 @@ describe("renderAddressSearch", () => {
         expect(onSearchSuccess).not.toHaveBeenCalled();
         expect(button).not.toBeDisabled();
     });
-
 });

--- a/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-uk-manual-entry.tests.ts
+++ b/ThePensionsRegulator.Frontend/__tests__/address-lookup/address-uk-manual-entry.tests.ts
@@ -1,0 +1,206 @@
+import "@testing-library/jest-dom";
+import { jest } from "@jest/globals";
+import { renderAddressUkManualEntry, validateUkManualEntryAddress } from "../../Scripts/address-lookup/address-uk-manual-entry.js";
+
+function createValidValues(overrides: Partial<Parameters<typeof validateUkManualEntryAddress>[0]> = {}) {
+    return {
+        addressLine1: "1 High Street",
+        addressLine2: "",
+        addressLine3: "",
+        townOrCity: "London",
+        county: "",
+        postcode: "SW1A 1AA",
+        ...overrides
+    };
+}
+
+describe("renderAddressUkManualEntry", () => {
+    it("renders the UK manual entry fields with the expected widths and secondary actions", () => {
+        const onAddressSubmitted = jest.fn();
+        const onBackToSearchRequested = jest.fn();
+        const component = renderAddressUkManualEntry({ onAddressSubmitted, onBackToSearchRequested });
+
+        const addressLine1 = component.querySelector<HTMLInputElement>("#address-line-1");
+        const addressLine2 = component.querySelector<HTMLInputElement>("#address-line-2");
+        const addressLine3 = component.querySelector<HTMLInputElement>("#address-line-3");
+        const townOrCity = component.querySelector<HTMLInputElement>("#town-or-city");
+        const county = component.querySelector<HTMLInputElement>("#county");
+        const postcode = component.querySelector<HTMLInputElement>("#postcode");
+        const confirmButton = component.querySelector<HTMLButtonElement>("button");
+        const backLink = component.querySelector<HTMLAnchorElement>("a");
+
+        expect(addressLine1).toHaveAttribute("name", "address-line-1");
+        expect(addressLine1).toHaveClass("govuk-input", "govuk-input--width-20");
+        expect(addressLine2).toHaveClass("govuk-input", "govuk-input--width-20");
+        expect(addressLine3).toHaveClass("govuk-input", "govuk-input--width-20");
+        expect(townOrCity).toHaveClass("govuk-input", "govuk-input--width-10");
+        expect(county).toHaveClass("govuk-input", "govuk-input--width-10");
+        expect(postcode).toHaveClass("govuk-input", "govuk-input--width-5");
+
+        expect(confirmButton).toHaveTextContent("Confirm address");
+        expect(confirmButton).toHaveClass("govuk-button", "govuk-button--secondary");
+        expect(backLink).toHaveTextContent("Back to postcode search");
+    });
+
+    it("calls the back link handler when the return link is clicked", () => {
+        const onAddressSubmitted = jest.fn();
+        const onBackToSearchRequested = jest.fn();
+        const component = renderAddressUkManualEntry({ onAddressSubmitted, onBackToSearchRequested });
+        const backLink = component.querySelector<HTMLAnchorElement>("a");
+        const clickEvent = new MouseEvent("click", { cancelable: true });
+
+        backLink!.dispatchEvent(clickEvent);
+
+        expect(clickEvent.defaultPrevented).toBe(true);
+        expect(onBackToSearchRequested).toHaveBeenCalledTimes(1);
+    });
+
+    it("submits the valid address when the confirm button is clicked", () => {
+        const onAddressSubmitted = jest.fn();
+        const onBackToSearchRequested = jest.fn();
+        const component = renderAddressUkManualEntry({ onAddressSubmitted, onBackToSearchRequested });
+
+        const addressLine1 = component.querySelector<HTMLInputElement>("#address-line-1");
+        const townOrCity = component.querySelector<HTMLInputElement>("#town-or-city");
+        const postcode = component.querySelector<HTMLInputElement>("#postcode");
+        const confirmButton = component.querySelector<HTMLButtonElement>("button");
+
+        addressLine1!.value = "1 High Street";
+        townOrCity!.value = "london";
+        postcode!.value = "sw1a 1aa";
+
+        confirmButton!.click();
+
+        expect(onAddressSubmitted).toHaveBeenCalledWith({
+            addressLine1: "1 High Street",
+            addressLine2: "",
+            addressLine3: "",
+            postTown: "london",
+            county: "",
+            postcode: "SW1A 1AA"
+        });
+        expect(onBackToSearchRequested).not.toHaveBeenCalled();
+    });
+
+    it("shows validation errors and does not submit when the confirm button is clicked with invalid data", () => {
+        const onAddressSubmitted = jest.fn();
+        const onBackToSearchRequested = jest.fn();
+        const component = renderAddressUkManualEntry({ onAddressSubmitted, onBackToSearchRequested });
+
+        const addressLine1 = component.querySelector<HTMLInputElement>("#address-line-1");
+        const townOrCity = component.querySelector<HTMLInputElement>("#town-or-city");
+        const postcode = component.querySelector<HTMLInputElement>("#postcode");
+        const confirmButton = component.querySelector<HTMLButtonElement>("button");
+
+        addressLine1!.value = "";
+        townOrCity!.value = "";
+        postcode!.value = "NOTREAL";
+
+        confirmButton!.click();
+
+        expect(onAddressSubmitted).not.toHaveBeenCalled();
+        expect(addressLine1).toHaveAttribute("aria-describedby", expect.stringContaining("address-line-1-error"));
+        expect(townOrCity).toHaveAttribute("aria-describedby", expect.stringContaining("town-or-city-error"));
+        expect(postcode).toHaveAttribute("aria-describedby", expect.stringContaining("postcode-error"));
+        expect(component.querySelector("#address-line-1-error")).toHaveClass("govuk-error-message");
+        expect(component.querySelector("#town-or-city-error")).toHaveClass("govuk-error-message");
+        expect(component.querySelector("#postcode-error")).toHaveClass("govuk-error-message");
+    });
+
+    it("clears validation errors when corrected values are confirmed", () => {
+        const onAddressSubmitted = jest.fn();
+        const onBackToSearchRequested = jest.fn();
+        const component = renderAddressUkManualEntry({ onAddressSubmitted, onBackToSearchRequested });
+
+        const addressLine1 = component.querySelector<HTMLInputElement>("#address-line-1");
+        const townOrCity = component.querySelector<HTMLInputElement>("#town-or-city");
+        const postcode = component.querySelector<HTMLInputElement>("#postcode");
+        const confirmButton = component.querySelector<HTMLButtonElement>("button");
+
+        confirmButton!.click();
+
+        expect(component.querySelector("#address-line-1-error")).not.toBeNull();
+        expect(component.querySelector("#town-or-city-error")).not.toBeNull();
+        expect(component.querySelector("#postcode-error")).not.toBeNull();
+
+        addressLine1!.value = "1 High Street";
+        townOrCity!.value = "London";
+        postcode!.value = "SW1A 1AA";
+
+        confirmButton!.click();
+
+        expect(onAddressSubmitted).toHaveBeenCalledTimes(1);
+        expect(component.querySelector("#address-line-1-error")).toBeNull();
+        expect(component.querySelector("#town-or-city-error")).toBeNull();
+        expect(component.querySelector("#postcode-error")).toBeNull();
+    });
+});
+
+describe("validateUkManualEntryAddress", () => {
+    it("returns the mapped address when all required fields are valid", () => {
+        const result = validateUkManualEntryAddress(createValidValues());
+
+        expect(result).toEqual({
+            isValid: true,
+            address: {
+                addressLine1: "1 High Street",
+                addressLine2: "",
+                addressLine3: "",
+                postTown: "London",
+                county: "",
+                postcode: "SW1A 1AA"
+            }
+        });
+    });
+
+    it("is valid when optional fields (address line 2, 3, county) are empty", () => {
+        const result = validateUkManualEntryAddress(createValidValues({ addressLine2: "", addressLine3: "", county: "" }));
+        expect(result.isValid).toBe(true);
+    });
+
+    it("is valid when optional fields are populated", () => {
+        const result = validateUkManualEntryAddress(createValidValues({ addressLine2: "Flat 2", addressLine3: "The Mansions", county: "Greater London" }));
+        expect(result.isValid).toBe(true);
+    });
+
+    it.each([
+        ["addressLine1", { addressLine1: "" }, "Address line 1 is required"],
+        ["addressLine1", { addressLine1: "a".repeat(101) }, "Address line 1 must be 100 characters or fewer"],
+        ["addressLine2", { addressLine2: "a".repeat(101) }, "Address line 2 must be 100 characters or fewer"],
+        ["addressLine3", { addressLine3: "a".repeat(101) }, "Address line 3 must be 100 characters or fewer"],
+        ["townOrCity", { townOrCity: "" }, "Enter a post town"],
+        ["townOrCity", { townOrCity: "a".repeat(101) }, "Town or city must be 100 characters or fewer"],
+        ["county", { county: "a".repeat(101) }, "County must be 100 characters or fewer"],
+        ["postcode", { postcode: "" }, "Enter a postcode"],
+        ["postcode", { postcode: "NOTREAL" }, "Enter a real postcode"]
+    ] as const)("returns a %s error: %s", (fieldName, overrides, message) => {
+        const result = validateUkManualEntryAddress(createValidValues(overrides));
+
+        expect(result.isValid).toBe(false);
+        if (!result.isValid) {
+            expect(result.errorMessages).toEqual([{ fieldName, message }]);
+        }
+    });
+
+    it("returns only the required-field error when the postcode is empty, not also the format or length error", () => {
+        const result = validateUkManualEntryAddress(createValidValues({ postcode: "" }));
+
+        expect(result.isValid).toBe(false);
+        if (!result.isValid) {
+            expect(result.errorMessages).toEqual([{ fieldName: "postcode", message: "Enter a postcode" }]);
+        }
+    });
+
+    it("returns one error per failing field when multiple fields are invalid", () => {
+        const result = validateUkManualEntryAddress(createValidValues({ addressLine1: "", townOrCity: "", postcode: "" }));
+
+        expect(result.isValid).toBe(false);
+        if (!result.isValid) {
+            expect(result.errorMessages).toEqual([
+                { fieldName: "addressLine1", message: "Address line 1 is required" },
+                { fieldName: "townOrCity", message: "Enter a post town" },
+                { fieldName: "postcode", message: "Enter a postcode" }
+            ]);
+        }
+    });
+});


### PR DESCRIPTION
This pull request adds support for international and UK manual address entry in the address lookup flow, improves type consistency for address fields, and refactors the state machine and mapping logic to handle these new flows. The main changes include new UI components for manual entry, updates to the state machine and event types, and standardization of address property names.

**Manual address entry support:**

* Added `renderAddressInternationalManualEntry` and supporting validation logic to enable international manual address entry, including form rendering, validation, and event handling (`ThePensionsRegulator.Frontend/Scripts/address-lookup/address-international-manual-entry.ts`).
* Updated `renderAddressResults` to add a "Enter address not on list" link for UK manual entry, and passed a callback for manual entry requests (`ThePensionsRegulator.Frontend/Scripts/address-lookup/address-results.ts`). [[1]](diffhunk://#diff-f7cfa7d85e0cb6072599f500fc3b77fabf4e6ccb7be5fce0982647ae0ab32ed5R12) [[2]](diffhunk://#diff-f7cfa7d85e0cb6072599f500fc3b77fabf4e6ccb7be5fce0982647ae0ab32ed5R36-R51)
* Updated `createAddressLookup` to handle new state machine states for manual entry and render appropriate UI components for UK and international manual entry (`ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup.ts`). [[1]](diffhunk://#diff-85984cba8deded254d80598a8ebbf2a995bf3b78462b604971eee8f02e31871cL6-R8) [[2]](diffhunk://#diff-85984cba8deded254d80598a8ebbf2a995bf3b78462b604971eee8f02e31871cL29-R62)

**State machine and event handling:**

* Extended the address lookup state machine to support new states and events for UK and international manual address entry, and to use mapping functions to convert manual entry addresses into the `ConfirmedAddress` format (`ThePensionsRegulator.Frontend/Scripts/address-lookup/address-lookup-state-machine.ts`). [[1]](diffhunk://#diff-5b5c593c411130255be4d304da2a738088fe82f38ef39273263b5a5aac3496b5L1-R9) [[2]](diffhunk://#diff-5b5c593c411130255be4d304da2a738088fe82f38ef39273263b5a5aac3496b5L21-R42) [[3]](diffhunk://#diff-5b5c593c411130255be4d304da2a738088fe82f38ef39273263b5a5aac3496b5L57-R108)

**Address mapping and type consistency:**

* Added mapping functions for manual entry addresses and standardized the `postcode` property (was previously `postCode`) in the mapping and confirmed address logic (`ThePensionsRegulator.Frontend/Scripts/address-lookup/address-result-mapper.ts`). [[1]](diffhunk://#diff-e66d1b35f573faf8311d95333c9ee7e937a4d40b45381e839530efa1c6013b39L1-R1) [[2]](diffhunk://#diff-e66d1b35f573faf8311d95333c9ee7e937a4d40b45381e839530efa1c6013b39L66-R96)
* Updated all references to address fields in `createAddressParagraph` and hidden input generation to use consistent camelCase property names (e.g., `postcode` instead of `postCode`, `addressLine1` instead of `AddressLine1`) (`ThePensionsRegulator.Frontend/Scripts/address-lookup/address-confirmed.ts`). [[1]](diffhunk://#diff-6768ddf084dbc8455b982e4b9600dd7f925e0502b0b711659d66b37acb31da54L35-R39) [[2]](diffhunk://#diff-6768ddf084dbc8455b982e4b9600dd7f925e0502b0b711659d66b37acb31da54L56-R83)